### PR TITLE
Update roadmap for WireframeApp builder

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,7 +16,7 @@ after formatting. Line numbers below refer to that file.
 - [ ] Build the Actix-inspired API around `WireframeApp` and `WireframeServer`
   as described in lines 586-676.
 
-  - [ ] Implement `WireframeApp` builder. Clarify method signatures (`new`,
+  - [x] Implement `WireframeApp` builder. Clarify method signatures (`new`,
     `route`, `service`, `wrap`), expose a consistent `Result<Self>` error
     strategy, and allow registration calls in any order for ergonomic chaining.
 


### PR DESCRIPTION
## Summary
- mark the `WireframeApp` builder task as complete

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/roadmap.md`
- `nixie docs/roadmap.md`


------
https://chatgpt.com/codex/tasks/task_e_6850a2c573e48322a007d7fcbb633cc9

## Summary by Sourcery

Documentation:
- Update docs/roadmap.md to check off the WireframeApp builder item as completed.