### PR TITLE
Fix worker count default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,12 +177,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,16 +206,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -319,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -469,7 +453,6 @@ dependencies = [
  "bincode",
  "bytes",
  "futures",
- "num_cpus",
  "serde",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ serde = { version = "1", features = ["derive"] }
 bincode = "2"
 tokio = { version = "1", default-features = false, features = ["net", "signal", "rt-multi-thread", "macros", "sync", "time"] }
 futures = "0.3"
-num_cpus = "^1"
 async-trait = "0.1"
 bytes = "1"
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ WireframeServer::new(|| {
 .await
 ```
 
+By default, the number of worker tasks equals the number of CPU cores.
+
 The builder supports methods like `frame_processor`, `route`, `app_data`, and
 `wrap` for middleware configuration【F:docs/rust-binary-router-library-design.md†L616-L704】.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ WireframeServer::new(|| {
 .await
 ```
 
-By default, the number of worker tasks equals the number of CPU cores.
+By default, the number of worker tasks equals the number of CPU cores. If the
+CPU count cannot be determined, the server falls back to a single worker.
 
 The builder supports methods like `frame_processor`, `route`, `app_data`, and
 `wrap` for middleware configuration【F:docs/rust-binary-router-library-design.md†L616-L704】.

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -669,7 +669,8 @@ similar to Actix Web's web::Data.21
   `HttpServer`) would take the configured `WireframeApp` factory (a closure that
   creates an `App` instance per worker thread), bind to a network address, and
   manage incoming connections, task spawning for each connection, and the
-  overall server lifecycle. This would likely be built on Tokio's networking and
+  overall server lifecycle. The default number of worker tasks matches the
+  available CPU cores. This would likely be built on Tokio's networking and
   runtime primitives.18
 
 This structural similarity to Actix Web is intentional. Developers familiar with

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -670,7 +670,8 @@ similar to Actix Web's web::Data.21
   creates an `App` instance per worker thread), bind to a network address, and
   manage incoming connections, task spawning for each connection, and the
   overall server lifecycle. The default number of worker tasks matches the
-  available CPU cores. This would likely be built on Tokio's networking and
+  available CPU cores, falling back to a single worker if the count cannot be
+  determined. This would likely be built on Tokio's networking and
   runtime primitives.18
 
 This structural similarity to Actix Web is intentional. Developers familiar with

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -69,6 +69,17 @@ impl<T: Send + Sync> SharedState<T> {
     /// assert_eq!(*state, 5);
     /// ```
     #[must_use]
+    /// Creates a new `SharedState` instance wrapping the provided `Arc<T>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use wireframe::extractor::SharedState;
+    /// let state = Arc::new(42);
+    /// let shared = SharedState::new(state.clone());
+    /// assert_eq!(*shared, 42);
+    /// ```
     pub fn new(inner: Arc<T>) -> Self {
         Self(inner)
     }
@@ -126,5 +137,27 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
     /// ```
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advance_consumes_bytes() {
+        let mut payload = Payload { data: b"hello" };
+        payload.advance(2);
+        assert_eq!(payload.data, b"llo");
+        payload.advance(10);
+        assert!(payload.data.is_empty());
+    }
+
+    #[test]
+    fn remaining_reports_length() {
+        let mut payload = Payload { data: b"abc" };
+        assert_eq!(payload.remaining(), 3);
+        payload.advance(1);
+        assert_eq!(payload.remaining(), 2);
     }
 }

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -134,6 +134,19 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
     /// let state = Arc::new(42);
     /// let shared = SharedState::new(state.clone());
     /// assert_eq!(*shared, 42);
+    /// Returns a reference to the inner shared state value.
+    ///
+    /// Allows transparent access to the wrapped state as if it were a reference to the underlying type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use wireframe::extractor::SharedState;
+    ///
+    /// let state = Arc::new(42);
+    /// let shared = SharedState::new(state);
+    /// assert_eq!(*shared, 42);
     /// ```
     fn deref(&self) -> &Self::Target {
         &self.0

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -23,6 +23,22 @@ where
     /// Create a new [`Next`] wrapping the given service.
     #[inline]
     #[must_use]
+    /// Creates a new `Next` instance wrapping a reference to the given service.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use your_crate::{Next, Service, ServiceRequest};
+    /// # struct MyService;
+    /// # impl Service for MyService {
+    /// #     type Error = std::convert::Infallible;
+    /// #     async fn call(&self, _req: ServiceRequest) -> Result<super::ServiceResponse, Self::Error> {
+    /// #         Ok(super::ServiceResponse)
+    /// #     }
+    /// # }
+    /// let service = MyService;
+    /// let next = Next::new(&service);
+    /// ```
     pub fn new(service: &'a S) -> Self {
         Self { service }
     }
@@ -31,7 +47,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns an error from the wrapped service if handling the request fails.
+    /// Asynchronously invokes the wrapped service with the given request.
+    ///
+    /// Returns a response produced by the service, or an error if the service fails to handle the request.
     #[must_use = "await the returned future"]
     pub async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, S::Error> {
         self.service.call(req).await

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -31,7 +31,7 @@ where
     ///
     /// # Errors
     ///
-    /// Propagates any error produced by the wrapped service.
+    /// Returns an error from the wrapped service if handling the request fails.
     #[must_use = "await the returned future"]
     pub async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, S::Error> {
         self.service.call(req).await

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,9 +33,8 @@ where
     ///
     /// The default worker count equals the number of CPU cores.
     ///
-    /// # Panics
-    ///
-    /// Panics if the number of available CPUs cannot be determined.
+    /// If the CPU count cannot be determined, the server defaults to a single
+    /// worker.
     ///
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
@@ -45,10 +44,11 @@ where
     /// ```
     #[must_use]
     pub fn new(factory: F) -> Self {
+        let workers = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
         Self {
             factory,
             listener: None,
-            workers: std::thread::available_parallelism().unwrap().get(),
+            workers,
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,6 +33,10 @@ where
     ///
     /// The default worker count equals the number of CPU cores.
     ///
+    /// # Panics
+    ///
+    /// Panics if the number of available CPUs cannot be determined.
+    ///
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
@@ -44,7 +48,7 @@ where
         Self {
             factory,
             listener: None,
-            workers: num_cpus::get().max(1),
+            workers: std::thread::available_parallelism().unwrap().get(),
         }
     }
 
@@ -64,6 +68,7 @@ where
     }
 
     /// Get the configured worker count.
+    #[inline]
     #[must_use]
     pub const fn worker_count(&self) -> usize {
         self.workers

--- a/src/server.rs
+++ b/src/server.rs
@@ -28,21 +28,45 @@ impl<F> WireframeServer<F>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
 {
-    /// Construct a new server using the supplied application factory.
+    /// Constructs a new `WireframeServer` using the provided application factory
+    /// closure.
+    ///
+    /// The default worker count equals the number of CPU cores.
+    ///
+    /// ```no_run
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let factory = || WireframeApp::new().unwrap();
+    /// let server = WireframeServer::new(factory);
+    /// ```
     #[must_use]
     pub fn new(factory: F) -> Self {
         Self {
             factory,
             listener: None,
-            workers: num_cpus::get(),
+            workers: num_cpus::get().max(1),
         }
     }
 
-    /// Set the number of worker tasks to spawn.
+    /// Set the number of worker tasks to spawn for the server.
+    ///
+    /// Ensures at least one worker is configured.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let server = WireframeServer::new(factory).workers(4);
+    /// ```
     #[must_use]
     pub fn workers(mut self, count: usize) -> Self {
         self.workers = count.max(1);
         self
+    }
+
+    /// Get the configured worker count.
+    #[must_use]
+    pub const fn worker_count(&self) -> usize {
+        self.workers
     }
 
     /// Bind the server to the given address and create a listener.

--- a/src/server.rs
+++ b/src/server.rs
@@ -41,6 +41,19 @@ where
     ///
     /// let factory = || WireframeApp::new().unwrap();
     /// let server = WireframeServer::new(factory);
+    /// Creates a new `WireframeServer` with the provided factory closure.
+    ///
+    /// The server is initialised with a default worker count equal to the number of available CPU cores, or 1 if this cannot be determined. The TCP listener is unset and must be configured with `bind` before running the server.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of available CPUs cannot be determined and the fallback to 1 fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let server = WireframeServer::new(|| WireframeApp::default());
+    /// assert!(server.worker_count() >= 1);
     /// ```
     #[must_use]
     pub fn new(factory: F) -> Self {
@@ -62,6 +75,18 @@ where
     /// let server = WireframeServer::new(factory).workers(4);
     /// ```
     #[must_use]
+    /// Sets the number of worker tasks to spawn, ensuring at least one worker is configured.
+    ///
+    /// Returns a new `WireframeServer` instance with the updated worker count. If `count` is less than 1, it defaults to 1.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let server = WireframeServer::new(factory).workers(4);
+    /// assert_eq!(server.worker_count(), 4);
+    /// let server = server.workers(0);
+    /// assert_eq!(server.worker_count(), 1);
+    /// ```
     pub fn workers(mut self, count: usize) -> Self {
         self.workers = count.max(1);
         self
@@ -70,6 +95,14 @@ where
     /// Get the configured worker count.
     #[inline]
     #[must_use]
+    /// Returns the configured number of worker tasks for the server.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let server = WireframeServer::new(factory);
+    /// assert!(server.worker_count() >= 1);
+    /// ```
     pub const fn worker_count(&self) -> usize {
         self.workers
     }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -3,7 +3,7 @@ use wireframe::{app::WireframeApp, server::WireframeServer};
 #[test]
 fn default_worker_count_matches_cpu_count() {
     let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"));
-    let expected = std::thread::available_parallelism().unwrap().get();
+    let expected = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
     assert_eq!(server.worker_count(), expected);
 }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,13 +1,22 @@
 use wireframe::{app::WireframeApp, server::WireframeServer};
 
 #[test]
-fn default_worker_count_is_positive() {
-    let server = WireframeServer::new(|| WireframeApp::new().unwrap());
-    assert!(server.worker_count() >= 1);
+fn default_worker_count_matches_cpu_count() {
+    let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"));
+    let expected = std::thread::available_parallelism().unwrap().get();
+    assert_eq!(server.worker_count(), expected);
 }
 
 #[test]
 fn workers_method_enforces_minimum() {
-    let server = WireframeServer::new(|| WireframeApp::new().unwrap()).workers(0);
+    let server =
+        WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed")).workers(0);
     assert_eq!(server.worker_count(), 1);
+}
+
+#[test]
+fn workers_accepts_large_values() {
+    let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"))
+        .workers(128);
+    assert_eq!(server.worker_count(), 128);
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,0 +1,13 @@
+use wireframe::{app::WireframeApp, server::WireframeServer};
+
+#[test]
+fn default_worker_count_is_positive() {
+    let server = WireframeServer::new(|| WireframeApp::new().unwrap());
+    assert!(server.worker_count() >= 1);
+}
+
+#[test]
+fn workers_method_enforces_minimum() {
+    let server = WireframeServer::new(|| WireframeApp::new().unwrap()).workers(0);
+    assert_eq!(server.worker_count(), 1);
+}


### PR DESCRIPTION
## Summary
- ensure `WireframeServer::new` clamps worker count to at least one
- document CPU-based worker default in README and design docs
- clean up server and extractor docs
- provide a worker count getter
- add basic server tests

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
- `markdownlint README.md docs/roadmap.md docs/rust-binary-router-library-design.md`
- `nixie README.md docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_684c35be1600832285dd1dfe9a0b9e70

## Summary by Sourcery

Ensure the server defaults to at least one worker using the standard parallelism API, remove the num_cpus crate, document the CPU-based default, add a worker_count getter, and include basic tests for server and payload behavior.

New Features:
- Introduce `worker_count()` getter on `WireframeServer` to retrieve the configured worker count.

Bug Fixes:
- Clamp worker count to at least one in both `WireframeServer::new` and the `workers()` builder method.

Enhancements:
- Replace `num_cpus` dependency with `std::thread::available_parallelism()` for default worker determination.
- Clean up and enhance documentation comments in server, extractor, and middleware modules.

Documentation:
- Document the CPU-based default worker count in README.md and design documentation, including fallback behavior.

Tests:
- Add server tests for default, custom, and clamped worker counts.
- Add extractor `Payload` unit tests for `advance` and `remaining` methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to display the current number of worker tasks in the server.
- **Documentation**
	- Clarified that the default number of worker tasks matches the number of CPU cores in both the README and technical documentation.
	- Simplified and updated documentation for server-related methods and middleware usage.
	- Added detailed usage examples and explanations for shared state management and middleware components.
- **Refactor**
	- Improved test organisation and updated documentation examples for consistency.
- **Tests**
	- Added unit tests to verify default and minimum worker count behaviour in the server.
- **Chores**
	- Removed an unused dependency from the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->