### PR TITLE
Document connection lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ reduce this boilerplate through layered abstractions:
 
 - **Transport adapter** built on Tokio I/O
 - **Framing layer** for length‑prefixed or custom frames
-- **Connection preamble** with customizable validation callbacks [[docs](docs/preamble-validator.md)]
+- **Connection preamble** with customizable validation callbacks \[[docs](docs/preamble-validator.md)\]
 - Call `with_preamble::<T>()` before registering success or failure callbacks
 - **Serialization engine** using `bincode` or a `wire-rs` wrapper
 - **Routing engine** that dispatches messages by ID
 - **Handler invocation** with extractor support
 - **Middleware chain** for request/response processing
+- **Connection lifecycle hooks** for per-connection setup and teardown
 
 These layers correspond to the architecture outlined in the design
 document【F:docs/rust-binary-router-library-design.md†L292-L344】.
@@ -83,8 +84,26 @@ binary protocol server【F:docs/rust-binary-router-library-design.md†L1120-L11
 Handlers can return types implementing the `Responder` trait. These values are
 encoded using the application's configured serializer and written
 back through the `FrameProcessor`【F:docs/rust-binary-router-library-design.md†L718-L724】.
+
 The included `LengthPrefixedProcessor` illustrates a simple framing strategy
 based on a big‑endian length prefix【F:docs/rust-binary-router-library-design.md†L1076-L1117】.
+
+## Connection Lifecycle
+
+`WireframeApp` can run callbacks when a connection opens or closes. The state
+produced by `on_connection_setup` is passed to `on_connection_teardown` when the
+connection ends.
+
+```rust
+let app = WireframeApp::new()
+    .unwrap()
+    .on_connection_setup(|| async { 42u32 })
+    .unwrap()
+    .on_connection_teardown(|state| async move {
+        println!("closing with {state}");
+    })
+    .unwrap();
+```
 
 ## Current Limitations
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ reduce this boilerplate through layered abstractions:
 - **Routing engine** that dispatches messages by ID
 - **Handler invocation** with extractor support
 - **Middleware chain** for request/response processing
-- **Connection lifecycle hooks** for per-connection setup and teardown
+- **[Connection lifecycle hooks](#connection-lifecycle)** for per-connection
+  setup and teardown
 
 These layers correspond to the architecture outlined in the design
 document【F:docs/rust-binary-router-library-design.md†L292-L344】.
@@ -90,19 +91,16 @@ based on a big‑endian length prefix【F:docs/rust-binary-router-library-design
 
 ## Connection Lifecycle
 
-`WireframeApp` can run callbacks when a connection opens or closes. The state
+`WireframeApp` can run callbacks when a connection is opened or closed. The state
 produced by `on_connection_setup` is passed to `on_connection_teardown` when the
 connection ends.
 
 ```rust
 let app = WireframeApp::new()
-    .unwrap()
     .on_connection_setup(|| async { 42u32 })
-    .unwrap()
     .on_connection_teardown(|state| async move {
         println!("closing with {state}");
-    })
-    .unwrap();
+    });
 ```
 
 ## Current Limitations


### PR DESCRIPTION
## Summary
- mention connection lifecycle hooks in README feature list
- describe `on_connection_setup` and `on_connection_teardown`
- give example storing state in setup and using it in teardown

## Testing
- `mdformat-all`
- `markdownlint README.md docs/*.md`
- `nixie docs/preamble-validator.md`
- `nixie docs/roadmap.md`
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6852c0e142a483228b255734a28b4a76

## Summary by Sourcery

Document the new connection lifecycle hooks by updating the feature list and adding explanatory documentation with a setup/teardown example

Documentation:
- Mention connection lifecycle hooks in the README feature list
- Add a new “Connection Lifecycle” section describing on_connection_setup and on_connection_teardown with an example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README with details on new connection lifecycle hooks for asynchronous setup and teardown in the `WireframeApp` API.
  - Added an example demonstrating how to use connection lifecycle callbacks to manage per-connection state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->