### PR TITLE
Fix conditional syntax in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+      CODESCENE_CLI_SHA256: ${{ secrets.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -23,9 +25,7 @@ jobs:
       - name: Run coverage
         run: cargo tarpaulin --out lcov
       - name: Install CodeScene coverage tool
-        if: ${{ secrets.CS_ACCESS_TOKEN }}
-        env:
-          CODESCENE_CLI_SHA256: ${{ secrets.CODESCENE_CLI_SHA256 }}
+        if: env.CS_ACCESS_TOKEN
         run: |
           set -euo pipefail
           curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
@@ -35,8 +35,6 @@ jobs:
           bash install-cs-coverage-tool.sh -y
           rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
-        if: ${{ secrets.CS_ACCESS_TOKEN }}
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run coverage
         run: cargo tarpaulin --out lcov
       - name: Install CodeScene coverage tool
-        if: secrets.CS_ACCESS_TOKEN
+        if: ${{ secrets.CS_ACCESS_TOKEN }}
         env:
           CODESCENE_CLI_SHA256: ${{ secrets.CODESCENE_CLI_SHA256 }}
         run: |
@@ -35,7 +35,7 @@ jobs:
           bash install-cs-coverage-tool.sh -y
           rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
-        if: secrets.CS_ACCESS_TOKEN
+        if: ${{ secrets.CS_ACCESS_TOKEN }}
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"


### PR DESCRIPTION
## Summary
- fix the `if` condition syntax for CodeScene steps in CI workflow

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684cec419e6083228e117aae63bf04c9

## Summary by Sourcery

Fix conditional syntax in CI workflow for CodeScene steps by sourcing credentials from environment variables and updating job-level env

Bug Fixes:
- Use env.CS_ACCESS_TOKEN in `if` conditions for CodeScene steps instead of secrets

Enhancements:
- Expose CS_ACCESS_TOKEN and CODESCENE_CLI_SHA256 as job-level environment variables to simplify step configs