### PR TITLE
Fix workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       CARGO_TERM_COLOR: always
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
- restrict `contents` permission for the CI workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint '**/*.md'` *(fails: 23 errors)*
- `nixie docs/*.md`

------
https://chatgpt.com/codex/tasks/task_e_684f50d20eb08322a7c38fd18a30f0f8

## Summary by Sourcery

CI:
- Add read-only `contents` permission to the CI job in ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow permissions to restrict access to read-only for repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->