### PR TITLE
Refactor connection callback types

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -27,15 +27,14 @@ type BoxedFrameProcessor =
 ///
 /// use wireframe::app::ConnectionSetup;
 ///
-/// let setup: ConnectionSetup<String> = Arc::new(|| {
+/// let setup: Arc<ConnectionSetup<String>> = Arc::new(|| {
 ///     Box::pin(async {
 ///         // Perform authentication and return connection state
 ///         String::from("hello")
 ///     })
 /// });
 /// ```
-pub type ConnectionSetup<C> =
-    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = C> + Send>> + Send + Sync>;
+pub type ConnectionSetup<C> = dyn Fn() -> Pin<Box<dyn Future<Output = C> + Send>> + Send + Sync;
 
 /// Callback invoked when a connection is closed.
 ///
@@ -46,14 +45,14 @@ pub type ConnectionSetup<C> =
 ///
 /// use wireframe::app::ConnectionTeardown;
 ///
-/// let teardown: ConnectionTeardown<String> = Arc::new(|state| {
+/// let teardown: Arc<ConnectionTeardown<String>> = Arc::new(|state| {
 ///     Box::pin(async move {
 ///         println!("Dropping {state}");
 ///     })
 /// });
 /// ```
 pub type ConnectionTeardown<C> =
-    Arc<dyn Fn(C) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync>;
+    dyn Fn(C) -> Pin<Box<dyn Future<Output = ()> + Send>> + Send + Sync;
 
 /// Configures routing and middleware for a `WireframeServer`.
 ///
@@ -66,8 +65,8 @@ pub struct WireframeApp<S: Serializer = BincodeSerializer, C: Send + 'static = (
     middleware: Vec<Box<dyn Middleware>>,
     frame_processor: BoxedFrameProcessor,
     serializer: S,
-    on_connect: Option<ConnectionSetup<C>>,
-    on_disconnect: Option<ConnectionTeardown<C>>,
+    on_connect: Option<Arc<ConnectionSetup<C>>>,
+    on_disconnect: Option<Arc<ConnectionTeardown<C>>>,
 }
 
 /// Alias for boxed asynchronous handlers.


### PR DESCRIPTION
## Summary
- alias setup and teardown callbacks for clarity
- add doc examples for connection callbacks

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6852c0c75bf88322a81a89c65853f3d3

## Summary by Sourcery

Introduce ConnectionSetup and ConnectionTeardown type aliases for connection callbacks with documentation examples, and update WireframeApp to use them

Enhancements:
- Add ConnectionSetup and ConnectionTeardown aliases for connection setup and teardown callbacks
- Refactor WireframeApp to use the new callback type aliases for on_connect and on_disconnect

Documentation:
- Include doc examples illustrating how to use ConnectionSetup and ConnectionTeardown callbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved documentation and added usage examples for connection setup and teardown callbacks.
  - Enhanced readability of method comments.

- **Refactor**
  - Simplified and clarified the definition of connection setup and teardown callbacks for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->