### PR TITLE
Fix doctest compilation

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -28,10 +28,12 @@ pub trait Message: Encode + for<'de> BorrowDecode<'de, ()> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use your_crate::Message;
-    /// let bytes = /* some valid serialised message bytes */;
-    /// let (msg, consumed) = MyMessageType::from_bytes(&bytes).unwrap();
+    /// #[derive(bincode::Encode, bincode::BorrowDecode)]
+    /// struct MyMessageType(u8);
+    /// let bytes = vec![]; // serialized message bytes
+    /// let (_msg, consumed) = MyMessageType::from_bytes(&bytes).unwrap();
     /// assert!(consumed <= bytes.len());
     /// ```
     fn from_bytes(bytes: &[u8]) -> Result<(Self, usize), DecodeError>

--- a/src/preamble.rs
+++ b/src/preamble.rs
@@ -74,9 +74,9 @@ where
 ///
 /// ```
 /// use tokio::io::BufReader;
-/// use bincode::BorrowDecode;
+/// use wireframe::preamble::read_preamble;
 ///
-/// #[derive(Debug, PartialEq, bincode::BorrowDecode)]
+/// #[derive(Debug, PartialEq, bincode::Encode, bincode::BorrowDecode)]
 /// struct MyPreamble(u8);
 ///
 /// #[tokio::main]

--- a/src/server.rs
+++ b/src/server.rs
@@ -93,6 +93,7 @@ where
     ///
     /// ```no_run
     /// # use wireframe::server::WireframeServer;
+    /// # use wireframe::app::WireframeApp;
     /// # let factory = || WireframeApp::new().unwrap();
     /// # struct MyPreamble;
     /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
@@ -377,10 +378,11 @@ async fn worker_task<F, T>(
 ///
 /// ```no_run
 /// # use std::sync::Arc;
-/// # use mycrate::{process_stream, WireframeApp, Preamble};
+/// # use wireframe::server::{Preamble, process_stream};
+/// # use wireframe::app::WireframeApp;
 /// # use tokio::net::TcpStream;
 /// # async fn example() {
-/// let stream: TcpStream = /* ... */;
+/// let stream: TcpStream = unimplemented!();
 /// let factory = || WireframeApp::new();
 /// process_stream::<_, ()>(stream, factory, None, None).await;
 /// # }


### PR DESCRIPTION
## Summary
- update doctest in `Message::from_bytes`
- fix `read_preamble` example
- correct server documentation imports

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --all-targets --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684ea4e943e88322b167ab01130e17b5

## Summary by Sourcery

Fix compilation errors in doctest examples across message, server, and preamble modules by updating annotations, imports, and trait derives to ensure the examples compile successfully.

Documentation:
- Mark the Message::from_bytes example as `no_run`, add `bincode::Encode` and `bincode::BorrowDecode` derives, and use a valid placeholder byte vector.
- Add missing `wireframe::app::WireframeApp` import in server examples and adjust import paths for `Preamble` and `process_stream`.
- Import `read_preamble` and add `bincode::Encode` derive to `MyPreamble` in the preamble example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved code examples in documentation for better clarity and accuracy, including corrected imports, explicit struct definitions, and updated variable naming to avoid warnings. No changes to application behaviour or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->