### PR TITLE
Improve connection handling stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
+name = "log"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +460,7 @@ dependencies = [
  "bincode",
  "bytes",
  "futures",
+ "log",
  "serde",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { version = "1", default-features = false, features = ["net", "signal", 
 futures = "0.3"
 async-trait = "0.1"
 bytes = "1"
+log = "0.4"
 
 [lints.clippy]
 pedantic = "warn"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ WireframeServer::new(|| {
 This example showcases how derive macros and the framing abstraction simplify a
 binary protocol server【F:docs/rust-binary-router-library-design.md†L1120-L1150】.
 
+## Current Limitations
+
+Connection processing is not implemented yet. After the optional
+preamble is read, the server logs a warning and immediately closes the
+stream. Release builds fail to compile to prevent accidental production
+use.
+
 ## Roadmap
 
 Development priorities are tracked in [docs/roadmap.md](docs/roadmap.md). Key

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,13 +85,17 @@ impl WireframeApp {
 
     /// Handle an accepted connection.
     ///
-    /// This placeholder simply drops the stream. Future implementations
-    /// will decode frames and dispatch them to registered handlers.
+    /// This placeholder immediately closes the connection after the
+    /// preamble phase. A warning is logged so tests and callers are
+    /// aware of the current limitation.
     pub async fn handle_connection<S>(&self, _stream: S)
     where
         S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
     {
-        // Connection handling will be implemented later.
+        log::warn!(
+            "`WireframeApp::handle_connection` called, but connection handling \
+             is not implemented; closing stream"
+        );
         tokio::task::yield_now().await;
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,9 @@
 use std::io;
+
+#[cfg(not(debug_assertions))]
+compile_error!(
+    "`wireframe` server functionality is experimental and not intended for production use"
+);
 use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::sync::Arc;
 
@@ -86,7 +91,10 @@ where
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore
+    /// # use wireframe::server::WireframeServer;
+    /// # let factory = || todo!();
+    /// # struct MyPreamble;
     /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
     /// ```
     #[must_use]


### PR DESCRIPTION
## Summary
- warn when connection handling is triggered
- prevent server from compiling in release
- document current connection limitations

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint README.md docs/*.md` (fails: many MD013 errors)
- `nixie docs/preamble-validator.md docs/rust-binary-router-library-design.md docs/roadmap.md docs/rust-testing-with-rstest-fixtures.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_684e9c68fa648322aa2cbcfc2f3c2c08

## Summary by Sourcery

Warn and close connections in the unimplemented handle_connection stub, add logging support, document current connection-handling limitations including release build prevention, and update example code annotations accordingly

Enhancements:
- Log a warning and immediately close the connection in the handle_connection stub after the preamble phase
- Yield to the scheduler in the handle_connection placeholder to avoid blocking

Build:
- Add the `log = "0.4"` dependency in Cargo.toml

Documentation:
- Document current connection processing limitations and release build prevention in the README
- Annotate the WireframeServer example code block as `ignore` in the server documentation