### PR TITLE
Remove redundant spawn in process_stream

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -393,10 +393,10 @@ async fn process_stream<F, T>(
             }
             let stream = RewindStream::new(leftover, stream);
             // Hand the connection to the application for processing.
+            // We already run `process_stream` inside a task, so spawning again
+            // only adds overhead.
             let app = (factory)();
-            tokio::spawn(async move {
-                app.handle_connection(stream).await;
-            });
+            app.handle_connection(stream).await;
         }
         Err(err) => {
             if let Some(handler) = on_failure.as_ref() {


### PR DESCRIPTION
## Summary
- call `handle_connection` directly instead of spawning a task

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684ed0d36464832280327dfc569281a3

## Summary by Sourcery

Enhancements:
- Call handle_connection directly in process_stream instead of spawning a new task to reduce overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal task handling for more efficient connection processing. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->