### PR TITLE
Fix clippy lint in preamble test

### DIFF
--- a/tests/preamble.rs
+++ b/tests/preamble.rs
@@ -36,7 +36,7 @@ async fn parse_valid_preamble() {
     let (p, _) = read_preamble::<_, HotlinePreamble>(&mut server)
         .await
         .expect("valid preamble");
-    eprintln!("decoded: {:?}", p);
+    eprintln!("decoded: {p:?}");
     p.validate().unwrap();
     assert_eq!(p.magic, HotlinePreamble::MAGIC);
     assert_eq!(p.min_version, 1);


### PR DESCRIPTION
## Summary
- fix uninlined format args clippy lint in tests

## Testing
- `cargo clippy --tests -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684dd86d7fb483228c0766e51dcc591f

## Summary by Sourcery

Tests:
- Fix Clippy lint in preamble test by using inline format arguments in debug printing