### PR TITLE
Fix docs for WireframeServer::new

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -60,10 +60,6 @@ where
     ///
     /// The server is initialised with a default worker count equal to the number of available CPU cores, or 1 if this cannot be determined. The TCP listener is unset and must be configured with `bind` before running the server.
     ///
-    /// # Panics
-    ///
-    /// Panics if the number of available CPUs cannot be determined and the fallback to 1 fails.
-    ///
     /// # Examples
     ///
     /// ```ignore


### PR DESCRIPTION
## Summary
- remove outdated panic section from server constructor docs

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint '**/*.md'` *(fails: many pre-existing errors)*
- `nixie docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_684e51103e6483228f03f2098a0e9d5c

## Summary by Sourcery

Documentation:
- Remove the ‘# Panics’ section from the server constructor docs as the CPU-count fallback no longer panics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed documentation about a specific panic condition in the server constructor. No changes to functionality or behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->