### PR TITLE
Refine cargo cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       CARGO_TERM_COLOR: always
       CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
+      BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
       - name: Install rust
@@ -26,10 +27,10 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+            target/${{ env.BUILD_PROFILE }}
+          key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
       - name: Format
         run: cargo fmt --all -- --check
       - name: Lint


### PR DESCRIPTION
## Summary
- narrow the cache key in CI to include the build profile

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `nixie docs/rust-binary-router-library-design.md`
- `markdownlint docs/**/*.md`

------
https://chatgpt.com/codex/tasks/task_e_68505d1ffe0c83229d7f6eff75d47f7a

## Summary by Sourcery

Refine GitHub Actions CI to segment the Cargo cache by build profile

CI:
- Include build profile in BUILD_PROFILE env var for CI
- Update cache paths to target/${BUILD_PROFILE}
- Augment cache key and restore-keys to incorporate the build profile