### PR TITLE
Update roadmap with grammar fixes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,6 +55,16 @@ after formatting. Line numbers below refer to that file.
     }
     ```
 
+- [ ] Add connection preamble support.
+      Provide built-in parsing of a handshake preamble (e.g., Hotline's "TRTP")
+      and invoke a user-configured handler on success or failure.
+- [ ] Add response serialization and transmission.
+      Encode handler responses using the selected serialization format and write
+      them back through the framing layer.
+- [ ] Add connection lifecycle hooks.
+      Integrate setup and teardown stages, so sessions can hold state (such as a
+      logged-in user ID) across messages.
+
 ## 2. Middleware and Extractors
 
 - [ ] Develop a minimal middleware system and extractor traits for payloads,
@@ -94,6 +104,10 @@ after formatting. Line numbers below refer to that file.
 
 - [ ] Create a CLI for protocol scaffolding and testing (lines 1424-1429).
 - [ ] Improve debugging support and expand documentation (lines 1430-1435).
+- [ ] Provide testing utilities for handlers.
+      Offer simple ways to drive handlers with raw frames for unit tests.
+      Early examples live in [`tests/server.rs`](../tests/server.rs); future
+      helpers may reside in a `wireframe-testing` crate.
 
 ## 6. Community Engagement and Integration
 


### PR DESCRIPTION
## Summary
- polish connection feature bullets for consistent verbs and grammar
- expand testing utilities bullet with an example reference

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `npx --yes markdownlint-cli2 '**/*.md'`
- `nixie docs/roadmap.md`


------
https://chatgpt.com/codex/tasks/task_e_684cc2469088832284a02668c1669efd

## Summary by Sourcery

Revise the roadmap documentation to improve consistency and clarity

Documentation:
- Polish connection feature bullets for consistent verbs and grammar
- Expand testing utilities entry with an example reference to tests/server.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap to include new core library foundation tasks and developer tooling enhancements, such as connection preamble support, response serialization, connection lifecycle hooks, and testing utilities for handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->