### PR TITLE
Deprecate SharedState::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## Unreleased
+
+- Deprecated `SharedState::new`; construct via `inner.into()` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-- Deprecated `SharedState::new`; construct via `inner.into()` instead.
+- Deprecated `SharedState::new` (since 0.2.0); construct via `inner.into()`
+  instead.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ connections and runs the Tokio event loop:
 WireframeServer::new(|| {
     WireframeApp::new()
         .frame_processor(MyFrameProcessor::new())
-        .app_data(SharedState::new(state.clone()))
+        .app_data(state.clone().into())
         .route(MessageType::Login, handle_login)
         .wrap(MyLoggingMiddleware::default())
 })

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -624,7 +624,7 @@ WireframeApp::new()
 
 .frame_processor(MyFrameProcessor::new()) // Configure the framing logic
 
-.app_data(SharedState::new(app_state.clone())) // Shared application state
+.app_data(app_state.clone().into()) // Shared application state
 
 //.service(login_handler) // If using attribute macros and auto-discovery
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -65,7 +65,7 @@ impl<T: Send + Sync> SharedState<T> {
     /// use wireframe::extractor::SharedState;
     ///
     /// let data = Arc::new(5u32);
-    /// let state = SharedState::new(Arc::clone(&data));
+    /// let state: SharedState<u32> = Arc::clone(&data).into();
     /// assert_eq!(*state, 5);
     /// ```
     #[must_use]
@@ -78,9 +78,10 @@ impl<T: Send + Sync> SharedState<T> {
     /// use wireframe::extractor::SharedState;
     ///
     /// let state = Arc::new(42);
-    /// let shared = SharedState::new(state.clone());
+    /// let shared: SharedState<u32> = state.clone().into();
     /// assert_eq!(*shared, 42);
     /// ```
+    #[deprecated(note = "construct via `inner.into()` instead")]
     pub fn new(inner: Arc<T>) -> Self {
         Self(inner)
     }
@@ -112,7 +113,7 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
     /// use wireframe::extractor::SharedState;
     ///
     /// let state = Arc::new(42);
-    /// let shared = SharedState::new(state.clone());
+    /// let shared: SharedState<u32> = state.clone().into();
     /// assert_eq!(*shared, 42);
     /// ```
     fn deref(&self) -> &Self::Target {

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -81,7 +81,7 @@ impl<T: Send + Sync> SharedState<T> {
     /// let shared: SharedState<u32> = state.clone().into();
     /// assert_eq!(*shared, 42);
     /// ```
-    #[deprecated(note = "construct via `inner.into()` instead")]
+    #[deprecated(since = "0.2.0", note = "construct via `inner.into()` instead")]
     pub fn new(inner: Arc<T>) -> Self {
         Self(inner)
     }


### PR DESCRIPTION
## Summary
- mark `SharedState::new` as deprecated
- update docs and README to construct `SharedState` via `From` impls
- add migration note to `CHANGELOG`

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md CHANGELOG.md` *(fails: 297 errors)*
- `nixie README.md docs/*.md`

------
https://chatgpt.com/codex/tasks/task_e_684e35de1fbc8322a8b8df5c164be392

## Summary by Sourcery

Deprecate the SharedState::new constructor in favor of the From impl and update documentation and code examples accordingly

Enhancements:
- Deprecate SharedState::new in v0.2.0 and recommend constructing via Arc<T>.into()
- Add an unreleased migration note to CHANGELOG pointing users to use .into()

Documentation:
- Update README and design docs to replace SharedState::new with .into() in code samples