### PR TITLE
Fix duplicated workers docs

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -86,7 +86,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
     /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
     /// ```
     #[must_use]
@@ -114,7 +114,8 @@ where
 {
     /// Set the number of worker tasks to spawn for the server.
     ///
-    /// Ensures at least one worker is configured.
+    /// The count is clamped to at least one so a worker is always
+    /// present. Returns a new server instance with the updated value.
     ///
     /// # Examples
     ///
@@ -123,23 +124,11 @@ where
     ///
     /// let factory = || WireframeApp::new().unwrap();
     /// let server = WireframeServer::new(factory).workers(4);
-    /// ```
-    #[must_use]
-    /// Sets the number of worker tasks to spawn, ensuring at least one worker is configured.
-    ///
-    /// Returns a new `WireframeServer` instance with the updated worker count. If `count` is less than 1, it defaults to 1.
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
-    ///
-    /// let factory = || WireframeApp::new().unwrap();
-    /// let server = WireframeServer::new(factory).workers(4);
     /// assert_eq!(server.worker_count(), 4);
     /// let server = server.workers(0);
     /// assert_eq!(server.worker_count(), 1);
     /// ```
+    #[must_use]
     pub fn workers(mut self, count: usize) -> Self {
         self.workers = count.max(1);
         self

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,8 +86,12 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
+    /// ```no_run
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// #[derive(bincode::Decode)]
+    /// struct MyPreamble;
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .with_preamble::<MyPreamble>();
     /// ```
     #[must_use]
     pub fn with_preamble<T>(self) -> WireframeServer<F, T>
@@ -162,7 +166,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
     /// let factory = || WireframeApp::new().unwrap();


### PR DESCRIPTION
## Summary
- clean up `workers` method docs
- mark doctest snippet as ignored

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/*.md README.md CHANGELOG.md` *(fails: many warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684e966f2d8c8322a5a0afa5cd0fd4a8

## Summary by Sourcery

Clean up and consolidate server method documentation and mark code examples as ignored to prevent doctest warnings.

Bug Fixes:
- Remove duplicated documentation comments for the `workers` method

Enhancements:
- Refine and simplify doc comments for `with_preamble` and `workers` methods
- Clamp worker count documentation to clarify minimum of one worker
- Convert doc example snippets to use `no_run` instead of `ignore`

Documentation:
- Update code examples with necessary imports and `no_run` tags
- Remove redundant example blocks and streamline method descriptions