### PR TITLE
Simplify preamble callback handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run cargo fmt, cargo clippy -- -D warnings, and RUSTFLAGS="-D warnings" cargo
-  test before committing.
+- Run `cargo fmt --all`, and `cargo clippy -- -D warnings` after making any change to the codebase.
+- Run `RUSTFLAGS="-D warnings" cargo test` before committing, in addition to the above.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.

--- a/src/app.rs
+++ b/src/app.rs
@@ -171,8 +171,8 @@ where
     /// # Type Parameters
     ///
     /// This method changes the connection state type parameter from `C` to `C2`.
-    /// This means that any subsequent builder methods will operate on the new connection state type `C2`.
-    /// Be aware of this type transition when chaining builder methods.
+    /// This means that any subsequent builder methods will operate on the new connection state type
+    /// `C2`. Be aware of this type transition when chaining builder methods.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary
- introduce `PreambleCallback` and `PreambleErrorCallback` aliases
- use the aliases in `WireframeServer`, `worker_task` and `process_stream`
- drop clippy `type_complexity` allowances

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6852c0eae4588322b30d99dff88eb7bc

## Summary by Sourcery

Simplify preamble callback types by introducing aliases and remove unnecessary lint allowances

Enhancements:
- Introduce PreambleCallback and PreambleErrorCallback type aliases
- Replace inline Arc<dyn Fn> callback signatures in WireframeServer, worker_task, and process_stream with the new aliases
- Remove clippy::type_complexity allowances now rendered obsolete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code clarity and maintainability by simplifying internal callback type definitions. No changes to user-facing features or behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->