### PR TITLE
Add shared state container

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ reduce this boilerplate through layered abstractions:
 
 - **Transport adapter** built on Tokio I/O
 - **Framing layer** for length‑prefixed or custom frames
-- **Connection preamble** with customizable validation callbacks [[docs](docs/preamble-validator.md)]
+- **Connection preamble** with customizable validation callbacks \[[docs](docs/preamble-validator.md)\]
 - Call `with_preamble::<T>()` before registering success or failure callbacks
 - **Serialization engine** using `bincode` or a `wire-rs` wrapper
 - **Routing engine** that dispatches messages by ID
@@ -33,7 +33,7 @@ connections and runs the Tokio event loop:
 WireframeServer::new(|| {
     WireframeApp::new()
         .frame_processor(MyFrameProcessor::new())
-        .app_data(state.clone().into())
+        .app_data(state.clone())
         .route(MessageType::Login, handle_login)
         .wrap(MyLoggingMiddleware::default())
 })
@@ -46,7 +46,8 @@ By default, the number of worker tasks equals the number of CPU cores. If the
 CPU count cannot be determined, the server falls back to a single worker.
 
 The builder supports methods like `frame_processor`, `route`, `app_data`, and
-`wrap` for middleware configuration【F:docs/rust-binary-router-library-design.md†L616-L704】.
+`wrap` for middleware configuration. `app_data` stores any `Send + Sync` value
+for later retrieval using the `SharedState<T>` extractor【F:docs/rust-binary-router-library-design.md†L616-L704】.
 
 Handlers are asynchronous functions whose parameters implement extractor traits
 and may return responses implementing the `Responder` trait. This pattern

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ CPU count cannot be determined, the server falls back to a single worker.
 
 The builder supports methods like `frame_processor`, `route`, `app_data`, and
 `wrap` for middleware configuration. `app_data` stores any `Send + Sync` value
-for later retrieval using the `SharedState<T>` extractor【F:docs/rust-binary-router-library-design.md†L616-L704】.
+keyed by type; registering another value of the same type overwrites the
+previous one. Handlers retrieve these values using the `SharedState<T>`
+extractor【F:docs/rust-binary-router-library-design.md†L616-L704】.
 
 Handlers are asynchronous functions whose parameters implement extractor traits
 and may return responses implementing the `Responder` trait. This pattern

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -809,7 +809,7 @@ instance of each type can exist; later registrations overwrite earlier ones.
 
   ````rustrust
   async fn handle_user_update(update: Message<UserUpdateData>) -> Result<()> {
-      // update.into_inner() gives UserUpdateData
+      // update.into_inner() returns a `UserUpdateData` instance
       //...
   }
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -626,7 +626,7 @@ WireframeApp::new()
 
 .frame_processor(MyFrameProcessor::new()) // Configure the framing logic
 
-.app_data(app_state.clone().into()) // Shared application state
+.app_data(app_state.clone()) // Shared application state
 
 //.service(login_handler) // If using attribute macros and auto-discovery
 
@@ -788,9 +788,9 @@ within handlers.
 
   ```rust
 
-  The `MessageRequest` would encapsulate information about the current incoming
-  message context (like connection details, already parsed headers if any), and
-  `Payload` would represent the raw or partially processed frame data.
+  The `MessageRequest` encapsulates connection metadata and any values
+  registered with `WireframeApp::app_data`. `Payload` represents the raw or
+  partially processed frame data.
 
   ````
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -662,9 +662,9 @@ inferring the message type it handles if attribute macros are used.
 \* .route(message_id, handler_function): Explicitly maps a message identifier to
 a handler.
 
-\* .app_data(SharedState\<T>) or .data(T): Provides shared application state,
-keyed by type. Registering another value of the same type replaces the previous
-one, mirroring Actix Web's `web::Data`.21
+\* .app_data(T): Provides shared application state, keyed by type. Registering
+another value of the same type replaces the previous one, mirroring Actix Web's
+`web::Data`.21
 
 \* .wrap(middleware_factory): Adds middleware to the processing pipeline.26
 
@@ -1286,7 +1286,7 @@ WireframeApp::new()
 
 .serializer(BincodeSerializer)
 
-.app_data(SharedChatRoomState::new(chat_state.clone()))
+.app_data(chat_state.clone())
 
 .route(ChatMessageType::ClientJoin, handle_join)
 

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -81,11 +81,8 @@ pub trait FromMessageRequest: Sized {
 }
 
 /// Shared application state accessible to handlers.
+#[derive(Clone)]
 pub struct SharedState<T: Send + Sync>(Arc<T>);
-
-impl<T: Send + Sync> Clone for SharedState<T> {
-    fn clone(&self) -> Self { Self(self.0.clone()) }
-}
 
 impl<T: Send + Sync> SharedState<T> {
     /// Construct a new [`SharedState`].
@@ -128,7 +125,11 @@ impl<T: Send + Sync> From<T> for SharedState<T> {
 }
 
 /// Errors that can occur when extracting built-in types.
+///
+/// This enum is marked `#[non_exhaustive]` so more variants may be added in
+/// the future without breaking changes.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ExtractError {
     /// No shared state of the requested type was found.
     MissingState(&'static str),

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -36,8 +36,9 @@ impl MessageRequest {
         T: Send + Sync + 'static,
     {
         self.app_data
-            .get(&TypeId::of::<SharedState<T>>())
-            .and_then(|data| data.downcast_ref::<SharedState<T>>().cloned())
+            .get(&TypeId::of::<T>())
+            .and_then(|data| data.clone().downcast::<T>().ok())
+            .map(SharedState)
     }
 }
 

--- a/tests/app_data.rs
+++ b/tests/app_data.rs
@@ -10,11 +10,10 @@ use wireframe::extractor::{
 
 #[test]
 fn shared_state_extractor_returns_data() {
-    let state: SharedState<u32> = 5u32.into();
     let mut map = HashMap::new();
     map.insert(
-        TypeId::of::<SharedState<u32>>(),
-        Arc::new(state.clone()) as Arc<dyn std::any::Any + Send + Sync>,
+        TypeId::of::<u32>(),
+        Arc::new(5u32) as Arc<dyn std::any::Any + Send + Sync>,
     );
     let req = MessageRequest {
         peer_addr: None,

--- a/tests/app_data.rs
+++ b/tests/app_data.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{any::TypeId, collections::HashMap, sync::Arc};
 
 use wireframe::extractor::{
     ExtractError,
@@ -11,9 +11,14 @@ use wireframe::extractor::{
 #[test]
 fn shared_state_extractor_returns_data() {
     let state: SharedState<u32> = 5u32.into();
+    let mut map = HashMap::new();
+    map.insert(
+        TypeId::of::<SharedState<u32>>(),
+        Arc::new(state.clone()) as Arc<dyn std::any::Any + Send + Sync>,
+    );
     let req = MessageRequest {
         peer_addr: None,
-        app_data: vec![Arc::new(state.clone()) as Arc<dyn std::any::Any + Send + Sync>],
+        app_data: map,
     };
     let mut payload = Payload::default();
     let extracted = SharedState::<u32>::from_message_request(&req, &mut payload).unwrap();

--- a/tests/app_data.rs
+++ b/tests/app_data.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use wireframe::extractor::{
+    ExtractError,
+    FromMessageRequest,
+    MessageRequest,
+    Payload,
+    SharedState,
+};
+
+#[test]
+fn shared_state_extractor_returns_data() {
+    let state: SharedState<u32> = 5u32.into();
+    let req = MessageRequest {
+        peer_addr: None,
+        app_data: vec![Arc::new(state.clone()) as Arc<dyn std::any::Any + Send + Sync>],
+    };
+    let mut payload = Payload::default();
+    let extracted = SharedState::<u32>::from_message_request(&req, &mut payload).unwrap();
+    assert_eq!(*extracted, 5);
+}
+
+#[test]
+fn missing_shared_state_returns_error() {
+    let req = MessageRequest::default();
+    let mut payload = Payload::default();
+    let err = SharedState::<u32>::from_message_request(&req, &mut payload)
+        .err()
+        .unwrap();
+    assert!(matches!(err, ExtractError::MissingState(_)));
+}


### PR DESCRIPTION
## Summary
- store app data in `WireframeApp`
- expose shared state via `MessageRequest`
- implement `ExtractError` and `SharedState` extractor
- add tests for shared state extraction
- document `app_data` usage

## Testing
- `cargo clippy -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6852d87f03e883229723421729a86bd5

## Summary by Sourcery

Enable registering and extracting shared application state in WireframeApp via a new app_data API and SharedState extractor

New Features:
- Introduce app_data builder method on WireframeApp to register shared state keyed by type
- Add SharedState extractor and ExtractError to retrieve registered application data from MessageRequest

Documentation:
- Document the app_data usage and SharedState extractor in design docs and README

Tests:
- Add tests for successful and missing shared state extraction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for registering and retrieving shared application state, enabling extractors to access shared data during request handling.

- **Bug Fixes**
  - Fixed Markdown rendering issues in documentation bullet points.

- **Documentation**
  - Improved and clarified documentation for shared state usage, builder methods, and extractor system.

- **Tests**
  - Added unit tests to verify shared state extraction and error handling when state is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->