### PR TITLE
Update roadmap with Actix API subtasks

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,13 @@ after formatting. Line numbers below refer to that file.
   329-333).
 - [ ] Build the Actix-inspired API around `WireframeApp` and `WireframeServer`
   as described in lines 586-676.
+  - [ ] Implement `WireframeApp` builder to register routes, services,
+    middleware, and shared state.
+  - [ ] Implement `WireframeServer` to spawn per-worker apps, bind to an
+    address, and run.
+  - [ ] Create supporting types like the `FrameProcessor` trait, state
+    extractors, and middleware trait.
+  - [ ] Provide example code mirroring the design document usage snippet.
 
 ## 2. Middleware and Extractors
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,13 +13,20 @@ after formatting. Line numbers below refer to that file.
   329-333).
 - [ ] Build the Actix-inspired API around `WireframeApp` and `WireframeServer`
   as described in lines 586-676.
-  - [ ] Implement `WireframeApp` builder to register routes, services,
-    middleware, and shared state.
-  - [ ] Implement `WireframeServer` to spawn per-worker apps, bind to an
-    address, and run.
-  - [ ] Create supporting types like the `FrameProcessor` trait, state
-    extractors, and middleware trait.
-  - [ ] Provide example code mirroring the design document usage snippet.
+  - [ ] Implement `WireframeApp` builder.
+        Clarify method signatures (`new`, `route`, `service`, `wrap`),
+        expose a consistent `Result<Self>` error strategy, and allow
+        registration calls in any order for ergonomic chaining.
+  - [ ] Implement `WireframeServer`.
+        Outline how worker threads are spawned via Tokio, with graceful
+        shutdown using a signal and per-worker `WireframeApp` instances.
+  - [ ] Standardise supporting trait definitions.
+        Provide naming conventions and generic bounds for the
+        `FrameProcessor` trait, state extractors and middleware via
+        `async_trait` and associated types.
+  - [ ] Provide a minimal, runnable example.
+        Include imports and an async `main` so the snippet compiles out of
+        the box.
 
 ## 2. Middleware and Extractors
 


### PR DESCRIPTION
## Summary
- outline implementation details for Actix-inspired API in `WireframeApp` and `WireframeServer`

## Testing
- `markdownlint docs/roadmap.md`
- `nixie docs/roadmap.md`
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684a0464d8ac8322aab14bce6b48cf6b

## Summary by Sourcery

Break down the Actix-inspired API roadmap item into detailed implementation subtasks

Documentation:
- Add subtasks for implementing `WireframeApp` builder to register routes, services, middleware, and state
- Add subtasks for implementing `WireframeServer` to spawn per-worker apps, bind to an address, and run
- Add subtasks for creating supporting types like `FrameProcessor` trait, state extractors, and middleware trait
- Add subtasks for providing example code mirroring the design document usage snippet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded the roadmap with detailed subtasks for building the Actix-inspired API, including implementation steps and example code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->