### PR TITLE
Format docs and fix lint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ project:
 - Run cargo fmt, cargo clippy -- -D warnings, and RUSTFLAGS="-D warnings" cargo
   test before committing.
 - Clippy warnings MUST be disallowed.
-- Fix any warnings emitted during tests in the code itself rather than silencing them.
+- Fix any warnings emitted during tests in the code itself rather than
+  silencing them.
 - Where a function is too long, extract meaningfully named helper functions
   adhering to separation of concerns and CQRS.
 - Where a function has too many parameters, group related parameters in

--- a/docs/preamble-validator.md
+++ b/docs/preamble-validator.md
@@ -34,9 +34,8 @@ and `on_preamble_decode_failure` on `WireframeServer`.
 
 ## Call Order
 
-`WireframeServer::with_preamble::<T>()` must be called **before**
-registering callbacks with `on_preamble_decode_success` or
-`on_preamble_decode_failure`. The method converts the server to use a
-custom preamble type, dropping any callbacks configured on the default
-`()` preamble. Registering callbacks after calling `with_preamble::<T>()`
-ensures they are retained.
+`WireframeServer::with_preamble::<T>()` must be called **before** registering
+callbacks with `on_preamble_decode_success` or `on_preamble_decode_failure`. The
+method converts the server to use a custom preamble type, dropping any callbacks
+configured on the default `()` preamble. Registering callbacks after calling
+`with_preamble::<T>()` ensures they are retained.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,26 +9,28 @@ after formatting. Line numbers below refer to that file.
 - [ ] Lines 316-345 outline the layered architecture comprising the Transport
   Layer Adapter, Framing Layer, Serialization engine, Routing engine, Handler
   invocation, and Middleware chain.
+
 - [x] Implement derive macros or wrappers for message serialization (lines
   329-333).
+
 - [ ] Build the Actix-inspired API around `WireframeApp` and `WireframeServer`
   as described in lines 586-676.
-  - [ ] Implement `WireframeApp` builder.
-        Clarify method signatures (`new`, `route`, `service`, `wrap`),
-        expose a consistent `Result<Self>` error strategy, and allow
-        registration calls in any order for ergonomic chaining.
-  - [x] Implement `WireframeServer`.
-        Worker tasks are spawned using Tokio. Each thread receives its own
-        `WireframeApp` instance from a factory closure. A Ctrl+C signal triggers
-        graceful shutdown, notifying all workers to stop accepting new
-        connections.
-  - [x] Standardize supporting trait definitions.
-        Provide naming conventions and generic bounds for the
-        `FrameProcessor` trait, state extractors and middleware via
-        `async_trait` and associated types.
-  - [x] Provide a minimal, runnable example.
-        Include imports and an async `main` so the snippet compiles out of
-        the box.
+
+  - [ ] Implement `WireframeApp` builder. Clarify method signatures (`new`,
+    `route`, `service`, `wrap`), expose a consistent `Result<Self>` error
+    strategy, and allow registration calls in any order for ergonomic chaining.
+
+  - [x] Implement `WireframeServer`. Worker tasks are spawned using Tokio. Each
+    thread receives its own `WireframeApp` instance from a factory closure. A
+    Ctrl+C signal triggers graceful shutdown, notifying all workers to stop
+    accepting new connections.
+
+  - [x] Standardize supporting trait definitions. Provide naming conventions and
+    generic bounds for the `FrameProcessor` trait, state extractors and
+    middleware via `async_trait` and associated types.
+
+  - [x] Provide a minimal, runnable example. Include imports and an async `main`
+    so the snippet compiles out of the box.
 
     ```rust
     // No extra imports required
@@ -55,39 +57,37 @@ after formatting. Line numbers below refer to that file.
     }
     ```
 
-- [x] Add connection preamble support.
-      Provide generic parsing of connection preambles with a Hotline handshake
-      example in the tests. Invoke user-configured callbacks on decode success
-      or failure. See [preamble-validator](preamble-validator.md).
-- [ ] Add response serialization and transmission.
-      Encode handler responses using the selected serialization format and write
-      them back through the framing layer.
-- [ ] Add connection lifecycle hooks.
-      Integrate setup and teardown stages, so sessions can hold state (such as a
-      logged-in user ID) across messages.
+- [x] Add connection preamble support. Provide generic parsing of connection
+  preambles with a Hotline handshake example in the tests. Invoke
+  user-configured callbacks on decode success or failure. See
+  [preamble-validator](preamble-validator.md).
+
+- [ ] Add response serialization and transmission. Encode handler responses
+  using the selected serialization format and write them back through the
+  framing layer.
+
+- [ ] Add connection lifecycle hooks. Integrate setup and teardown stages, so
+  sessions can hold state (such as a logged-in user ID) across messages.
 
 ## 2. Middleware and Extractors
 
 - [ ] Develop a minimal middleware system and extractor traits for payloads,
   connection metadata, and shared state.
-  - [ ] Define `FromMessageRequest` for extractor types (lines 760-782).
-        See [`FromMessageRequest`][from-message-request] in
-        [`src/extractor.rs`](../src/extractor.rs).
+  - [ ] Define `FromMessageRequest` for extractor types (lines 760-782). See
+    [`FromMessageRequest`][from-message-request] in
+    [`src/extractor.rs`](../src/extractor.rs).
   - [ ] Provide built-in extractors `Message<T>`, `ConnectionInfo`, and
-        `SharedState<T>` (lines 792-840). `SharedState<T>` is defined in
-        [`src/extractor.rs`](../src/extractor.rs#L54-L87).
-  - [ ] Support custom extractors implementing `FromMessageRequest`
-        (lines 842-858). Refer again to
-        [`src/extractor.rs`](../src/extractor.rs#L39-L52).
+    `SharedState<T>` (lines 792-840). `SharedState<T>` is defined in
+    [`src/extractor.rs`](../src/extractor.rs#L54-L87).
+  - [ ] Support custom extractors implementing `FromMessageRequest` (lines
+    842-858). Refer again to [`src/extractor.rs`](../src/extractor.rs#L39-L52).
   - [ ] Implement middleware using `Transform`/`Service` traits and a simple
-        `from_fn` style variant (lines 866-899). Trait definitions live in
-        [`src/middleware.rs`](../src/middleware.rs#L71-L84).
+    `from_fn` style variant (lines 866-899). Trait definitions live in
+    [`src/middleware.rs`](../src/middleware.rs#L71-L84).
   - [ ] Register middleware with `WireframeApp::wrap` and execute it in order
-        (lines 900-919). See the [`wrap` method](../src/app.rs#L73-L84).
+    (lines 900-919). See the [`wrap` method](../src/app.rs#L73-L84).
   - [ ] Document common middleware use cases like logging and authentication
-        (lines 920-935).
-
-[from-message-request]: ../src/extractor.rs#L39-L52
+    (lines 920-935).
 
 ## 3. Initial Examples and Documentation
 
@@ -105,12 +105,14 @@ after formatting. Line numbers below refer to that file.
 
 - [ ] Create a CLI for protocol scaffolding and testing (lines 1424-1429).
 - [ ] Improve debugging support and expand documentation (lines 1430-1435).
-- [ ] Provide testing utilities for handlers.
-      Offer simple ways to drive handlers with raw frames for unit tests.
-      Early examples live in [`tests/server.rs`](../tests/server.rs); future
-      helpers may reside in a `wireframe-testing` crate.
+- [ ] Provide testing utilities for handlers. Offer simple ways to drive
+  handlers with raw frames for unit tests. Early examples live in
+  [`tests/server.rs`](../tests/server.rs); future helpers may reside in a
+  `wireframe-testing` crate.
 
 ## 6. Community Engagement and Integration
 
 - [ ] Collaborate with `wire-rs` for trait derivation and future enhancements
   (lines 1437-1442).
+
+[from-message-request]: ../src/extractor.rs#L39-L52

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -671,8 +671,8 @@ similar to Actix Web's web::Data.21
   manage incoming connections, task spawning for each connection, and the
   overall server lifecycle. The default number of worker tasks matches the
   available CPU cores, falling back to a single worker if the count cannot be
-  determined. This would likely be built on Tokio's networking and
-  runtime primitives.18
+  determined. This would likely be built on Tokio's networking and runtime
+  primitives.18
 
 This structural similarity to Actix Web is intentional. Developers familiar with
 Actix Web's application setup will find "wireframe's" approach intuitive,
@@ -867,10 +867,9 @@ pipeline.
   by implementing a pair of traits, analogous to Actix Web's `Transform` and
   `Service` traits.25
 
-  - The `Transform` trait would act as a factory for the middleware service.
-    Its `transform` method is annotated with `#[must_use]` (to encourage
-    using the returned service) and `#[inline]` for potential performance
-    gains.
+  - The `Transform` trait would act as a factory for the middleware service. Its
+    `transform` method is annotated with `#[must_use]` (to encourage using the
+    returned service) and `#[inline]` for potential performance gains.
   - The `Service` trait would define the actual request/response processing
     logic. Middleware would operate on "wireframe's" internal request and
     response types, which could be raw frames at one level or deserialized

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1,65 +1,134 @@
 # Mastering Test Fixtures in Rust with `rstest`
 
-Testing is an indispensable part of modern software development, ensuring code reliability, maintainability, and correctness. In the Rust ecosystem, while the built-in testing framework provides a solid foundation, managing test dependencies and creating parameterized tests can become verbose. The `rstest` crate (`github.com/la10736/rstest`) emerges as a powerful solution, offering a sophisticated fixture-based and parameterized testing framework that significantly simplifies these tasks through the use of procedural macros.1 This document provides a comprehensive exploration of `rstest`, from fundamental concepts to advanced techniques, enabling Rust developers to write cleaner, more expressive, and robust tests.
+Testing is an indispensable part of modern software development, ensuring code
+reliability, maintainability, and correctness. In the Rust ecosystem, while the
+built-in testing framework provides a solid foundation, managing test
+dependencies and creating parameterized tests can become verbose. The `rstest`
+crate (`github.com/la10736/rstest`) emerges as a powerful solution, offering a
+sophisticated fixture-based and parameterized testing framework that
+significantly simplifies these tasks through the use of procedural macros.1 This
+document provides a comprehensive exploration of `rstest`, from fundamental
+concepts to advanced techniques, enabling Rust developers to write cleaner, more
+expressive, and robust tests.
 
 ## I. Introduction to `rstest` and Test Fixtures in Rust
 
 ### A. What are Test Fixtures and Why Use Them?
 
-In software testing, a **test fixture** refers to a fixed state of a set of objects used as a baseline for running tests. The primary purpose of a fixture is to ensure that there is a well-known and controlled environment in which tests are run so that results are repeatable. Test dependencies, such as database connections, user objects, or specific configurations, often require careful setup before a test can execute and, sometimes, teardown afterward. Managing this setup and teardown logic within each test function can lead to considerable boilerplate code and repetition, making tests harder to read and maintain.
+In software testing, a **test fixture** refers to a fixed state of a set of
+objects used as a baseline for running tests. The primary purpose of a fixture
+is to ensure that there is a well-known and controlled environment in which
+tests are run so that results are repeatable. Test dependencies, such as
+database connections, user objects, or specific configurations, often require
+careful setup before a test can execute and, sometimes, teardown afterward.
+Managing this setup and teardown logic within each test function can lead to
+considerable boilerplate code and repetition, making tests harder to read and
+maintain.
 
-Fixtures address this by encapsulating these dependencies and their setup logic.1 For instance, if multiple tests require a logged-in user object or a pre-populated database, instead of creating these in every test, a fixture can provide them. This approach allows developers to focus on the specific logic being tested rather than the auxiliary utilities.
+Fixtures address this by encapsulating these dependencies and their setup
+logic.1 For instance, if multiple tests require a logged-in user object or a
+pre-populated database, instead of creating these in every test, a fixture can
+provide them. This approach allows developers to focus on the specific logic
+being tested rather than the auxiliary utilities.
 
-Fundamentally, the use of fixtures promotes a crucial separation of concerns: the *preparation* of the test environment is decoupled from the *execution* of the test logic. Traditional testing approaches often intermingle setup, action, and assertion logic within a single test function. This can result in lengthy and convoluted tests that are difficult to comprehend at a glance. By extracting the setup logic into reusable components (fixtures), the actual test functions become shorter, more focused, and thus more readable and maintainable.
+Fundamentally, the use of fixtures promotes a crucial separation of concerns:
+the *preparation* of the test environment is decoupled from the *execution* of
+the test logic. Traditional testing approaches often intermingle setup, action,
+and assertion logic within a single test function. This can result in lengthy
+and convoluted tests that are difficult to comprehend at a glance. By extracting
+the setup logic into reusable components (fixtures), the actual test functions
+become shorter, more focused, and thus more readable and maintainable.
 
 ### B. Introducing `rstest`: Simplifying Fixture-Based Testing in Rust
 
-`rstest` is a Rust crate specifically designed to simplify and enhance testing by leveraging the concept of fixtures and providing powerful parameterization capabilities.1 It is available on `crates.io` and its source code is hosted at `github.com/la10736/rstest` 3, distinguishing it from other software projects that may share the same name but operate in different ecosystems (e.g., a JavaScript/TypeScript framework mentioned in 5).
+`rstest` is a Rust crate specifically designed to simplify and enhance testing
+by leveraging the concept of fixtures and providing powerful parameterization
+capabilities.1 It is available on `crates.io` and its source code is hosted at
+`github.com/la10736/rstest` 3, distinguishing it from other software projects
+that may share the same name but operate in different ecosystems (e.g., a
+JavaScript/TypeScript framework mentioned in 5).
 
-The `rstest` crate utilizes Rust's procedural macros, such as `#[rstest]` and `#[fixture]`, to achieve its declarative and expressive syntax.2 These macros allow developers to define fixtures and inject them into test functions simply by listing them as arguments. This compile-time mechanism analyzes test function signatures and fixture definitions to wire up dependencies automatically.
+The `rstest` crate utilizes Rust's procedural macros, such as `#[rstest]` and
+`#[fixture]`, to achieve its declarative and expressive syntax.2 These macros
+allow developers to define fixtures and inject them into test functions simply
+by listing them as arguments. This compile-time mechanism analyzes test function
+signatures and fixture definitions to wire up dependencies automatically.
 
-This reliance on procedural macros is a key architectural decision. It enables `rstest` to offer a remarkably clean and intuitive syntax at the test-writing level. Developers declare the dependencies their tests need, and the macros handle the resolution and injection. While this significantly improves the developer experience for writing tests, the underlying macro expansion involves compile-time code generation. This complexity, though hidden, can have implications for build times, particularly in large test suites.7 Furthermore, understanding the macro expansion can sometimes be necessary for debugging complex test scenarios or unexpected behavior.8
+This reliance on procedural macros is a key architectural decision. It enables
+`rstest` to offer a remarkably clean and intuitive syntax at the test-writing
+level. Developers declare the dependencies their tests need, and the macros
+handle the resolution and injection. While this significantly improves the
+developer experience for writing tests, the underlying macro expansion involves
+compile-time code generation. This complexity, though hidden, can have
+implications for build times, particularly in large test suites.7 Furthermore,
+understanding the macro expansion can sometimes be necessary for debugging
+complex test scenarios or unexpected behavior.8
 
 ### C. Core Benefits: Readability, Reusability, Reduced Boilerplate
 
-The primary advantages of using `rstest` revolve around enhancing test code quality and developer productivity:
+The primary advantages of using `rstest` revolve around enhancing test code
+quality and developer productivity:
 
-- **Readability:** By injecting dependencies as function arguments, `rstest` makes the requirements of a test explicit and easy to understand.9 The test function's signature clearly documents what it needs to run. This allows developers to "focus on the important stuff in your tests" by abstracting away the setup details.1
-- **Reusability:** Fixtures defined with `rstest` are reusable components. A single fixture, such as one setting up a database connection or creating a complex data structure, can be used across multiple tests, eliminating redundant setup code.
-- **Reduced Boilerplate:** `rstest` significantly cuts down on repetitive setup and teardown code. Parameterization features, like `#[case]` and `#[values]`, further reduce boilerplate by allowing the generation of multiple test variations from a single function.
+- **Readability:** By injecting dependencies as function arguments, `rstest`
+  makes the requirements of a test explicit and easy to understand.9 The test
+  function's signature clearly documents what it needs to run. This allows
+  developers to "focus on the important stuff in your tests" by abstracting away
+  the setup details.1
+- **Reusability:** Fixtures defined with `rstest` are reusable components. A
+  single fixture, such as one setting up a database connection or creating a
+  complex data structure, can be used across multiple tests, eliminating
+  redundant setup code.
+- **Reduced Boilerplate:** `rstest` significantly cuts down on repetitive setup
+  and teardown code. Parameterization features, like `#[case]` and `#[values]`,
+  further reduce boilerplate by allowing the generation of multiple test
+  variations from a single function.
 
-The declarative nature of `rstest` is central to these benefits. Instead of imperatively writing setup code within each test (the *how*), developers declare the fixtures they need (the *what*) in the test function's signature. This shifts the cognitive load from managing setup details in every test to designing a system of well-defined, reusable fixtures. Over time, particularly in larger projects, this can lead to a more robust, maintainable, and understandable test suite as common setup patterns are centralized and managed effectively.
+The declarative nature of `rstest` is central to these benefits. Instead of
+imperatively writing setup code within each test (the *how*), developers declare
+the fixtures they need (the *what*) in the test function's signature. This
+shifts the cognitive load from managing setup details in every test to designing
+a system of well-defined, reusable fixtures. Over time, particularly in larger
+projects, this can lead to a more robust, maintainable, and understandable test
+suite as common setup patterns are centralized and managed effectively.
 
 ## II. Getting Started with `rstest`
 
-Embarking on `rstest` usage involves a straightforward setup process, from adding it to the project dependencies to defining and using basic fixtures.
+Embarking on `rstest` usage involves a straightforward setup process, from
+adding it to the project dependencies to defining and using basic fixtures.
 
 ### A. Installation and Project Setup (`Cargo.toml`)
 
-To begin using `rstest`, it must be added as a development dependency in the project's `Cargo.toml` file. This ensures that `rstest` is only compiled and linked when running tests, not when building the main application or library.
+To begin using `rstest`, it must be added as a development dependency in the
+project's `Cargo.toml` file. This ensures that `rstest` is only compiled and
+linked when running tests, not when building the main application or library.
 
-Add the following lines to your `Cargo.toml` under the `[dev-dependencies]` section:
+Add the following lines to your `Cargo.toml` under the `[dev-dependencies]`
+section:
 
-Ini, TOML
-
-```
+```toml
 [dev-dependencies]
 rstest = "0.18" # Or the latest version available on crates.io
 # rstest_macros may also be needed explicitly depending on usage or version
 # rstest_macros = "0.18" # Check crates.io for the latest version
 ```
 
-It is advisable to check `crates.io` for the latest stable version of `rstest` (and `rstest_macros` if required separately by the version of `rstest` being used).1 Using `dev-dependencies` is a standard practice in Rust for testing libraries. This convention prevents testing utilities from being included in production binaries, which helps keep them small and reduces compile times for non-test builds.11
+It is advisable to check `crates.io` for the latest stable version of `rstest`
+(and `rstest_macros` if required separately by the version of `rstest` being
+used).1 Using `dev-dependencies` is a standard practice in Rust for testing
+libraries. This convention prevents testing utilities from being included in
+production binaries, which helps keep them small and reduces compile times for
+non-test builds.11
 
 ### B. Your First Fixture: Defining with `#[fixture]`
 
-A fixture in `rstest` is essentially a Rust function that provides some data or performs some setup action, with its result being injectable into tests. To designate a function as a fixture, it is annotated with the `#[fixture]` attribute.
+A fixture in `rstest` is essentially a Rust function that provides some data or
+performs some setup action, with its result being injectable into tests. To
+designate a function as a fixture, it is annotated with the `#[fixture]`
+attribute.
 
 Consider a simple fixture that provides a numeric value:
 
-Rust
-
-```
+```rust
 use rstest::fixture; // Or use rstest::*;
 
 #[fixture]
@@ -68,17 +137,25 @@ pub fn answer_to_life() -> u32 {
 }
 ```
 
-In this example, `answer_to_life` is a public function marked with `#[fixture]`. It takes no arguments and returns a `u32` value of 42.9 The `#[fixture]` macro effectively registers this function with the `rstest` system, transforming it into a component that `rstest` can discover and utilize. The return type of the fixture function (here, `u32`) defines the type of the data that will be injected into tests requesting this fixture. Fixtures can return any valid Rust type, from simple primitives to complex structs or trait objects.1 Fixtures can also depend on other fixtures, allowing for compositional setup.12
+In this example, `answer_to_life` is a public function marked with `#[fixture]`.
+It takes no arguments and returns a `u32` value of 42.9 The `#[fixture]` macro
+effectively registers this function with the `rstest` system, transforming it
+into a component that `rstest` can discover and utilize. The return type of the
+fixture function (here, `u32`) defines the type of the data that will be
+injected into tests requesting this fixture. Fixtures can return any valid Rust
+type, from simple primitives to complex structs or trait objects.1 Fixtures can
+also depend on other fixtures, allowing for compositional setup.12
 
 ### C. Injecting Fixtures into Tests with `#[rstest]`
 
-Once a fixture is defined, it can be used in a test function. Test functions that utilize `rstest` features, including fixture injection, must be annotated with the `#[rstest]` attribute. The fixture is then injected by simply declaring an argument in the test function with the same name as the fixture function.
+Once a fixture is defined, it can be used in a test function. Test functions
+that utilize `rstest` features, including fixture injection, must be annotated
+with the `#[rstest]` attribute. The fixture is then injected by simply declaring
+an argument in the test function with the same name as the fixture function.
 
 Here’s how to use the `answer_to_life` fixture in a test:
 
-Rust
-
-```
+```rust
 use rstest::{fixture, rstest}; // Or use rstest::*;
 
 #[fixture]
@@ -92,51 +169,61 @@ fn test_with_fixture(answer_to_life: u32) {
 }
 ```
 
-In `test_with_fixture`, the argument `answer_to_life: u32` signals to `rstest` that the `answer_to_life` fixture should be injected.1 `rstest` resolves this by name: it looks for a fixture function named `answer_to_life`, calls it, and passes its return value as the argument to the test function.13
+In `test_with_fixture`, the argument `answer_to_life: u32` signals to `rstest`
+that the `answer_to_life` fixture should be injected.1 `rstest` resolves this by
+name: it looks for a fixture function named `answer_to_life`, calls it, and
+passes its return value as the argument to the test function.13
 
-The argument name in the test function serves as the primary key for fixture resolution. This convention makes usage intuitive but necessitates careful naming of fixtures to avoid ambiguity, especially if multiple fixtures with the same name exist in different modules but are brought into the same scope. `rstest` generally follows Rust's standard name resolution rules, meaning an identically named fixture can be used in different contexts depending on visibility and `use` declarations.1
+The argument name in the test function serves as the primary key for fixture
+resolution. This convention makes usage intuitive but necessitates careful
+naming of fixtures to avoid ambiguity, especially if multiple fixtures with the
+same name exist in different modules but are brought into the same scope.
+`rstest` generally follows Rust's standard name resolution rules, meaning an
+identically named fixture can be used in different contexts depending on
+visibility and `use` declarations.1
 
 ## III. Mastering Fixture Injection and Basic Usage
 
-Understanding how fixtures behave and how they can be structured is key to leveraging `rstest` effectively.
+Understanding how fixtures behave and how they can be structured is key to
+leveraging `rstest` effectively.
 
 ### A. Simple Fixture Examples
 
-The flexibility of `rstest` fixtures allows them to provide a wide array of data types and perform various setup tasks. Fixtures are not limited by the kind of data they can return; any valid Rust type is permissible.1 This enables fixtures to encapsulate diverse setup logic, providing ready-to-use dependencies for tests.
+The flexibility of `rstest` fixtures allows them to provide a wide array of data
+types and perform various setup tasks. Fixtures are not limited by the kind of
+data they can return; any valid Rust type is permissible.1 This enables fixtures
+to encapsulate diverse setup logic, providing ready-to-use dependencies for
+tests.
 
 Here are a few examples illustrating different kinds of fixtures:
 
 - **Fixture returning a primitive data type:**
 
-  Rust
-
-  ```
+  ```rust
   use rstest::*;
-  
+
   #[fixture]
   fn default_username() -> String {
       "test_user".to_string()
   }
-  
+
   #[rstest]
   fn test_username_length(default_username: String) {
       assert!(default_username.len() > 0);
   }
-  
+
   ```
 
 - **Fixture returning a struct:**
 
-  Rust
-
-  ```
+  ```rust
   use rstest::*;
-  
+
   struct User {
       id: u32,
       name: String,
   }
-  
+
   #[fixture]
   fn sample_user() -> User {
       User {
@@ -144,78 +231,97 @@ Here are a few examples illustrating different kinds of fixtures:
           name: "Alice".to_string(),
       }
   }
-  
+
   #[rstest]
   fn test_sample_user_id(sample_user: User) {
       assert_eq!(sample_user.id, 1);
   }
-  
-  ```
-
-- **Fixture performing setup and returning a resource (e.g., a mock repository):**
-
-  Rust
 
   ```
+
+- **Fixture performing setup and returning a resource (e.g., a mock
+  repository):**
+
+  ```rust
   use rstest::*;
   use std::collections::HashMap;
-  
+
   // A simple trait for a repository
   trait Repository {
       fn add_item(&mut self, id: &str, name: &str);
       fn get_item_name(&self, id: &str) -> Option<String>;
   }
-  
+
   // A mock implementation
   #
   struct MockRepository {
       data: HashMap<String, String>,
   }
-  
+
   impl Repository for MockRepository {
       fn add_item(&mut self, id: &str, name: &str) {
           self.data.insert(id.to_string(), name.to_string());
       }
-  
+
       fn get_item_name(&self, id: &str) -> Option<String> {
           self.data.get(id).cloned()
       }
   }
-  
+
   #[fixture]
   fn empty_repository() -> impl Repository {
       MockRepository::default()
   }
-  
+
   #[rstest]
   fn test_add_to_repository(mut empty_repository: impl Repository) {
       empty_repository.add_item("item1", "Test Item");
       assert_eq!(empty_repository.get_item_name("item1"), Some("Test Item".to_string()));
   }
-  
+
   ```
 
-  This example, adapted from concepts in 1 and 1, demonstrates a fixture providing a mutable `Repository` implementation.
+  This example, adapted from concepts in 1 and 1, demonstrates a fixture
+  providing a mutable `Repository` implementation.
 
 ### B. Understanding Fixture Scope and Lifetime (Default Behavior)
 
-By default, `rstest` calls a fixture function anew for each test that uses it. This means if five different tests inject the same fixture, the fixture function will be executed five times, and each test will receive a fresh, independent instance of the fixture's result. This behavior is crucial for test isolation. The `rstest` macro effectively desugars a test like `fn the_test(injected: i32)` into something conceptually similar to `#[test] fn the_test() { let injected = injected_fixture_func(); /*... */ }` within the test body, implying a new call each time.13
+By default, `rstest` calls a fixture function anew for each test that uses it.
+This means if five different tests inject the same fixture, the fixture function
+will be executed five times, and each test will receive a fresh, independent
+instance of the fixture's result. This behavior is crucial for test isolation.
+The `rstest` macro effectively desugars a test like `fn the_test(injected: i32)`
+into something conceptually similar to
+`#[test] fn the_test() { let injected = injected_fixture_func(); /*... */ }`
+within the test body, implying a new call each time.13
 
-Test isolation prevents the state from one test from inadvertently affecting another. If fixtures were shared by default, a mutation to a fixture's state in one test could lead to unpredictable behavior or failures in subsequent tests that use the same fixture. Such dependencies would make tests order-dependent and significantly harder to debug. By providing a fresh instance for each test (unless explicitly specified otherwise using `#[once]`), `rstest` upholds this cornerstone of reliable testing, ensuring each test operates on a known and independent baseline. The `#[once]` attribute, discussed later, provides an explicit mechanism to opt into shared fixture state when isolation is not a concern or when the cost of fixture creation is prohibitive.
+Test isolation prevents the state from one test from inadvertently affecting
+another. If fixtures were shared by default, a mutation to a fixture's state in
+one test could lead to unpredictable behavior or failures in subsequent tests
+that use the same fixture. Such dependencies would make tests order-dependent
+and significantly harder to debug. By providing a fresh instance for each test
+(unless explicitly specified otherwise using `#[once]`), `rstest` upholds this
+cornerstone of reliable testing, ensuring each test operates on a known and
+independent baseline. The `#[once]` attribute, discussed later, provides an
+explicit mechanism to opt into shared fixture state when isolation is not a
+concern or when the cost of fixture creation is prohibitive.
 
 ## IV. Parameterized Tests with `rstest`
 
-`rstest` excels at creating parameterized tests, allowing a single test logic to be executed with multiple sets of input data. This is achieved primarily through the `#[case]` and `#[values]` attributes.
+`rstest` excels at creating parameterized tests, allowing a single test logic to
+be executed with multiple sets of input data. This is achieved primarily through
+the `#[case]` and `#[values]` attributes.
 
 ### A. Table-Driven Tests with `#[case]`: Defining Specific Scenarios
 
-The `#[case(...)]` attribute enables table-driven testing, where each `#[case]` defines a specific scenario with a distinct set of input arguments for the test function. Arguments within the test function that are intended to receive these values must also be annotated with `#[case]`.
+The `#[case(...)]` attribute enables table-driven testing, where each `#[case]`
+defines a specific scenario with a distinct set of input arguments for the test
+function. Arguments within the test function that are intended to receive these
+values must also be annotated with `#[case]`.
 
 A classic example is testing the Fibonacci sequence 1:
 
-Rust
-
-```
+```rust
 use rstest::rstest;
 
 fn fibonacci(n: u32) -> u32 {
@@ -238,17 +344,26 @@ fn test_fibonacci(#[case] input: u32, #[case] expected: u32) {
 }
 ```
 
-For each `#[case(input_val, expected_val)]` line, `rstest` generates a separate, independent test. If one case fails, the others are still executed and reported individually by the test runner. These generated tests are often named by appending `::case_N` to the original test function name (e.g., `test_fibonacci::case_1`, `test_fibonacci::case_2`, etc.), which aids in identifying specific failing cases.8 This individual reporting mechanism provides clearer feedback than a loop within a single test, where the first failure might obscure subsequent ones.
+For each `#[case(input_val, expected_val)]` line, `rstest` generates a separate,
+independent test. If one case fails, the others are still executed and reported
+individually by the test runner. These generated tests are often named by
+appending `::case_N` to the original test function name (e.g.,
+`test_fibonacci::case_1`, `test_fibonacci::case_2`, etc.), which aids in
+identifying specific failing cases.8 This individual reporting mechanism
+provides clearer feedback than a loop within a single test, where the first
+failure might obscure subsequent ones.
 
 ### B. Combinatorial Testing with `#[values]`: Generating Test Matrices
 
-The `#[values(...)]` attribute is used on test function arguments to generate tests for every possible combination of the provided values (the Cartesian product). This is particularly useful for testing interactions between different parameters or ensuring comprehensive coverage across various input states.1
+The `#[values(...)]` attribute is used on test function arguments to generate
+tests for every possible combination of the provided values (the Cartesian
+product). This is particularly useful for testing interactions between different
+parameters or ensuring comprehensive coverage across various input states.1
 
-Consider testing a state machine's transition logic based on current state and an incoming event:
+Consider testing a state machine's transition logic based on current state and
+an incoming event:
 
-Rust
-
-```
+```rust
 use rstest::rstest;
 
 #
@@ -282,19 +397,31 @@ fn test_state_transitions(
 }
 ```
 
-In this scenario, `rstest` will generate 3×3=9 individual test cases, covering all combinations of `initial_state` and `event` specified in the `#[values]` attributes.1
+In this scenario, `rstest` will generate 3×3=9 individual test cases, covering
+all combinations of `initial_state` and `event` specified in the `#[values]`
+attributes.1
 
-It is important to be mindful that the number of generated tests can grow very rapidly with `#[values]`. If a test function has three arguments, each with ten values specified via `#[values]`, 10×10×10=1000 tests will be generated. This combinatorial explosion can significantly impact test execution time and even compile times. Developers must balance the desire for exhaustive combinatorial coverage against these practical constraints, perhaps by selecting representative values or using `#[case]` for more targeted scenarios.
+It is important to be mindful that the number of generated tests can grow very
+rapidly with `#[values]`. If a test function has three arguments, each with ten
+values specified via `#[values]`, 10×10×10=1000 tests will be generated. This
+combinatorial explosion can significantly impact test execution time and even
+compile times. Developers must balance the desire for exhaustive combinatorial
+coverage against these practical constraints, perhaps by selecting
+representative values or using `#[case]` for more targeted scenarios.
 
 ### C. Using Fixtures within Parameterized Tests
 
-Fixtures can be seamlessly combined with parameterized arguments (`#[case]` or `#[values]`) in the same test function. This powerful combination allows for testing different aspects of a component (varied by parameters) within a consistent environment or context (provided by fixtures). The "Complete Example" in the `rstest` documentation hints at this synergy, stating that all features can be used together, mixing fixture variables, fixed cases, and value lists.9
+Fixtures can be seamlessly combined with parameterized arguments (`#[case]` or
+`#[values]`) in the same test function. This powerful combination allows for
+testing different aspects of a component (varied by parameters) within a
+consistent environment or context (provided by fixtures). The "Complete Example"
+in the `rstest` documentation hints at this synergy, stating that all features
+can be used together, mixing fixture variables, fixed cases, and value lists.9
 
-For example, a test might use a fixture to obtain a database connection and then use `#[case]` arguments to test operations with different user IDs:
+For example, a test might use a fixture to obtain a database connection and then
+use `#[case]` arguments to test operations with different user IDs:
 
-Rust
-
-```
+```rust
 use rstest::*;
 
 // Assume UserDb and User types are defined elsewhere
@@ -308,19 +435,27 @@ use rstest::*;
 // }
 ```
 
-In such a setup, the fixture provides the "stable" part of the test setup (the `db_connection`), while `#[case]` provides the "variable" parts (the specific `user_id` and `expected_name`). `rstest` resolves each argument independently: if an argument name matches a fixture, it's injected; if it's marked with `#[case]` or `#[values]`, it's populated from the parameterization attributes. This enables rich and expressive test scenarios.
+In such a setup, the fixture provides the "stable" part of the test setup (the
+`db_connection`), while `#[case]` provides the "variable" parts (the specific
+`user_id` and `expected_name`). `rstest` resolves each argument independently:
+if an argument name matches a fixture, it's injected; if it's marked with
+`#[case]` or `#[values]`, it's populated from the parameterization attributes.
+This enables rich and expressive test scenarios.
 
 ## V. Advanced Fixture Techniques
 
-`rstest` offers several advanced features for defining and using fixtures, providing greater control, reusability, and clarity.
+`rstest` offers several advanced features for defining and using fixtures,
+providing greater control, reusability, and clarity.
 
 ### A. Composing Fixtures: Fixtures Depending on Other Fixtures
 
-Fixtures can depend on other fixtures. This is achieved by simply listing one fixture as an argument to another fixture function. `rstest` will resolve this dependency graph, ensuring that prerequisite fixtures are evaluated first. This allows for the construction of complex setup logic from smaller, modular, and reusable fixture components.4
+Fixtures can depend on other fixtures. This is achieved by simply listing one
+fixture as an argument to another fixture function. `rstest` will resolve this
+dependency graph, ensuring that prerequisite fixtures are evaluated first. This
+allows for the construction of complex setup logic from smaller, modular, and
+reusable fixture components.4
 
-Rust
-
-```
+```rust
 use rstest::*;
 
 #[fixture]
@@ -347,15 +482,21 @@ fn test_composed_fixture_with_override(#[with("special_")] configured_item: Stri
 }
 ```
 
-In this example, `derived_value` depends on `base_value`, and `configured_item` depends on `derived_value`. When `test_composed_fixture` requests `configured_item`, `rstest` first calls `base_value()`, then `derived_value(10)`, and finally `configured_item(20, "item_".to_string())`. This hierarchical dependency resolution mirrors good software design principles, promoting modularity and maintainability in test setups.
+In this example, `derived_value` depends on `base_value`, and `configured_item`
+depends on `derived_value`. When `test_composed_fixture` requests
+`configured_item`, `rstest` first calls `base_value()`, then
+`derived_value(10)`, and finally `configured_item(20, "item_".to_string())`.
+This hierarchical dependency resolution mirrors good software design principles,
+promoting modularity and maintainability in test setups.
 
 ### B. Controlling Fixture Initialization: `#[once]` for Shared State
 
-For fixtures that are expensive to create or represent read-only shared data, `rstest` provides the `#[once]` attribute. A fixture marked `#[once]` is initialized only a single time, and all tests using it will receive a static reference to this shared instance.9
+For fixtures that are expensive to create or represent read-only shared data,
+`rstest` provides the `#[once]` attribute. A fixture marked `#[once]` is
+initialized only a single time, and all tests using it will receive a static
+reference to this shared instance.9
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -382,18 +523,31 @@ fn test_once_2(expensive_setup: &'static AtomicUsize) {
 
 When using `#[once]`, there are critical caveats 12:
 
-1. **Resource Lifetime:** The value returned by an `#[once]` fixture is effectively promoted to a `static` lifetime and is **never dropped**. This means any resources it holds (e.g., file handles, network connections) that require explicit cleanup via `Drop` will not be cleaned up automatically at the end of the test suite. This makes `#[once]` fixtures best suited for truly passive data or resources whose cleanup is managed by the operating system upon process exit.
-2. **Functional Limitations:** `#[once]` fixtures cannot be `async` functions and cannot be generic functions (neither with generic type parameters nor using `impl Trait` in arguments or return types).
+1. **Resource Lifetime:** The value returned by an `#[once]` fixture is
+   effectively promoted to a `static` lifetime and is **never dropped**. This
+   means any resources it holds (e.g., file handles, network connections) that
+   require explicit cleanup via `Drop` will not be cleaned up automatically at
+   the end of the test suite. This makes `#[once]` fixtures best suited for
+   truly passive data or resources whose cleanup is managed by the operating
+   system upon process exit.
+2. **Functional Limitations:** `#[once]` fixtures cannot be `async` functions
+   and cannot be generic functions (neither with generic type parameters nor
+   using `impl Trait` in arguments or return types).
 
-The "never dropped" behavior arises because `rstest` typically creates a `static` variable to hold the result of the `#[once]` fixture. `static` variables in Rust live for the entire duration of the program, and their `Drop` implementations are not usually called at program exit. This is a crucial consideration for resource management.
+The "never dropped" behavior arises because `rstest` typically creates a
+`static` variable to hold the result of the `#[once]` fixture. `static`
+variables in Rust live for the entire duration of the program, and their `Drop`
+implementations are not usually called at program exit. This is a crucial
+consideration for resource management.
 
 ### C. Renaming Fixtures for Clarity: The `#[from]` Attribute
 
-Sometimes a fixture's function name might be long and descriptive, but a shorter or different name is preferred for the argument in a test or another fixture. The `#[from(original_fixture_name)]` attribute on an argument allows renaming.12 This is particularly useful when destructuring the result of a fixture.
+Sometimes a fixture's function name might be long and descriptive, but a shorter
+or different name is preferred for the argument in a test or another fixture.
+The `#[from(original_fixture_name)]` attribute on an argument allows renaming.12
+This is particularly useful when destructuring the result of a fixture.
 
-Rust
-
-```
+```rust
 use rstest::*;
 
 #[fixture]
@@ -412,18 +566,25 @@ fn test_with_destructured_fixture(#[from(complex_user_data_fixture)] (name, _, _
 }
 ```
 
-The `#[from]` attribute decouples the fixture's actual function name from the variable name used within the consuming function. As shown, if a fixture returns a tuple or struct and the test only cares about some parts or wants to use more idiomatic names for destructured elements, `#[from]` is essential to link the argument pattern to the correct source fixture.12
+The `#[from]` attribute decouples the fixture's actual function name from the
+variable name used within the consuming function. As shown, if a fixture returns
+a tuple or struct and the test only cares about some parts or wants to use more
+idiomatic names for destructured elements, `#[from]` is essential to link the
+argument pattern to the correct source fixture.12
 
 ### D. Partial Fixture Injection and Default Arguments: `#[with]` and `#[default]`
 
-`rstest` provides mechanisms for creating highly configurable "template" fixtures using `#[default(...)]` for fixture arguments and `#[with(...)]` to override these defaults on a per-test basis.
+`rstest` provides mechanisms for creating highly configurable "template"
+fixtures using `#[default(...)]` for fixture arguments and `#[with(...)]` to
+override these defaults on a per-test basis.
 
-- `#[default(...)]`: Used within a fixture function's signature to provide default values for its own arguments.4
-- `#[with(...)]`: Used on a test function's fixture argument (or a fixture argument within another fixture) to supply specific values to the parameters of the invoked fixture, overriding any defaults.4
+- `#[default(...)]`: Used within a fixture function's signature to provide
+  default values for its own arguments.4
+- `#[with(...)]`: Used on a test function's fixture argument (or a fixture
+  argument within another fixture) to supply specific values to the parameters
+  of the invoked fixture, overriding any defaults.4
 
-Rust
-
-```
+```rust
 use rstest::*;
 
 struct User { name: String, age: u8, role: String }
@@ -469,17 +630,22 @@ fn test_custom_name_user(# user_fixture: User) {
 }
 ```
 
-This pattern of `#[default]` in fixtures and `#[with]` in tests allows a small number of flexible fixtures to serve a large number of test variations. It promotes a DRY (Don't Repeat Yourself) approach to test setup by centralizing common configurations in the fixture's defaults and allowing targeted customization where needed, thus reducing the proliferation of slightly different fixtures.
+This pattern of `#[default]` in fixtures and `#[with]` in tests allows a small
+number of flexible fixtures to serve a large number of test variations. It
+promotes a DRY (Don't Repeat Yourself) approach to test setup by centralizing
+common configurations in the fixture's defaults and allowing targeted
+customization where needed, thus reducing the proliferation of slightly
+different fixtures.
 
 ### E. "Magic" Argument Conversions (e.g., `FromStr`)
 
-For convenience, if a type implements the `std::str::FromStr` trait, `rstest` can often automatically convert string literals provided in `#[case]` or `#[values]` attributes directly into an instance of that type.1
+For convenience, if a type implements the `std::str::FromStr` trait, `rstest`
+can often automatically convert string literals provided in `#[case]` or
+`#[values]` attributes directly into an instance of that type.1
 
 An example is converting string literals to `std::net::SocketAddr`:
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::net::SocketAddr;
 
@@ -491,19 +657,30 @@ fn check_socket_port(#[case] addr: SocketAddr, #[case] expected_port: u16) {
 }
 ```
 
-In this test, `rstest` sees the argument `addr: SocketAddr` and the string literal `"127.0.0.1:8080"`. It implicitly calls `SocketAddr::from_str("127.0.0.1:8080")` to create the `SocketAddr` instance. This "magic" conversion makes test definitions more concise and readable by allowing the direct use of string representations for types that support it. However, if the `FromStr` conversion fails (e.g., due to a malformed string), the error will typically occur at test runtime, potentially leading to a panic. For types with complex parsing logic or many failure modes, it might be clearer to perform the conversion explicitly within a fixture or at the beginning of the test to handle errors more gracefully or provide more specific diagnostic messages.
+In this test, `rstest` sees the argument `addr: SocketAddr` and the string
+literal `"127.0.0.1:8080"`. It implicitly calls
+`SocketAddr::from_str("127.0.0.1:8080")` to create the `SocketAddr` instance.
+This "magic" conversion makes test definitions more concise and readable by
+allowing the direct use of string representations for types that support it.
+However, if the `FromStr` conversion fails (e.g., due to a malformed string),
+the error will typically occur at test runtime, potentially leading to a panic.
+For types with complex parsing logic or many failure modes, it might be clearer
+to perform the conversion explicitly within a fixture or at the beginning of the
+test to handle errors more gracefully or provide more specific diagnostic
+messages.
 
 ## VI. Asynchronous Testing with `rstest`
 
-`rstest` provides robust support for testing asynchronous Rust code, integrating with common async runtimes and offering syntactic sugar for managing futures.
+`rstest` provides robust support for testing asynchronous Rust code, integrating
+with common async runtimes and offering syntactic sugar for managing futures.
 
 ### A. Defining Asynchronous Fixtures (`async fn`)
 
-Creating an asynchronous fixture is straightforward: simply define the fixture function as an `async fn`.12 `rstest` will recognize it as an async fixture and handle its execution accordingly when used in an async test.
+Creating an asynchronous fixture is straightforward: simply define the fixture
+function as an `async fn`.12 `rstest` will recognize it as an async fixture and
+handle its execution accordingly when used in an async test.
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::time::Duration;
 
@@ -517,15 +694,20 @@ async fn async_data_fetcher() -> String {
 // This fixture will be used in an async test later.
 ```
 
-The example above uses `async_std::task::sleep`, aligning with `rstest`'s default async runtime support, but the fixture logic can be any async code.4
+The example above uses `async_std::task::sleep`, aligning with `rstest`'s
+default async runtime support, but the fixture logic can be any async code.4
 
 ### B. Writing Asynchronous Tests (`async fn` with `#[rstest]`)
 
-Test functions themselves can also be `async fn`. `rstest` will manage the execution of these async tests. By default, `rstest` often uses `#[async_std::test]` to annotate the generated async test functions.9 However, it is designed to be largely runtime-agnostic and can be integrated with other popular async runtimes like Tokio or Actix. This is typically done by adding the runtime's specific test attribute (e.g., `#[tokio::test]` or `#[actix_rt::test]`) alongside `#[rstest]`.4
+Test functions themselves can also be `async fn`. `rstest` will manage the
+execution of these async tests. By default, `rstest` often uses
+`#[async_std::test]` to annotate the generated async test functions.9 However,
+it is designed to be largely runtime-agnostic and can be integrated with other
+popular async runtimes like Tokio or Actix. This is typically done by adding the
+runtime's specific test attribute (e.g., `#[tokio::test]` or
+`#[actix_rt::test]`) alongside `#[rstest]`.4
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::time::Duration;
 
@@ -544,18 +726,31 @@ async fn my_async_test(async_fixture_value: u32) {
 }
 ```
 
-The order of procedural macro attributes can sometimes matter.15 While `rstest` documentation and examples show flexibility (e.g., `#[rstest]` then `#[tokio::test]` 4, or vice-versa), users should ensure their chosen async runtime's test macro is correctly placed to provide the necessary execution context for the async test body and any async fixtures. `rstest` itself does not bundle a runtime; it integrates with existing ones. The "Inject Test Attribute" feature mentioned in `rstest` documentation 10 may offer more explicit control over which test runner attribute is applied.
+The order of procedural macro attributes can sometimes matter.15 While `rstest`
+documentation and examples show flexibility (e.g., `#[rstest]` then
+`#[tokio::test]` 4, or vice-versa), users should ensure their chosen async
+runtime's test macro is correctly placed to provide the necessary execution
+context for the async test body and any async fixtures. `rstest` itself does not
+bundle a runtime; it integrates with existing ones. The "Inject Test Attribute"
+feature mentioned in `rstest` documentation 10 may offer more explicit control
+over which test runner attribute is applied.
 
 ### C. Managing Futures: `#[future]` and `#[awt]` Attributes
 
-To improve the ergonomics of working with async fixtures and values in tests, `rstest` provides the `#[future]` and `#[awt]` attributes.
+To improve the ergonomics of working with async fixtures and values in tests,
+`rstest` provides the `#[future]` and `#[awt]` attributes.
 
-- `#[future]`: When an async fixture or an async block is passed as an argument, its type is `impl Future<Output = T>`. The `#[future]` attribute on such an argument allows developers to refer to it with type `T` directly in the test signature, removing the `impl Future` boilerplate. However, the value still needs to be `.await`ed explicitly within the test body or by using `#[awt]`.4
-- `#[awt]` (or `#[future(awt)]`): This attribute, when applied to the entire test function (`#[awt]`) or a specific `#[future]` argument (`#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for those futures.
+- `#[future]`: When an async fixture or an async block is passed as an argument,
+  its type is `impl Future<Output = T>`. The `#[future]` attribute on such an
+  argument allows developers to refer to it with type `T` directly in the test
+  signature, removing the `impl Future` boilerplate. However, the value still
+  needs to be `.await`ed explicitly within the test body or by using `#[awt]`.4
+- `#[awt]` (or `#[future(awt)]`): This attribute, when applied to the entire
+  test function (`#[awt]`) or a specific `#[future]` argument
+  (`#[future(awt)]`), tells `rstest` to automatically insert `.await` calls for
+  those futures.
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::time::Duration;
 
@@ -596,15 +791,18 @@ async fn test_with_future_awt_arg(
 }
 ```
 
-These attributes significantly reduce boilerplate associated with async code, making the test logic appear more synchronous and easier to read by abstracting away some of the explicit `async`/`.await` mechanics.
+These attributes significantly reduce boilerplate associated with async code,
+making the test logic appear more synchronous and easier to read by abstracting
+away some of the explicit `async`/`.await` mechanics.
 
 ### D. Test Timeouts for Async Tests (`#[timeout]`)
 
-Long-running or stalled asynchronous operations can cause tests to hang indefinitely. `rstest` provides a `#[timeout(...)]` attribute to set a maximum execution time for async tests.10 This feature typically relies on the `async-timeout` feature of `rstest`, which is enabled by default.1
+Long-running or stalled asynchronous operations can cause tests to hang
+indefinitely. `rstest` provides a `#[timeout(...)]` attribute to set a maximum
+execution time for async tests.10 This feature typically relies on the
+`async-timeout` feature of `rstest`, which is enabled by default.1
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::time::Duration;
 
@@ -629,21 +827,28 @@ async fn test_operation_exceeds_timeout() {
 }
 ```
 
-A default timeout for all `rstest` async tests can also be set using the `RSTEST_TIMEOUT` environment variable (value in seconds), evaluated at test compile time.10 This built-in timeout support is a practical feature for ensuring test suite stability.
+A default timeout for all `rstest` async tests can also be set using the
+`RSTEST_TIMEOUT` environment variable (value in seconds), evaluated at test
+compile time.10 This built-in timeout support is a practical feature for
+ensuring test suite stability.
 
 ## VII. Working with External Resources and Test Data
 
-Tests often need to interact with the filesystem, databases, or network services. `rstest` fixtures provide an excellent way to manage these external resources and test data.
+Tests often need to interact with the filesystem, databases, or network
+services. `rstest` fixtures provide an excellent way to manage these external
+resources and test data.
 
 ### A. Fixtures for Temporary Files and Directories
 
-Managing temporary files and directories is a common requirement for tests that involve file I/O. While `rstest` itself doesn't directly provide temporary file utilities, its fixture system integrates seamlessly with crates like `tempfile` or `test-temp-dir`.16 A fixture can create a temporary file or directory, provide its path or handle to the test, and ensure cleanup (often via RAII).
+Managing temporary files and directories is a common requirement for tests that
+involve file I/O. While `rstest` itself doesn't directly provide temporary file
+utilities, its fixture system integrates seamlessly with crates like `tempfile`
+or `test-temp-dir`.16 A fixture can create a temporary file or directory,
+provide its path or handle to the test, and ensure cleanup (often via RAII).
 
 Here's an illustrative example using the `tempfile` crate:
 
-Rust
-
-```
+```rust
 use rstest::*;
 use tempfile::{tempdir, TempDir}; // Add tempfile = "3" to [dev-dependencies]
 use std::fs::File;
@@ -681,17 +886,33 @@ fn test_read_from_temp_file(temp_file_with_content: PathBuf) {
 }
 ```
 
-By encapsulating temporary resource management within fixtures, tests become cleaner and less prone to errors related to resource setup or cleanup. The RAII (Resource Acquisition Is Initialization) pattern, common in Rust and exemplified by `tempfile::TempDir` (which cleans up the directory when dropped), works effectively with `rstest`'s fixture model. When a regular (non-`#[once]`) fixture returns a `TempDir` object, or an object that owns it, the resource is typically cleaned up after the test finishes, as the fixture's return value goes out of scope. This localizes resource management logic to the fixture, keeping the test focused on its assertions. For temporary resources, regular (per-test) fixtures are generally preferred over `#[once]` fixtures to ensure proper cleanup, as `#[once]` fixtures are never dropped.
+By encapsulating temporary resource management within fixtures, tests become
+cleaner and less prone to errors related to resource setup or cleanup. The RAII
+(Resource Acquisition Is Initialization) pattern, common in Rust and exemplified
+by `tempfile::TempDir` (which cleans up the directory when dropped), works
+effectively with `rstest`'s fixture model. When a regular (non-`#[once]`)
+fixture returns a `TempDir` object, or an object that owns it, the resource is
+typically cleaned up after the test finishes, as the fixture's return value goes
+out of scope. This localizes resource management logic to the fixture, keeping
+the test focused on its assertions. For temporary resources, regular (per-test)
+fixtures are generally preferred over `#[once]` fixtures to ensure proper
+cleanup, as `#[once]` fixtures are never dropped.
 
 ### B. Mocking External Services (e.g., Database Connections, HTTP APIs)
 
-For unit and integration tests that depend on external services like databases or HTTP APIs, mocking is a crucial technique. Mocks allow tests to run in isolation, without relying on real external systems, making them faster and more reliable. `rstest` fixtures are an ideal place to encapsulate the setup and configuration of mock objects. Crates like `mockall` can be used to create mocks, or they can be hand-rolled. The fixture would then provide the configured mock instance to the test. General testing advice also strongly recommends mocking external dependencies.17 The `rstest` documentation itself shows examples with fakes or mocks like `empty_repository` and `string_processor`.1
+For unit and integration tests that depend on external services like databases
+or HTTP APIs, mocking is a crucial technique. Mocks allow tests to run in
+isolation, without relying on real external systems, making them faster and more
+reliable. `rstest` fixtures are an ideal place to encapsulate the setup and
+configuration of mock objects. Crates like `mockall` can be used to create
+mocks, or they can be hand-rolled. The fixture would then provide the configured
+mock instance to the test. General testing advice also strongly recommends
+mocking external dependencies.17 The `rstest` documentation itself shows
+examples with fakes or mocks like `empty_repository` and `string_processor`.1
 
 A conceptual example using a hypothetical mocking library:
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::sync::Arc;
 
@@ -757,15 +978,27 @@ fn test_user_service_with_mock_db(mock_db_returns_alice: MockMyDatabase) {
 }
 ```
 
-Placing mock setup logic within fixtures hides its complexity (which can be verbose, involving defining expectations, return values, and call counts) from the actual test function. Tests then simply request the configured mock as an argument. If different tests require the mock to behave differently, multiple specialized mock fixtures can be created, or fixture arguments combined with `#[with(...)]` can be used to dynamically configure the mock's behavior within the fixture itself. This makes tests that depend on external services more readable and maintainable.
+Placing mock setup logic within fixtures hides its complexity (which can be
+verbose, involving defining expectations, return values, and call counts) from
+the actual test function. Tests then simply request the configured mock as an
+argument. If different tests require the mock to behave differently, multiple
+specialized mock fixtures can be created, or fixture arguments combined with
+`#[with(...)]` can be used to dynamically configure the mock's behavior within
+the fixture itself. This makes tests that depend on external services more
+readable and maintainable.
 
 ### C. Using `#[files(...)]` for Test Input from Filesystem Paths
 
-For tests that need to process data from multiple input files, `rstest` provides the `#[files("glob_pattern")]` attribute. This attribute can be used on a test function argument to inject file paths that match a given glob pattern. The argument type is typically `PathBuf`. It can also inject file contents directly as `&str` or `&[u8]` by specifying a mode, e.g., `#[files("glob_pattern", mode = "str")]`.13 Additional attributes like `#[base_dir = "..."]` can specify a base directory for the glob, and `#[exclude("regex")]` can filter out paths matching a regular expression.10
+For tests that need to process data from multiple input files, `rstest` provides
+the `#[files("glob_pattern")]` attribute. This attribute can be used on a test
+function argument to inject file paths that match a given glob pattern. The
+argument type is typically `PathBuf`. It can also inject file contents directly
+as `&str` or `&[u8]` by specifying a mode, e.g.,
+`#[files("glob_pattern", mode = "str")]`.13 Additional attributes like
+`#[base_dir = "..."]` can specify a base directory for the glob, and
+`#[exclude("regex")]` can filter out paths matching a regular expression.10
 
-Rust
-
-```
+```rust
 use rstest::*;
 use std::path::PathBuf;
 use std::fs;
@@ -788,24 +1021,36 @@ fn process_json_content(#[files] content: &str) {
 }
 ```
 
-The `#[files]` attribute effectively parameterizes a test over a set of files discovered at compile time. For each file matching the glob, `rstest` generates a separate test case, injecting the `PathBuf` or content into the designated argument. This is powerful for data-driven testing where inputs reside in separate files. When using `mode = "str"` or `mode = "bytes"`, `rstest` uses `include_str!` or `include_bytes!` respectively. This embeds the file content directly into the compiled binary, which is convenient for small files but can significantly increase binary size if used with large data files.
+The `#[files]` attribute effectively parameterizes a test over a set of files
+discovered at compile time. For each file matching the glob, `rstest` generates
+a separate test case, injecting the `PathBuf` or content into the designated
+argument. This is powerful for data-driven testing where inputs reside in
+separate files. When using `mode = "str"` or `mode = "bytes"`, `rstest` uses
+`include_str!` or `include_bytes!` respectively. This embeds the file content
+directly into the compiled binary, which is convenient for small files but can
+significantly increase binary size if used with large data files.
 
 ## VIII. Reusability and Organization
 
-As test suites grow, maintaining reusability and clear organization becomes paramount. `rstest` and its ecosystem provide tools and encourage practices that support these goals.
+As test suites grow, maintaining reusability and clear organization becomes
+paramount. `rstest` and its ecosystem provide tools and encourage practices that
+support these goals.
 
 ### A. Leveraging `rstest_reuse` for Test Templates
 
-While `rstest`'s `#[case]` attribute is excellent for parameterization, repeating the same set of `#[case]` attributes across multiple test functions can lead to duplication. The `rstest_reuse` crate addresses this by allowing the definition of reusable test templates.9
+While `rstest`'s `#[case]` attribute is excellent for parameterization,
+repeating the same set of `#[case]` attributes across multiple test functions
+can lead to duplication. The `rstest_reuse` crate addresses this by allowing the
+definition of reusable test templates.9
 
 `rstest_reuse` introduces two main attributes:
 
-- `#[template]`: Used to define a named template that encapsulates a set of `#[rstest]` attributes, typically `#[case]` definitions.
-- `#[apply(template_name)]`: Used on a test function to apply a previously defined template, effectively injecting its attributes.
+- `#[template]`: Used to define a named template that encapsulates a set of
+  `#[rstest]` attributes, typically `#[case]` definitions.
+- `#[apply(template_name)]`: Used on a test function to apply a previously
+  defined template, effectively injecting its attributes.
 
-Rust
-
-```
+```rust
 // Add to Cargo.toml: rstest_reuse = "0.7" (or latest)
 // In your test module or lib.rs/main.rs for crate-wide visibility if needed:
 // #[cfg(test)]
@@ -838,111 +1083,237 @@ fn test_multiplication_by_one(#[case] a: i32, #[case] b: i32) {
 }
 ```
 
-`rstest_reuse` works by having `#[template]` define a macro. When `#[apply(template_name)]` is used, this macro is called and expands to the set of attributes (like `#[case]`) onto the target function.18 This meta-programming technique effectively avoids direct code duplication of parameter sets, promoting DRY principles in test case definitions. `rstest_reuse` also supports composing templates with additional `#[case]` or `#[values]` attributes when applying them.18
+`rstest_reuse` works by having `#[template]` define a macro. When
+`#[apply(template_name)]` is used, this macro is called and expands to the set
+of attributes (like `#[case]`) onto the target function.18 This meta-programming
+technique effectively avoids direct code duplication of parameter sets,
+promoting DRY principles in test case definitions. `rstest_reuse` also supports
+composing templates with additional `#[case]` or `#[values]` attributes when
+applying them.18
 
 ### B. Best Practices for Organizing Fixtures and Tests
 
-Good fixture and test organization mirrors good software design principles. As the number of tests and fixtures grows, a well-structured approach is critical for maintainability and scalability.
+Good fixture and test organization mirrors good software design principles. As
+the number of tests and fixtures grows, a well-structured approach is critical
+for maintainability and scalability.
 
 - **Placement:**
-  - For fixtures used within a single module, they can be defined within that module's `tests` submodule (annotated with `#[cfg(test)]`).11
-  - For fixtures intended to be shared across multiple integration test files (in the `tests/` directory), consider creating a common module within the `tests/` directory (e.g., `tests/common/fixtures.rs`) and re-exporting public fixtures.
-  - Alternatively, define shared fixtures in the library crate itself (e.g., in `src/lib.rs` or `src/fixtures.rs` under `#[cfg(test)]`) and `use` them in integration tests.
-- **Naming Conventions:** Use clear, descriptive names for fixtures that indicate what they provide or set up. Test function names should clearly state what behavior they are verifying.
-- **Fixture Responsibility:** Aim for fixtures with a single, well-defined responsibility. Complex setups can be achieved by composing smaller, focused fixtures.12
-- **Scope Management (**`#[once]` **vs. Regular):** Make conscious decisions about fixture lifetimes. Use `#[once]` sparingly, only for genuinely expensive, read-only, and safely static resources, being mindful of its "never dropped" nature.12 Prefer regular (per-test) fixtures for test isolation and proper resource management.
-- **Modularity:** Group related fixtures and tests into modules. This improves navigation and understanding of the test suite.
-- **Readability:** Utilize features like `#[from]` for renaming 12 and `#[default]` / `#[with]` for configurable fixtures to enhance the clarity of both fixture definitions and their usage in tests.
+  - For fixtures used within a single module, they can be defined within that
+    module's `tests` submodule (annotated with `#[cfg(test)]`).11
+  - For fixtures intended to be shared across multiple integration test files
+    (in the `tests/` directory), consider creating a common module within the
+    `tests/` directory (e.g., `tests/common/fixtures.rs`) and re-exporting
+    public fixtures.
+  - Alternatively, define shared fixtures in the library crate itself (e.g., in
+    `src/lib.rs` or `src/fixtures.rs` under `#[cfg(test)]`) and `use` them in
+    integration tests.
+- **Naming Conventions:** Use clear, descriptive names for fixtures that
+  indicate what they provide or set up. Test function names should clearly state
+  what behavior they are verifying.
+- **Fixture Responsibility:** Aim for fixtures with a single, well-defined
+  responsibility. Complex setups can be achieved by composing smaller, focused
+  fixtures.12
+- **Scope Management (**`#[once]` **vs. Regular):** Make conscious decisions
+  about fixture lifetimes. Use `#[once]` sparingly, only for genuinely
+  expensive, read-only, and safely static resources, being mindful of its "never
+  dropped" nature.12 Prefer regular (per-test) fixtures for test isolation and
+  proper resource management.
+- **Modularity:** Group related fixtures and tests into modules. This improves
+  navigation and understanding of the test suite.
+- **Readability:** Utilize features like `#[from]` for renaming 12 and
+  `#[default]` / `#[with]` for configurable fixtures to enhance the clarity of
+  both fixture definitions and their usage in tests.
 
-General testing advice, such as keeping tests small and focused and mocking external dependencies 17, also applies and is well-supported by `rstest`'s design.
+General testing advice, such as keeping tests small and focused and mocking
+external dependencies 17, also applies and is well-supported by `rstest`'s
+design.
 
 ## IX. `rstest` in Context: Comparison and Considerations
 
-Understanding how `rstest` compares to standard Rust testing approaches and its potential trade-offs helps in deciding when and how to best utilize it.
+Understanding how `rstest` compares to standard Rust testing approaches and its
+potential trade-offs helps in deciding when and how to best utilize it.
 
 ### A. `rstest` vs. Standard Rust `#[test]` and Manual Setup
 
-Standard Rust testing using just the `#[test]` attribute is functional but can become verbose for scenarios involving shared setup or parameterization. `rstest` offers significant improvements in these areas:
+Standard Rust testing using just the `#[test]` attribute is functional but can
+become verbose for scenarios involving shared setup or parameterization.
+`rstest` offers significant improvements in these areas:
 
-- **Fixture Management:** With standard `#[test]`, shared setup typically involves calling helper functions manually at the beginning of each test. `rstest` automates this via declarative fixture injection.
-- **Parameterization:** Achieving table-driven tests with standard `#[test]` often requires writing loops inside a single test function (which has poor failure reporting for individual cases) or creating multiple distinct `#[test]` functions with slight variations. `rstest`'s `#[case]` and `#[values]` attributes provide a much cleaner and more powerful solution.
-- **Readability and Boilerplate:** `rstest` generally leads to less boilerplate code and more readable tests because dependencies are explicit in the function signature, and parameterization is handled declaratively.
+- **Fixture Management:** With standard `#[test]`, shared setup typically
+  involves calling helper functions manually at the beginning of each test.
+  `rstest` automates this via declarative fixture injection.
+- **Parameterization:** Achieving table-driven tests with standard `#[test]`
+  often requires writing loops inside a single test function (which has poor
+  failure reporting for individual cases) or creating multiple distinct
+  `#[test]` functions with slight variations. `rstest`'s `#[case]` and
+  `#[values]` attributes provide a much cleaner and more powerful solution.
+- **Readability and Boilerplate:** `rstest` generally leads to less boilerplate
+  code and more readable tests because dependencies are explicit in the function
+  signature, and parameterization is handled declaratively.
 
 The following table summarizes key differences:
 
-**Table 1:** `rstest` **vs. Standard Rust** `#[test]` **for Fixture Management and Parameterization**
+**Table 1:** `rstest` **vs. Standard Rust** `#[test]` **for Fixture Management
+and Parameterization**
 
-<table class="not-prose border-collapse table-auto w-full" style="min-width: 75px">
-<colgroup><col style="min-width: 25px"><col style="min-width: 25px"><col style="min-width: 25px"></colgroup><tbody><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Feature</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Standard #[test] Approach</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>rstest Approach</strong></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Fixture Injection</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Manual calls to setup functions within each test.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Fixture name as argument in <code class="code-inline">#[rstest]</code> function; fixture defined with <code class="code-inline">#[fixture]</code>.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Parameterized Tests (Specific Cases)</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Loop inside one test, or multiple distinct <code class="code-inline">#[test]</code> functions.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[case(...)]</code> attributes on <code class="code-inline">#[rstest]</code> function.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Parameterized Tests (Value Combinations)</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Nested loops inside one test, or complex manual generation.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[values(...)]</code> attributes on arguments of <code class="code-inline">#[rstest]</code> function.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Async Fixture Setup</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Manual <code class="code-inline">async</code> block and <code class="code-inline">.await</code> calls inside test.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">async fn</code> fixtures, with <code class="code-inline">#[future]</code> and <code class="code-inline">#[awt]</code> for ergonomic <code class="code-inline">.await</code>ing.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Reusing Parameter Sets</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Manual duplication of cases or custom helper macros.</p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">rstest_reuse</code> crate with <code class="code-inline">#[template]</code> and <code class="code-inline">#[apply]</code> attributes.</p></td></tr></tbody>
-</table>
+| Feature                                                       | Standard #[test] Approach                                     | rstest Approach                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Fixture Injection                                             | Manual calls to setup functions within each test.             | Fixture name as argument in #[rstest] function; fixture defined with #[fixture]. |
+| Parameterized Tests (Specific Cases)                          | Loop inside one test, or multiple distinct #[test] functions. | #[case(...)] attributes on #[rstest] function.                                   |
+| Parameterized Tests (Value Combinations)                      | Nested loops inside one test, or complex manual generation.   | #[values(...)] attributes on arguments of #[rstest] function.                    |
+| Async Fixture Setup                                           | Manual async block and .await calls inside test.              | async fn fixtures, with #[future] and #[awt] for ergonomic .awaiting.            |
+| Reusing Parameter Sets                                        | Manual duplication of cases or custom helper macros.          | rstest_reuse crate with #[template] and #[apply] attributes.                     |
 
-This comparison highlights how `rstest`'s attribute-based, declarative approach streamlines common testing patterns, reducing manual effort and improving the clarity of test intentions.
+This comparison highlights how `rstest`'s attribute-based, declarative approach
+streamlines common testing patterns, reducing manual effort and improving the
+clarity of test intentions.
 
 ### B. When to Choose `rstest`
 
 `rstest` is particularly beneficial in the following scenarios:
 
-- **Complex Setups:** When tests require non-trivial setup or shared state (e.g., database connections, mock servers, complex data structures).
-- **Parameterized Testing:** When a piece of logic needs to be tested against numerous input combinations or specific edge cases.
-- **Improved Readability:** When aiming for tests where dependencies are immediately obvious from the function signature.
-- **DRY Principles:** When looking to reduce boilerplate and avoid duplication in test setup and parameter definitions.
+- **Complex Setups:** When tests require non-trivial setup or shared state
+  (e.g., database connections, mock servers, complex data structures).
+- **Parameterized Testing:** When a piece of logic needs to be tested against
+  numerous input combinations or specific edge cases.
+- **Improved Readability:** When aiming for tests where dependencies are
+  immediately obvious from the function signature.
+- **DRY Principles:** When looking to reduce boilerplate and avoid duplication
+  in test setup and parameter definitions.
 
-For very simple unit tests that have no shared setup and require no parameterization (e.g., testing a pure function with a single input), the standard `#[test]` attribute might be sufficient. The overhead of learning and integrating `rstest` (including its macro-driven nature) is most justified when the complexity it helps manage is significant.
+For very simple unit tests that have no shared setup and require no
+parameterization (e.g., testing a pure function with a single input), the
+standard `#[test]` attribute might be sufficient. The overhead of learning and
+integrating `rstest` (including its macro-driven nature) is most justified when
+the complexity it helps manage is significant.
 
 ### C. Potential Considerations
 
-While `rstest` offers many advantages, some considerations should be kept in mind:
+While `rstest` offers many advantages, some considerations should be kept in
+mind:
 
-- **Macro Expansion Impact:** Procedural macros, by their nature, involve code generation at compile time. This can sometimes lead to longer compilation times for test suites, especially large ones.7 Debugging macro-related issues can also be less straightforward if the developer is unfamiliar with how the macros expand.8
-- **Debugging Parameterized Tests:** `rstest` generates individual test functions for parameterized cases, often named like `test_function_name::case_N`.8 Understanding this naming convention is helpful for identifying and running specific failing cases with `cargo test test_function_name::case_N`. Some IDEs or debuggers might require specific configurations or might not fully support stepping through the macro-generated code as seamlessly as hand-written code, though support is improving.
-- **Static Nature of Test Cases:** Test cases (e.g., from `#[case]` or `#[files]`) are defined and discovered at compile time.7 This means the structure of the tests is validated by the Rust compiler, which can catch structural errors (like type mismatches in `#[case]` arguments or references to non-existent fixtures) earlier than runtime test discovery mechanisms. This compile-time validation is a strength, offering a degree of static verification for the test suite itself. However, it also means that dynamically generating test cases at runtime based on external factors (not known at compile time) is not directly supported by `rstest`'s core model.
-- `no_std` **Support:** `rstest` generally relies on the standard library (`std`) being available, as test runners and many common testing utilities depend on `std`. Therefore, it is typically not suitable for testing `#![no_std]` libraries in a truly `no_std` test environment where the test harness itself cannot link `std`.20
-- **Learning Curve:** While designed for simplicity in basic use cases, the full range of attributes and advanced features (e.g., fixture composition, partial injection, async management attributes) has a learning curve.
+- **Macro Expansion Impact:** Procedural macros, by their nature, involve code
+  generation at compile time. This can sometimes lead to longer compilation
+  times for test suites, especially large ones.7 Debugging macro-related issues
+  can also be less straightforward if the developer is unfamiliar with how the
+  macros expand.8
+- **Debugging Parameterized Tests:** `rstest` generates individual test
+  functions for parameterized cases, often named like
+  `test_function_name::case_N`.8 Understanding this naming convention is helpful
+  for identifying and running specific failing cases with
+  `cargo test test_function_name::case_N`. Some IDEs or debuggers might require
+  specific configurations or might not fully support stepping through the
+  macro-generated code as seamlessly as hand-written code, though support is
+  improving.
+- **Static Nature of Test Cases:** Test cases (e.g., from `#[case]` or
+  `#[files]`) are defined and discovered at compile time.7 This means the
+  structure of the tests is validated by the Rust compiler, which can catch
+  structural errors (like type mismatches in `#[case]` arguments or references
+  to non-existent fixtures) earlier than runtime test discovery mechanisms. This
+  compile-time validation is a strength, offering a degree of static
+  verification for the test suite itself. However, it also means that
+  dynamically generating test cases at runtime based on external factors (not
+  known at compile time) is not directly supported by `rstest`'s core model.
+- `no_std` **Support:** `rstest` generally relies on the standard library
+  (`std`) being available, as test runners and many common testing utilities
+  depend on `std`. Therefore, it is typically not suitable for testing
+  `#![no_std]` libraries in a truly `no_std` test environment where the test
+  harness itself cannot link `std`.20
+- **Learning Curve:** While designed for simplicity in basic use cases, the full
+  range of attributes and advanced features (e.g., fixture composition, partial
+  injection, async management attributes) has a learning curve.
 
 ## X. Ecosystem and Advanced Integrations
 
-The `rstest` ecosystem includes helper crates that extend its functionality for specific needs like logging and conditional test execution.
+The `rstest` ecosystem includes helper crates that extend its functionality for
+specific needs like logging and conditional test execution.
 
 ### A. `rstest-log`: Logging in `rstest` Tests
 
-For developers who rely on logging frameworks like `log` or `tracing` for debugging tests, the `rstest-log` crate can simplify integration.21 Test runners often capture standard output and error streams, and logging frameworks require proper initialization. `rstest-log` likely provides attributes or wrappers to ensure that logging is correctly set up before each `rstest`-generated test case runs, making it easier to get consistent log output from tests.
+For developers who rely on logging frameworks like `log` or `tracing` for
+debugging tests, the `rstest-log` crate can simplify integration.21 Test runners
+often capture standard output and error streams, and logging frameworks require
+proper initialization. `rstest-log` likely provides attributes or wrappers to
+ensure that logging is correctly set up before each `rstest`-generated test case
+runs, making it easier to get consistent log output from tests.
 
 ### B. `test-with`: Conditional Testing with `rstest`
 
-The `test-with` crate allows for conditional execution of tests based on various runtime conditions, such as the presence of environment variables, the existence of specific files or folders, or the availability of network services.22 It can be used in conjunction with `rstest`. For example, an `rstest` test could be further annotated with `test-with` attributes to ensure it only runs if a particular database configuration file exists or if a dependent web service is reachable. The order of macros is important: `rstest` should typically generate the test cases first, and then `test-with` can apply its conditional execution logic to these generated tests.22 This allows `rstest` to focus on test structure and data provision, while `test-with` provides an orthogonal layer of control over test execution conditions.
+The `test-with` crate allows for conditional execution of tests based on various
+runtime conditions, such as the presence of environment variables, the existence
+of specific files or folders, or the availability of network services.22 It can
+be used in conjunction with `rstest`. For example, an `rstest` test could be
+further annotated with `test-with` attributes to ensure it only runs if a
+particular database configuration file exists or if a dependent web service is
+reachable. The order of macros is important: `rstest` should typically generate
+the test cases first, and then `test-with` can apply its conditional execution
+logic to these generated tests.22 This allows `rstest` to focus on test
+structure and data provision, while `test-with` provides an orthogonal layer of
+control over test execution conditions.
 
 ## XI. Conclusion and Further Resources
 
-`rstest` significantly enhances the testing experience in Rust by providing a powerful and expressive framework for fixture-based and parameterized testing. Its declarative syntax, enabled by procedural macros, reduces boilerplate, improves test readability, and promotes reusability of test setup logic. From simple value injection and table-driven tests to complex fixture compositions, asynchronous testing, and integration with the broader ecosystem, `rstest` equips developers with the tools to build comprehensive and maintainable test suites.
+`rstest` significantly enhances the testing experience in Rust by providing a
+powerful and expressive framework for fixture-based and parameterized testing.
+Its declarative syntax, enabled by procedural macros, reduces boilerplate,
+improves test readability, and promotes reusability of test setup logic. From
+simple value injection and table-driven tests to complex fixture compositions,
+asynchronous testing, and integration with the broader ecosystem, `rstest`
+equips developers with the tools to build comprehensive and maintainable test
+suites.
 
-While considerations such as compile-time impact and the learning curve for advanced features exist, the benefits in terms of cleaner, more robust, and more expressive tests often outweigh these for projects with non-trivial testing requirements.
+While considerations such as compile-time impact and the learning curve for
+advanced features exist, the benefits in terms of cleaner, more robust, and more
+expressive tests often outweigh these for projects with non-trivial testing
+requirements.
 
 ### A. Recap of `rstest`'s Power for Fixture-Based Testing
 
 `rstest` empowers Rust developers by:
 
 - Simplifying dependency management in tests through fixture injection.
-- Enabling concise and readable parameterized tests with `#[case]` and `#[values]`.
-- Supporting advanced fixture patterns like composition, `#[once]` for shared state, renaming, and partial injection.
-- Providing seamless support for asynchronous tests and fixtures, including ergonomic future management.
-- Facilitating interaction with external resources through fixtures that can manage temporary files or mock objects.
+- Enabling concise and readable parameterized tests with `#[case]` and
+  `#[values]`.
+- Supporting advanced fixture patterns like composition, `#[once]` for shared
+  state, renaming, and partial injection.
+- Providing seamless support for asynchronous tests and fixtures, including
+  ergonomic future management.
+- Facilitating interaction with external resources through fixtures that can
+  manage temporary files or mock objects.
 - Allowing test case reuse via the `rstest_reuse` crate.
 
 ### B. Pointers to Official Documentation and Community Resources
 
-For further exploration and the most up-to-date information, the following resources are recommended:
+For further exploration and the most up-to-date information, the following
+resources are recommended:
 
 - **Official** `rstest` **Documentation:** <https://docs.rs/rstest/> 1
 - `rstest` **GitHub Repository:** <https://github.com/la10736/rstest> 3
 - `rstest_reuse` **Crate:** <https://crates.io/crates/rstest_reuse> 18
-- **Rust Community Forums:** Platforms like the Rust Users Forum (users.rust-lang.org) and Reddit (e.g., r/rust) may contain discussions and community experiences with `rstest`.19
+- **Rust Community Forums:** Platforms like the Rust Users Forum
+  (users.rust-lang.org) and Reddit (e.g., r/rust) may contain discussions and
+  community experiences with `rstest`.19
 
-The following table provides a quick reference to some of the key attributes provided by `rstest`:
+The following table provides a quick reference to some of the key attributes
+provided by `rstest`:
 
 **Table 2: Key** `rstest` **Attributes Quick Reference**
 
-<table class="not-prose border-collapse table-auto w-full" style="min-width: 50px">
-<colgroup><col style="min-width: 25px"><col style="min-width: 25px"></colgroup><tbody><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Attribute</strong></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><strong>Core Purpose</strong></p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[rstest]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Marks a function as an <code class="code-inline">rstest</code> test; enables fixture injection and parameterization.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[fixture]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Defines a function that provides a test fixture (setup data or services).</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[case(...)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Defines a single parameterized test case with specific input values.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[values(...)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Defines a list of values for an argument, generating tests for each value or combination.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[once]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Marks a fixture to be initialized only once and shared (as a static reference) across tests.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[future]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Simplifies async argument types by removing <code class="code-inline">impl Future</code> boilerplate.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[awt]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>(Function or argument level) Automatically <code class="code-inline">.await</code>s future arguments in async tests.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[from(original_name)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Allows renaming an injected fixture argument in the test function.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[with(...)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Overrides default arguments of a fixture for a specific test.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[default(...)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Provides default values for arguments within a fixture function.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[timeout(...)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Sets a timeout for an asynchronous test.</p></td></tr><tr><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p><code class="code-inline">#[files("glob_pattern",...)]</code></p></td><td class="border border-neutral-300 dark:border-neutral-600 p-1.5" colspan="1" rowspan="1"><p>Injects file paths (or contents, with <code class="code-inline">mode=</code>) matching a glob pattern as test arguments.</p></td></tr></tbody>
-</table>
+| Attribute                    | Core Purpose                                                                                 |
+| ---------------------------- | -------------------------------------------------------------------------------------------- |
+| #[rstest]                    | Marks a function as an rstest test; enables fixture injection and parameterization.          |
+| #[fixture]                   | Defines a function that provides a test fixture (setup data or services).                    |
+| #[case(...)]                 | Defines a single parameterized test case with specific input values.                         |
+| #[values(...)]               | Defines a list of values for an argument, generating tests for each value or combination.    |
+| #[once]                      | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
+| #[future]                    | Simplifies async argument types by removing impl Future boilerplate.                         |
+| #[awt]                       | (Function or argument level) Automatically .awaits future arguments in async tests.          |
+| #[from(original_name)]       | Allows renaming an injected fixture argument in the test function.                           |
+| #[with(...)]                 | Overrides default arguments of a fixture for a specific test.                                |
+| #[default(...)]              | Provides default values for arguments within a fixture function.                             |
+| #[timeout(...)]              | Sets a timeout for an asynchronous test.                                                     |
+| #[files("glob_pattern",...)] | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
 
-By mastering `rstest`, Rust developers can significantly elevate the quality and efficiency of their testing practices, leading to more reliable and maintainable software.
+By mastering `rstest`, Rust developers can significantly elevate the quality and
+efficiency of their testing practices, leading to more reliable and maintainable
+software.


### PR DESCRIPTION
## Summary
- run `mdformat-all`
- correct fenced code languages in fixture docs
- wrap a long line in `AGENTS.md`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `npx markdownlint-cli2 "**/*.md" '#node_modules'`

------
https://chatgpt.com/codex/tasks/task_e_684f47d490588322af01dbffe21de7e4