### PR TITLE
Fix compile errors and clippy

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -42,10 +42,9 @@ after formatting. Line numbers below refer to that file.
     #[tokio::main]
     async fn main() -> std::io::Result<()> {
         let factory = || {
-            let svc: Service = Box::new(|| Box::pin(handler()));
             WireframeApp::new()
                 .unwrap()
-                .route(1, svc)
+                .route(1, Box::new(|| Box::pin(handler())))
                 .unwrap()
         };
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@ after formatting. Line numbers below refer to that file.
         the box.
 
     ```rust
-    use std::{future::Future, pin::Pin};
+    // No extra imports required
     use wireframe::{
         app::{Service, WireframeApp},
         server::WireframeServer,

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,9 +26,35 @@ after formatting. Line numbers below refer to that file.
         Provide naming conventions and generic bounds for the
         `FrameProcessor` trait, state extractors and middleware via
         `async_trait` and associated types.
-  - [ ] Provide a minimal, runnable example.
+  - [x] Provide a minimal, runnable example.
         Include imports and an async `main` so the snippet compiles out of
         the box.
+
+        ```rust
+        use std::{future::Future, pin::Pin};
+        use wireframe::{
+            app::{Service, WireframeApp},
+            server::WireframeServer,
+        };
+
+        async fn handler() {}
+
+        #[tokio::main]
+        async fn main() -> std::io::Result<()> {
+            let factory = || {
+                let svc: Service = Box::new(|| Box::pin(handler()));
+                WireframeApp::new()
+                    .unwrap()
+                    .route(1, svc)
+                    .unwrap()
+            };
+
+            WireframeServer::new(factory)
+                .bind("127.0.0.1:7878".parse().unwrap())?
+                .run()
+                .await
+        }
+        ```
 
 ## 2. Middleware and Extractors
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,31 +30,31 @@ after formatting. Line numbers below refer to that file.
         Include imports and an async `main` so the snippet compiles out of
         the box.
 
-        ```rust
-        use std::{future::Future, pin::Pin};
-        use wireframe::{
-            app::{Service, WireframeApp},
-            server::WireframeServer,
+    ```rust
+    use std::{future::Future, pin::Pin};
+    use wireframe::{
+        app::{Service, WireframeApp},
+        server::WireframeServer,
+    };
+
+    async fn handler() {}
+
+    #[tokio::main]
+    async fn main() -> std::io::Result<()> {
+        let factory = || {
+            let svc: Service = Box::new(|| Box::pin(handler()));
+            WireframeApp::new()
+                .unwrap()
+                .route(1, svc)
+                .unwrap()
         };
 
-        async fn handler() {}
-
-        #[tokio::main]
-        async fn main() -> std::io::Result<()> {
-            let factory = || {
-                let svc: Service = Box::new(|| Box::pin(handler()));
-                WireframeApp::new()
-                    .unwrap()
-                    .route(1, svc)
-                    .unwrap()
-            };
-
-            WireframeServer::new(factory)
-                .bind("127.0.0.1:7878".parse().unwrap())?
-                .run()
-                .await
-        }
-        ```
+        WireframeServer::new(factory)
+            .bind("127.0.0.1:7878".parse().unwrap())?
+            .run()
+            .await
+    }
+    ```
 
 ## 2. Middleware and Extractors
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -69,6 +69,10 @@ impl<T: Send + Sync> SharedState<T> {
     /// assert_eq!(*state, 5);
     /// ```
     #[must_use]
+    pub fn new(inner: Arc<T>) -> Self {
+        Self(inner)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -91,20 +95,6 @@ mod tests {
         assert_eq!(payload.remaining(), 2);
     }
 }
-    /// Creates a new `SharedState` instance wrapping the provided `Arc<T>`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::sync::Arc;
-    /// let state = Arc::new(42);
-    /// let shared = SharedState::new(state.clone());
-    /// assert_eq!(*shared, 42);
-    /// ```
-    pub fn new(inner: Arc<T>) -> Self {
-        Self(inner)
-    }
-}
 
 impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
     type Target = T;
@@ -117,6 +107,7 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
     ///
     /// ```
     /// use std::sync::Arc;
+    /// use wireframe::extractor::SharedState;
     /// let state = Arc::new(42);
     /// let shared = SharedState::new(state.clone());
     /// assert_eq!(*shared, 42);

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -60,7 +60,7 @@ impl<T: Send + Sync> SharedState<T> {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use std::sync::Arc;
     /// use wireframe::extractor::SharedState;
     ///
@@ -71,6 +71,18 @@ impl<T: Send + Sync> SharedState<T> {
     #[must_use]
     pub fn new(inner: Arc<T>) -> Self {
         Self(inner)
+    }
+}
+
+impl<T: Send + Sync> From<Arc<T>> for SharedState<T> {
+    fn from(inner: Arc<T>) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T: Send + Sync> From<T> for SharedState<T> {
+    fn from(inner: T) -> Self {
+        Self(Arc::new(inner))
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -31,6 +31,7 @@ where
     /// # Errors
     ///
     /// Propagates any error produced by the wrapped service.
+    #[must_use = "call the returned future"]
     pub async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, S::Error> {
         self.service.call(req).await
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -21,6 +21,7 @@ where
     S: Service + ?Sized,
 {
     /// Create a new [`Next`] wrapping the given service.
+    #[inline]
     #[must_use]
     pub fn new(service: &'a S) -> Self {
         Self { service }
@@ -31,7 +32,7 @@ where
     /// # Errors
     ///
     /// Propagates any error produced by the wrapped service.
-    #[must_use = "call the returned future"]
+    #[must_use = "await the returned future"]
     pub async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, S::Error> {
         self.service.call(req).await
     }

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -20,48 +20,17 @@ impl<'a, S> Next<'a, S>
 where
     S: Service + ?Sized,
 {
-    /// Creates a new `Next` instance wrapping a reference to the given service.
-    ///
-///
-/// ```ignore
-/// use wireframe::middleware::{ServiceRequest, ServiceResponse, Next, Service};
-/// ```
-    /// Service produced by the middleware.
-    type Wrapped: Service;
-    async fn transform(&self, service: S) -> Self::Wrapped;
-    /// let service = MyService::default();
-    /// let next = Next::new(&service);
-    type Wrapped: Service;
-    async fn transform(&self, service: S) -> Self::Wrapped;
+    /// Create a new [`Next`] wrapping the given service.
+    #[must_use]
+    pub fn new(service: &'a S) -> Self {
         Self { service }
     }
 
-    /// Call the next service with the given request.
+    /// Call the next service with the provided request.
     ///
     /// # Errors
     ///
-    /// Asynchronously invokes the next service in the middleware chain with the given request.
-    ///
-    /// Returns the response from the wrapped service, or propagates any error produced.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use your_crate::{ServiceRequest, ServiceResponse, Next, Service};
-    /// # struct DummyService;
-    /// # #[async_trait::async_trait]
-    /// # impl Service for DummyService {
-    /// #     type Error = std::convert::Infallible;
-    /// #     async fn call(&self, _req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
-    /// #         Ok(ServiceResponse::default())
-    /// #     }
-    /// # }
-    /// # let service = DummyService;
-    /// let next = Next::new(&service);
-    /// let req = ServiceRequest {};
-    /// let res = tokio_test::block_on(next.call(req));
-    /// assert!(res.is_ok());
-    /// ```
+    /// Propagates any error produced by the wrapped service.
     pub async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, S::Error> {
         self.service.call(req).await
     }
@@ -83,7 +52,7 @@ pub trait Transform<S>: Send + Sync
 where
     S: Service,
 {
-    /// Wrapped service produced by the middleware.
+    /// Middleware-wrapped service produced by `transform`.
     type Output: Service;
 
     /// Create a new middleware service wrapping `service`.

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,7 +40,7 @@ where
 
     /// Set the number of worker tasks to spawn.
     #[must_use]
-    pub fn workers(&mut self, count: usize) -> &mut Self {
+    pub fn workers(mut self, count: usize) -> Self {
         self.workers = count.max(1);
         self
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,42 +28,18 @@ impl<F> WireframeServer<F>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
 {
-    /// Constructs a new `WireframeServer` using the provided application factory closure.
-    ///
-    /// The server is initialised with a default worker count equal to the number of CPU cores.
-    ///
-    /// ```no_run
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
-    ///
-    /// let factory = || WireframeApp::new().unwrap();
-    /// let server = WireframeServer::new(factory);
-    /// ```
+    /// Construct a new server using the supplied application factory.
+    #[must_use]
+    pub fn new(factory: F) -> Self {
+        Self {
+            factory,
+            listener: None,
             workers: num_cpus::get().max(1),
+        }
+    }
 
-    /// Set the number of worker tasks to spawn for the server.
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> std::io::Result<()> {
-    ///     let factory = || WireframeApp::new().unwrap();
-    ///     WireframeServer::new(factory)
-    ///         .workers(4)
-    ///         .bind("127.0.0.1:0".parse().unwrap())?
-    ///         .run()
-    ///         .await
-    /// }
-    /// A new `WireframeServer` instance with the updated worker count.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let server = WireframeServer::new(factory).workers(4);
-    /// Sets the number of worker tasks for the server, ensuring at least one worker.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// let server = WireframeServer::new(factory).workers(4);
-    /// ```
+    /// Set the number of worker tasks to spawn.
+    #[must_use]
     pub fn workers(mut self, count: usize) -> Self {
         self.workers = count.max(1);
         self

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,13 +34,13 @@ where
         Self {
             factory,
             listener: None,
-            workers: num_cpus::get().max(1),
+            workers: num_cpus::get(),
         }
     }
 
     /// Set the number of worker tasks to spawn.
     #[must_use]
-    pub fn workers(mut self, count: usize) -> Self {
+    pub fn workers(&mut self, count: usize) -> &mut Self {
         self.workers = count.max(1);
         self
     }


### PR DESCRIPTION
## Summary
- move extractor tests outside impl
- rewrite middleware traits
- add WireframeServer::new and cleanup comments

## Testing
- `markdownlint docs/roadmap.md`
- `nixie docs/roadmap.md`
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo test -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_684bd1f2b88483229b0c3a91dfddccc8

## Summary by Sourcery

Fix compilation errors and resolve Clippy warnings by adding missing constructors, refining middleware and extractor traits, annotating public APIs, and updating documentation with a runnable example.

New Features:
- Add `WireframeServer::new` constructor to initialize server with a factory
- Introduce `Next::new` constructor in middleware to wrap services
- Implement `From<Arc<T>>` and `From<T>` for `SharedState` extractor

Enhancements:
- Refactor middleware traits and streamline `call` and `transform` APIs
- Add `#[must_use]` and `#[inline]` annotations to key public methods
- Clean up duplicate and outdated doc comments across modules

Documentation:
- Mark minimal example as completed and add a runnable example to `docs/roadmap.md`

Tests:
- Move extractor tests outside of the `impl` block in extractor module

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a complete, runnable Rust example demonstrating core library usage.
	- Improved and clarified documentation for middleware and server components, with simplified comments and updated examples.
- **New Features**
	- Made the SharedState constructor and Next middleware constructor publicly available for easier use in applications.
- **Style**
	- Refined wording and structure in documentation for better clarity and conciseness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->