### PR TITLE
Add Makefile and reference it in guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,9 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run cargo fmt, cargo clippy -- -D warnings, and RUSTFLAGS="-D warnings" cargo
-  test before committing.
+- Run `make fmt`, `make lint`, and `make test` before committing. These targets
+  wrap `cargo fmt`, `cargo clippy`, and `cargo test` with the appropriate
+  flags.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+.PHONY: lint test fmt
+
+# Run Clippy lints across all targets and features, failing on warnings
+lint:
+	cargo clippy --all-targets --all-features -- -D warnings
+
+# Execute tests with warnings treated as errors
+# --quiet ensures less verbose output on success
+# Use RUSTFLAGS to deny warnings at compile time
+# so new warnings cause failures
+
+test:
+	RUSTFLAGS="-D warnings" cargo test --quiet
+
+# Format the entire workspace
+fmt:
+	cargo fmt --all

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -67,7 +67,7 @@ async fn teardown_without_setup_does_not_run() {
 
     let app = WireframeApp::new()
         .unwrap()
-        .on_connection_teardown(move |_| {
+        .on_connection_teardown(move |()| {
             let teardown_clone = teardown_clone.clone();
             async move {
                 teardown_clone.fetch_add(1, Ordering::SeqCst);


### PR DESCRIPTION
## Summary
- add Makefile with lint, fmt and test helpers
- update AGENTS to use make commands for checks
- fix clippy lint in teardown test

## Testing
- `make lint`
- `make test`
- `make fmt`
- `mdformat-all`
- `markdownlint AGENTS.md docs/*.md README.md`


------
https://chatgpt.com/codex/tasks/task_e_6853028266308322ba89ae9763829177

## Summary by Sourcery

Add a Makefile with lint, test, and fmt targets, update contribution guidelines to reference these make commands, and fix a Clippy lint in the teardown test.

Bug Fixes:
- Fix Clippy lint in teardown test by correcting closure signature

Build:
- Add Makefile with lint, test, and fmt targets wrapping cargo commands

Documentation:
- Update AGENTS.md to reference make fmt, lint, and test targets instead of direct cargo commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated contributor instructions to use Makefile targets for formatting, linting, and testing instead of direct Cargo commands.
  - Introduced a Makefile with convenient commands for formatting, linting, and testing the Rust project.

- **Tests**
  - Adjusted a test callback signature to improve consistency with teardown expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->