### PR TITLE
Automate CodeScene CLI SHA256 updates and use repo var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ secrets.CODESCENE_CLI_SHA256 }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/get-codescene-sha.yml
+++ b/.github/workflows/get-codescene-sha.yml
@@ -1,17 +1,31 @@
-name: Get CodeScene CLI SHA256
+name: Refresh CodeScene CLI SHA256
 
 on:
   workflow_dispatch:
 
 jobs:
-  fetch-sha:
+  refresh-sha:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
-      - name: Compute SHA256 of install script
+      - name: Fetch script & compute SHA256
+        id: compute
         run: |
           set -euo pipefail
           url="https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh"
           curl -fsSL "$url" -o install-cs-coverage-tool.sh
-          hash=$(sha256sum install-cs-coverage-tool.sh | awk '{print $1}')
-          echo "CODESCENE_CLI_SHA256=$hash"
-          rm install-cs-coverage-tool.sh
+          echo "sha=$(sha256sum install-cs-coverage-tool.sh | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+      - name: Update repository variable
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sha = process.env.SHA
+            await github.rest.actions.updateRepoVariable({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'CODESCENE_CLI_SHA256',
+              value: sha,
+            })
+        env:
+          SHA: ${{ steps.compute.outputs.sha }}


### PR DESCRIPTION
Switches CI to reference a repository variable for the CodeScene CLI SHA256
Adds a manual workflow to fetch the install script, compute its SHA256, and update the repo variable automatically
Removes the previous workflow that only computed and printed the hash

## Summary by Sourcery

Automate the retrieval and management of the CodeScene CLI install script checksum and switch CI to use a repository variable for the SHA256 value.

New Features:
- Add a manual GitHub Actions workflow to fetch the CodeScene CLI installer, compute its SHA256, and update the CODESCENE_CLI_SHA256 repository variable.

Enhancements:
- Update the CI workflow to reference the CODESCENE_CLI_SHA256 repository variable instead of a secret.