### PR TITLE
Make frame processors stateless

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ async fn handle_echo(req: Message<EchoRequest>) -> WireframeResult<EchoResponse>
 
 WireframeServer::new(|| {
     WireframeApp::new()
-        .serialization_format(SerializationFormat::Bincode)
+        .serializer(BincodeSerializer)
         .route(MyMessageType::Echo, handle_echo)
 })
 .bind("127.0.0.1:8000")?
@@ -77,6 +77,14 @@ WireframeServer::new(|| {
 
 This example showcases how derive macros and the framing abstraction simplify a
 binary protocol server【F:docs/rust-binary-router-library-design.md†L1120-L1150】.
+
+## Response Serialization and Framing
+
+Handlers can return types implementing the `Responder` trait. These values are
+encoded using the application's configured serializer and written
+back through the `FrameProcessor`【F:docs/rust-binary-router-library-design.md†L718-L724】.
+The included `LengthPrefixedProcessor` illustrates a simple framing strategy
+based on a big‑endian length prefix【F:docs/rust-binary-router-library-design.md†L1076-L1117】.
 
 ## Current Limitations
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,7 +62,7 @@ after formatting. Line numbers below refer to that file.
   user-configured callbacks on decode success or failure. See
   [preamble-validator](preamble-validator.md).
 
-- [ ] Add response serialization and transmission. Encode handler responses
+- [x] Add response serialization and transmission. Encode handler responses
   using the selected serialization format and write them back through the
   framing layer.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,21 +1,34 @@
 //! Application builder configuring routes and middleware.
 //!
 //! `WireframeApp` stores registered routes, services, and middleware
-//! for a [`WireframeServer`]. Methods return [`Result<Self>`] so callers
-//! can chain registrations ergonomically.
+//! for a [`WireframeServer`]. Most builder methods return [`Result<Self>`]
+//! so callers can chain registrations ergonomically.
 
 use std::{boxed::Box, collections::HashMap, future::Future, pin::Pin};
+
+use bytes::BytesMut;
+use tokio::io::{self, AsyncWrite, AsyncWriteExt};
+
+use crate::{
+    frame::{FrameProcessor, LengthPrefixedProcessor},
+    message::Message,
+    serializer::{BincodeSerializer, Serializer},
+};
+
+type BoxedFrameProcessor =
+    Box<dyn FrameProcessor<Frame = Vec<u8>, Error = io::Error> + Send + Sync>;
 
 /// Configures routing and middleware for a `WireframeServer`.
 ///
 /// The builder stores registered routes, services, and middleware
 /// without enforcing an ordering. Methods return [`Result<Self>`] so
 /// registrations can be chained ergonomically.
-#[derive(Default)]
-pub struct WireframeApp {
+pub struct WireframeApp<S: Serializer = BincodeSerializer> {
     routes: HashMap<u32, Service>,
     services: Vec<Service>,
     middleware: Vec<Box<dyn Middleware>>,
+    frame_processor: BoxedFrameProcessor,
+    serializer: S,
 }
 
 /// Alias for boxed asynchronous handlers.
@@ -34,10 +47,56 @@ pub enum WireframeError {
     DuplicateRoute(u32),
 }
 
+/// Errors produced when sending a handler response over a stream.
+#[derive(Debug)]
+pub enum SendError {
+    /// Serialization failed.
+    Serialize(Box<dyn std::error::Error + Send + Sync>),
+    /// Writing to the stream failed.
+    Io(io::Error),
+}
+
+impl std::fmt::Display for SendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SendError::Serialize(e) => write!(f, "serialization error: {e}"),
+            SendError::Io(e) => write!(f, "I/O error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SendError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            SendError::Serialize(e) => Some(&**e),
+            SendError::Io(e) => Some(e),
+        }
+    }
+}
+
+impl From<io::Error> for SendError {
+    fn from(e: io::Error) -> Self { SendError::Io(e) }
+}
+
 /// Result type used throughout the builder API.
 pub type Result<T> = std::result::Result<T, WireframeError>;
 
-impl WireframeApp {
+impl<S> Default for WireframeApp<S>
+where
+    S: Serializer + Default,
+{
+    fn default() -> Self {
+        Self {
+            routes: HashMap::new(),
+            services: Vec::new(),
+            middleware: Vec::new(),
+            frame_processor: Box::new(LengthPrefixedProcessor),
+            serializer: S::default(),
+        }
+    }
+}
+
+impl WireframeApp<BincodeSerializer> {
     /// Construct a new empty application builder.
     ///
     /// # Errors
@@ -45,7 +104,19 @@ impl WireframeApp {
     /// This function currently never returns an error but uses the
     /// [`Result`] type for forward compatibility.
     pub fn new() -> Result<Self> { Ok(Self::default()) }
+}
 
+impl<S> WireframeApp<S>
+where
+    S: Serializer,
+{
+    /// Construct a new empty application builder.
+    ///
+    /// # Errors
+    ///
+    /// This function currently never returns an error but uses the
+    /// [`Result`] type for forward compatibility.
+    ///
     /// Register a route that maps `id` to `handler`.
     ///
     /// # Errors
@@ -84,14 +155,65 @@ impl WireframeApp {
         Ok(self)
     }
 
+    /// Set the frame processor used for encoding and decoding frames.
+    #[must_use]
+    pub fn frame_processor<P>(mut self, processor: P) -> Self
+    where
+        P: FrameProcessor<Frame = Vec<u8>, Error = io::Error> + Send + Sync + 'static,
+    {
+        self.frame_processor = Box::new(processor);
+        self
+    }
+
+    /// Replace the serializer used for messages.
+    #[must_use]
+    pub fn serializer<Ser>(self, serializer: Ser) -> WireframeApp<Ser>
+    where
+        Ser: Serializer,
+    {
+        WireframeApp {
+            routes: self.routes,
+            services: self.services,
+            middleware: self.middleware,
+            frame_processor: self.frame_processor,
+            serializer,
+        }
+    }
+
+    /// Serialize `msg` and write it to `stream` using the frame processor.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`SendError`] if serialization or writing fails.
+    pub async fn send_response<W, M>(
+        &self,
+        stream: &mut W,
+        msg: &M,
+    ) -> std::result::Result<(), SendError>
+    where
+        W: AsyncWrite + Unpin,
+        M: Message,
+    {
+        let bytes = self
+            .serializer
+            .serialize(msg)
+            .map_err(SendError::Serialize)?;
+        let mut framed = BytesMut::with_capacity(4 + bytes.len());
+        self.frame_processor
+            .encode(&bytes, &mut framed)
+            .map_err(SendError::Io)?;
+        stream.write_all(&framed).await.map_err(SendError::Io)?;
+        stream.flush().await.map_err(SendError::Io)
+    }
+
     /// Handle an accepted connection.
     ///
     /// This placeholder immediately closes the connection after the
     /// preamble phase. A warning is logged so tests and callers are
     /// aware of the current limitation.
-    pub async fn handle_connection<S>(&self, _stream: S)
+    pub async fn handle_connection<W>(&self, _stream: W)
     where
-        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
+        W: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
     {
         log::warn!(
             "`WireframeApp::handle_connection` called, but connection handling is not \

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -4,8 +4,9 @@
 //! Implementations may use any framing strategy suitable for the
 //! underlying transport.
 
-use async_trait::async_trait;
-use bytes::BytesMut;
+use std::io;
+
+use bytes::{Buf, BytesMut};
 
 /// Trait defining how raw bytes are decoded into frames and how frames are
 /// encoded back into bytes for transmission.
@@ -13,7 +14,8 @@ use bytes::BytesMut;
 /// The `Frame` associated type represents a logical unit extracted from or
 /// written to the wire. Errors are represented by the `Error` associated type,
 /// which must implement [`std::error::Error`].
-#[async_trait]
+/// Frame processors operate synchronously on in-memory buffers and need
+/// no mutable state. The trait therefore uses `&self` receivers.
 pub trait FrameProcessor: Send + Sync {
     /// Logical frame type extracted from the stream.
     type Frame;
@@ -22,8 +24,49 @@ pub trait FrameProcessor: Send + Sync {
     type Error: std::error::Error + Send + Sync + 'static;
 
     /// Attempt to decode the next frame from `src`.
-    async fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Frame>, Self::Error>;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes in `src` cannot be parsed into a complete frame.
+    fn decode(&self, src: &mut BytesMut) -> Result<Option<Self::Frame>, Self::Error>;
 
     /// Encode `frame` and append the bytes to `dst`.
-    async fn encode(&mut self, frame: &Self::Frame, dst: &mut BytesMut) -> Result<(), Self::Error>;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the frame cannot be written to `dst`.
+    fn encode(&self, frame: &Self::Frame, dst: &mut BytesMut) -> Result<(), Self::Error>;
+}
+
+/// Simple length-prefixed framing using big-endian u32 lengths.
+pub struct LengthPrefixedProcessor;
+
+impl FrameProcessor for LengthPrefixedProcessor {
+    type Frame = Vec<u8>;
+    type Error = std::io::Error;
+
+    fn decode(&self, src: &mut BytesMut) -> Result<Option<Self::Frame>, Self::Error> {
+        if src.len() < 4 {
+            return Ok(None);
+        }
+        let mut len_bytes = [0u8; 4];
+        len_bytes.copy_from_slice(&src[..4]);
+        let len = u32::from_be_bytes(len_bytes);
+        let len_usize = usize::try_from(len).map_err(|_| io::Error::other("frame too large"))?;
+        if src.len() < 4 + len_usize {
+            return Ok(None);
+        }
+        src.advance(4);
+        Ok(Some(src.split_to(len_usize).to_vec()))
+    }
+
+    fn encode(&self, frame: &Self::Frame, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        use bytes::BufMut;
+        dst.reserve(4 + frame.len());
+        let len = u32::try_from(frame.len())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "frame too large"))?;
+        dst.put_u32(len);
+        dst.extend_from_slice(frame);
+        Ok(())
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! servers, including routing, middleware, and connection utilities.
 
 pub mod app;
+pub mod serializer;
+pub use serializer::{BincodeSerializer, Serializer};
 pub mod extractor;
 pub mod frame;
 pub mod message;

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -1,0 +1,48 @@
+//! Message serialization traits.
+//!
+//! This module defines the [`Serializer`] trait enabling applications to plug in
+//! custom encoding formats. A basic [`BincodeSerializer`] implementation is
+//! provided as the default.
+
+use std::error::Error;
+
+use crate::message::Message;
+
+/// Trait for serializing and deserializing messages.
+pub trait Serializer {
+    /// Serialize `value` into a byte vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the value cannot be serialized.
+    fn serialize<M: Message>(&self, value: &M) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>>;
+
+    /// Deserialize a message from `bytes`, returning the message and bytes consumed.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the bytes cannot be parsed into a message.
+    fn deserialize<M: Message>(
+        &self,
+        bytes: &[u8],
+    ) -> Result<(M, usize), Box<dyn Error + Send + Sync>>;
+}
+
+/// Serializer using `bincode` with its standard configuration.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BincodeSerializer;
+
+impl Serializer for BincodeSerializer {
+    fn serialize<M: Message>(&self, value: &M) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
+        value
+            .to_bytes()
+            .map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+
+    fn deserialize<M: Message>(
+        &self,
+        bytes: &[u8],
+    ) -> Result<(M, usize), Box<dyn Error + Send + Sync>> {
+        M::from_bytes(bytes).map_err(|e| Box::new(e) as Box<dyn Error + Send + Sync>)
+    }
+}

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -1,0 +1,119 @@
+//! Tests covering response serialization and framing logic.
+//!
+//! These verify normal encoding as well as error conditions like
+//! write failures and encode errors.
+
+use bytes::BytesMut;
+use wireframe::{
+    app::WireframeApp,
+    frame::{FrameProcessor, LengthPrefixedProcessor},
+    message::Message,
+    serializer::BincodeSerializer,
+};
+
+#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
+struct TestResp(u32);
+
+#[derive(Debug)]
+struct FailingResp;
+
+impl bincode::Encode for FailingResp {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        _: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        Err(bincode::error::EncodeError::Other("fail"))
+    }
+}
+
+impl<'de> bincode::BorrowDecode<'de, ()> for FailingResp {
+    fn borrow_decode<D: bincode::de::BorrowDecoder<'de, Context = ()>>(
+        _: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        Ok(FailingResp)
+    }
+}
+
+#[tokio::test]
+async fn send_response_encodes_and_frames() {
+    let app = WireframeApp::new()
+        .unwrap()
+        .frame_processor(LengthPrefixedProcessor)
+        .serializer(BincodeSerializer);
+
+    let mut out = Vec::new();
+    app.send_response(&mut out, &TestResp(7)).await.unwrap();
+
+    let processor = LengthPrefixedProcessor;
+    let mut buf = BytesMut::from(&out[..]);
+    let frame = processor.decode(&mut buf).unwrap().unwrap();
+    let (decoded, _) = TestResp::from_bytes(&frame).unwrap();
+    assert_eq!(decoded, TestResp(7));
+}
+
+#[tokio::test]
+async fn length_prefixed_decode_requires_complete_header() {
+    let processor = LengthPrefixedProcessor;
+    let mut buf = BytesMut::from(&[0x00, 0x00, 0x00][..]); // only 3 bytes
+    assert!(processor.decode(&mut buf).unwrap().is_none());
+    assert_eq!(buf.len(), 3); // nothing consumed
+}
+
+#[tokio::test]
+async fn length_prefixed_decode_requires_full_frame() {
+    let processor = LengthPrefixedProcessor;
+    let mut buf = BytesMut::from(&[0x00, 0x00, 0x00, 0x05, 0x01, 0x02][..]);
+    assert!(processor.decode(&mut buf).unwrap().is_none());
+    // buffer should retain bytes since frame isn't complete
+    assert_eq!(buf.len(), 6);
+}
+
+struct FailingWriter;
+
+impl tokio::io::AsyncWrite for FailingWriter {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        _: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        std::task::Poll::Ready(Err(std::io::Error::other("fail")))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn send_response_propagates_write_error() {
+    let app = WireframeApp::new()
+        .unwrap()
+        .frame_processor(LengthPrefixedProcessor);
+
+    let mut writer = FailingWriter;
+    let err = app
+        .send_response(&mut writer, &TestResp(3))
+        .await
+        .expect_err("expected error");
+    assert!(matches!(err, wireframe::app::SendError::Io(_)));
+}
+
+#[tokio::test]
+async fn send_response_returns_encode_error() {
+    let app = WireframeApp::new().unwrap();
+    let err = app
+        .send_response(&mut Vec::new(), &FailingResp)
+        .await
+        .expect_err("expected error");
+    assert!(matches!(err, wireframe::app::SendError::Serialize(_)));
+}


### PR DESCRIPTION
## Summary
- define a `SendError` preserving encode and write failures
- change `FrameProcessor` trait to use synchronous, immutable methods
- update `WireframeApp::send_response` to use `&self` and return `SendError`
- extend response tests for encode and IO errors
- switch to trait-based serialization using `Serializer` and `BincodeSerializer`
- remove unnecessary `default()` calls in examples and tests
- document response serialization tests module

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`
- `markdownlint docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md README.md`
- `nixie docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_6850a3439ea8832287c8431cdfbb87f9