### PR TITLE
Fix doc examples and remove duplicate tests

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -119,25 +119,3 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
         &self.0
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn advance_consumes_bytes() {
-        let mut payload = Payload { data: b"hello" };
-        payload.advance(2);
-        assert_eq!(payload.data, b"llo");
-        payload.advance(10);
-        assert!(payload.data.is_empty());
-    }
-
-    #[test]
-    fn remaining_reports_length() {
-        let mut payload = Payload { data: b"abc" };
-        assert_eq!(payload.remaining(), 3);
-        payload.advance(1);
-        assert_eq!(payload.remaining(), 2);
-    }
-}

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -28,12 +28,14 @@ where
     /// # Examples
     ///
     /// ```ignore
-    /// # use your_crate::{Next, Service, ServiceRequest};
+    /// # use async_trait::async_trait;
+    /// # use wireframe::middleware::{Next, Service, ServiceRequest, ServiceResponse};
     /// # struct MyService;
+    /// # #[async_trait]
     /// # impl Service for MyService {
     /// #     type Error = std::convert::Infallible;
-    /// #     async fn call(&self, _req: ServiceRequest) -> Result<super::ServiceResponse, Self::Error> {
-    /// #         Ok(super::ServiceResponse)
+    /// #     async fn call(&self, _req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
+    /// #         Ok(ServiceResponse)
     /// #     }
     /// # }
     /// let service = MyService;

--- a/src/server.rs
+++ b/src/server.rs
@@ -54,6 +54,8 @@ where
     /// # Examples
     ///
     /// ```ignore
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
     /// let server = WireframeServer::new(|| WireframeApp::default());
     /// assert!(server.worker_count() >= 1);
     /// ```
@@ -73,7 +75,10 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let factory = || WireframeApp::new().unwrap();
     /// let server = WireframeServer::new(factory).workers(4);
     /// ```
     #[must_use]
@@ -84,6 +89,9 @@ where
     /// # Examples
     ///
     /// ```ignore
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let factory = || WireframeApp::new().unwrap();
     /// let server = WireframeServer::new(factory).workers(4);
     /// assert_eq!(server.worker_count(), 4);
     /// let server = server.workers(0);
@@ -102,6 +110,9 @@ where
     /// # Examples
     ///
     /// ```ignore
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let factory = || WireframeApp::new().unwrap();
     /// let server = WireframeServer::new(factory);
     /// assert!(server.worker_count() >= 1);
     /// ```
@@ -127,8 +138,11 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use std::net::SocketAddr;
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let factory = || WireframeApp::new().unwrap();
     /// let server = WireframeServer::new(factory);
     /// let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
     /// let server = server.bind(addr).expect("Failed to bind address");
@@ -167,16 +181,16 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// # use std::net::SocketAddr;
-    /// # use mycrate::{WireframeServer, WireframeApp};
-    /// # async fn run_server() -> std::io::Result<()> {
-    /// let factory = || WireframeApp::new();
-    /// let server = WireframeServer::new(factory)
-    ///     .workers(4)
-    ///     .bind("127.0.0.1:8080".parse::<SocketAddr>().unwrap())?;
-    /// server.run().await
-    /// # }
+    /// ```no_run
+    /// use std::net::SocketAddr;
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// async fn run_server() -> std::io::Result<()> {
+    ///     let factory = || WireframeApp::new().unwrap();
+    ///     let server = WireframeServer::new(factory)
+    ///         .workers(4)
+    ///         .bind("127.0.0.1:8080".parse::<SocketAddr>().unwrap())?;
+    ///     server.run().await
+    /// }
     /// ```
     pub async fn run(self) -> io::Result<()> {
         let listener = self.listener.expect("`bind` must be called before `run`");


### PR DESCRIPTION
## Summary
- deduplicate payload tests in `extractor.rs`
- update doc comments to use `no_run` and include necessary imports
- fix example in middleware docs

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md` *(fails: many pre-existing issues)*
- `nixie docs/*`

------
https://chatgpt.com/codex/tasks/task_e_684ca13457e08322b98c479e06e77c98

## Summary by Sourcery

Clean up documentation examples by converting code blocks to `no_run`, adding necessary imports, and fixing the middleware example, and remove duplicate payload tests in the extractor.

Enhancements:
- Deduplicate and remove redundant payload tests in `extractor.rs`

Documentation:
- Convert doc code blocks in `server.rs` and `middleware.rs` from `ignore` to `no_run`
- Add required `use` statements to code examples in server and middleware docs
- Fix the middleware example to reference correct types (`ServiceResponse`) in docs
- Adjust `SharedState` example in `extractor.rs` to clone state consistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified example code in documentation, including explicit imports and usage annotations for better guidance.
  - Enhanced server and middleware documentation with realistic initialisation patterns and updated code block attributes.

- **Tests**
  - Removed internal unit tests for payload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->