### PR TITLE
Ensure minimum worker count and test

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -74,7 +74,12 @@ where
     /// ```
     #[must_use]
     pub fn new(factory: F) -> Self {
-        let workers = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
+        // Ensure at least one worker is always configured. While
+        // `available_parallelism` cannot return zero, defensive programming
+        // protects against unexpected platform behaviour.
+        let workers = std::thread::available_parallelism()
+            .map_or(1, std::num::NonZeroUsize::get)
+            .max(1);
         Self {
             factory,
             listener: None,

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -8,6 +8,12 @@ fn default_worker_count_matches_cpu_count() {
 }
 
 #[test]
+fn default_workers_at_least_one() {
+    let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"));
+    assert!(server.worker_count() >= 1);
+}
+
+#[test]
 fn workers_method_enforces_minimum() {
     let server =
         WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed")).workers(0);


### PR DESCRIPTION
## Summary
- safeguard default worker count by enforcing a minimum of one
- add regression test for default worker count

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint '**/*.md'` *(fails: MD013, MD040, MD033, MD047)*

------
https://chatgpt.com/codex/tasks/task_e_684e2d396d688322a678bc7e1f70492f

## Summary by Sourcery

Ensure that the server always uses at least one worker even if `available_parallelism` returns zero and add a corresponding test to prevent regressions

Enhancements:
- Enforce a minimum default worker count of one by adding a `.max(1)` check

Tests:
- Add a regression test to verify that the default worker count is at least one