### PR TITLE
Implement response framing with serialization

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,7 +62,7 @@ after formatting. Line numbers below refer to that file.
   user-configured callbacks on decode success or failure. See
   [preamble-validator](preamble-validator.md).
 
-- [ ] Add response serialization and transmission. Encode handler responses
+- [x] Add response serialization and transmission. Encode handler responses
   using the selected serialization format and write them back through the
   framing layer.
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -718,7 +718,10 @@ messages and optionally producing responses.
 
   - A specific message type that implements a `wireframe::Responder` trait
     (analogous to Actix Web's `Responder` trait 4). This trait defines how the
-    returned value is serialized and sent back to the client.
+    returned value is serialized and sent back to the client. When a handler
+    yields such a value, `wireframe` encodes it using the application’s
+    configured `SerializationFormat` and passes the resulting bytes to the
+    `FrameProcessor` for transmission back to the peer.
   - `Result<ResponseType, ErrorType>`: For explicit error handling. If
     `Ok(response_message)`, the message is sent. If `Err(error_value)`, the
     error is processed by "wireframe's" error handling mechanism (see Section

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,39 @@
+//! Application configuration types.
+//!
+//! This module defines enums and helpers for selecting
+//! serialization formats used by `wireframe` when encoding
+//! and decoding messages.
+use bincode::error::{DecodeError, EncodeError};
+
+use crate::message::Message;
+
+/// Serialization formats supported by `wireframe`.
+#[derive(Clone, Copy)]
+pub enum SerializationFormat {
+    /// Use `bincode` with its standard configuration.
+    Bincode,
+}
+
+impl SerializationFormat {
+    /// Serialize a message into a byte vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`EncodeError`] if serialization fails.
+    pub fn serialize<M: Message>(self, value: &M) -> Result<Vec<u8>, EncodeError> {
+        match self {
+            SerializationFormat::Bincode => value.to_bytes(),
+        }
+    }
+
+    /// Deserialize a message from a byte slice.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`DecodeError`] if deserialization fails.
+    pub fn deserialize<M: Message>(self, bytes: &[u8]) -> Result<(M, usize), DecodeError> {
+        match self {
+            SerializationFormat::Bincode => M::from_bytes(bytes),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! servers, including routing, middleware, and connection utilities.
 
 pub mod app;
+pub mod config;
 pub mod extractor;
 pub mod frame;
 pub mod message;

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -1,0 +1,29 @@
+use bytes::BytesMut;
+use wireframe::{
+    app::WireframeApp,
+    config::SerializationFormat,
+    frame::{FrameProcessor, LengthPrefixedProcessor},
+    message::Message,
+};
+
+#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
+struct TestResp(u32);
+
+#[tokio::test]
+async fn send_response_encodes_and_frames() {
+    let mut app = WireframeApp::new()
+        .unwrap()
+        .frame_processor(LengthPrefixedProcessor)
+        .unwrap()
+        .serialization_format(SerializationFormat::Bincode)
+        .unwrap();
+
+    let mut out = Vec::new();
+    app.send_response(&mut out, &TestResp(7)).await.unwrap();
+
+    let mut processor = LengthPrefixedProcessor;
+    let mut buf = BytesMut::from(&out[..]);
+    let frame = processor.decode(&mut buf).await.unwrap().unwrap();
+    let (decoded, _) = TestResp::from_bytes(&frame).unwrap();
+    assert_eq!(decoded, TestResp(7));
+}


### PR DESCRIPTION
## Summary
- add `SerializationFormat` config module
- implement `LengthPrefixedProcessor` and response sending helpers
- update roadmap and design docs for response serialization
- provide tests for encoding handler responses
- document config module

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md README.md`
- `nixie docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_6850a3439ea8832287c8431cdfbb87f9