### PR TITLE
Document preamble setup order

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ reduce this boilerplate through layered abstractions:
 - **Transport adapter** built on Tokio I/O
 - **Framing layer** for length‑prefixed or custom frames
 - **Connection preamble** with customizable validation callbacks [[docs](docs/preamble-validator.md)]
+- Call `with_preamble::<T>()` before registering success or failure callbacks
 - **Serialization engine** using `bincode` or a `wire-rs` wrapper
 - **Routing engine** that dispatches messages by ID
 - **Handler invocation** with extractor support

--- a/docs/preamble-validator.md
+++ b/docs/preamble-validator.md
@@ -31,3 +31,12 @@ sequenceDiagram
 In the tests, a `HotlinePreamble` struct illustrates the pattern, but any
 preamble type may be used. Register callbacks via `on_preamble_decode_success`
 and `on_preamble_decode_failure` on `WireframeServer`.
+
+## Call Order
+
+`WireframeServer::with_preamble` must be called **before**
+registering callbacks with `on_preamble_decode_success` or
+`on_preamble_decode_failure`. The method converts the server to use a
+custom preamble type, dropping any callbacks configured on the default
+`()` preamble. Registering callbacks after calling `with_preamble`
+ensures they are retained.

--- a/src/server.rs
+++ b/src/server.rs
@@ -88,8 +88,7 @@ where
 
     /// Convert this server to parse a custom preamble `T`.
     ///
-    /// Call this before registering preamble handlers, otherwise any
-    /// previously configured callbacks will be dropped.
+    /// Call this before registering preamble handlers. Calling it later drops any previously configured callbacks.
     #[must_use]
     pub fn with_preamble<T>(self) -> WireframeServer<F, T>
     where


### PR DESCRIPTION
## Summary
- document that `with_preamble` must be called before registering callbacks
- mention the call order in README
- clarify the `with_preamble` doc comment

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/preamble-validator.md`
- `nixie docs/preamble-validator.md`


------
https://chatgpt.com/codex/tasks/task_e_684e5eb84c8483228cc92a7eb717c0ab