### PR TITLE
Update roadmap for middleware tasks

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,25 +77,42 @@ after formatting. Line numbers below refer to that file.
   - [ ] Define `FromMessageRequest` for extractor types (lines 760-782). See
     [`FromMessageRequest`][from-message-request] in
     [`src/extractor.rs`](../src/extractor.rs).
+
   - [ ] Provide built-in extractors `Message<T>`, `ConnectionInfo`, and
     `SharedState<T>` (lines 792-840). `SharedState<T>` is defined in
     [`src/extractor.rs`](../src/extractor.rs#L54-L87).
+
   - [ ] Support custom extractors implementing `FromMessageRequest` (lines
     842-858). Refer again to [`src/extractor.rs`](../src/extractor.rs#L39-L52).
+
   - [ ] Implement middleware using `Transform`/`Service` traits.
-    - [ ] Flesh out `ServiceRequest` and `ServiceResponse` wrappers (lines
+
+    - [ ] Implement `ServiceRequest` and `ServiceResponse` wrappers (lines
       866-899) and introduce a `Next` helper to build the asynchronous call
       chain. Trait definitions live in
       [`src/middleware.rs`](../src/middleware.rs#L71-L84).
     - [ ] Provide a `from_fn` helper for functional middleware.
     - [ ] Add tests verifying middleware can modify requests and observe
       responses.
+
   - [ ] Register middleware with `WireframeApp::wrap` and build the chain around
-    handlers so the last registered middleware runs first on requests and first
+    handlers, so the last registered middleware runs first on requests and first
     on responses (lines 900-919). See the
     [`wrap` method](../src/app.rs#L73-L84).
+
   - [ ] Document common middleware use cases like logging and authentication
-    (lines 920-935). Include a logging example using `from_fn`.
+    (lines 920-935). Include a logging example using `from_fn`:
+
+    ```rust
+    use wireframe::middleware::from_fn;
+
+    let logging = from_fn(|req, next| async move {
+        tracing::info!("request_frame = {:?}", req.frame());
+        let mut res = next.call(req).await?;
+        tracing::info!("response_frame = {:?}", res.frame());
+        Ok(res)
+    });
+    ```
 
 ## 3. Initial Examples and Documentation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,13 +82,20 @@ after formatting. Line numbers below refer to that file.
     [`src/extractor.rs`](../src/extractor.rs#L54-L87).
   - [ ] Support custom extractors implementing `FromMessageRequest` (lines
     842-858). Refer again to [`src/extractor.rs`](../src/extractor.rs#L39-L52).
-  - [ ] Implement middleware using `Transform`/`Service` traits and a simple
-    `from_fn` style variant (lines 866-899). Trait definitions live in
-    [`src/middleware.rs`](../src/middleware.rs#L71-L84).
-  - [ ] Register middleware with `WireframeApp::wrap` and execute it in order
-    (lines 900-919). See the [`wrap` method](../src/app.rs#L73-L84).
+  - [ ] Implement middleware using `Transform`/`Service` traits.
+    - [ ] Flesh out `ServiceRequest` and `ServiceResponse` wrappers (lines
+      866-899) and introduce a `Next` helper to build the asynchronous call
+      chain. Trait definitions live in
+      [`src/middleware.rs`](../src/middleware.rs#L71-L84).
+    - [ ] Provide a `from_fn` helper for functional middleware.
+    - [ ] Add tests verifying middleware can modify requests and observe
+      responses.
+  - [ ] Register middleware with `WireframeApp::wrap` and build the chain around
+    handlers so the last registered middleware runs first on requests and first
+    on responses (lines 900-919). See the
+    [`wrap` method](../src/app.rs#L73-L84).
   - [ ] Document common middleware use cases like logging and authentication
-    (lines 920-935).
+    (lines 920-935). Include a logging example using `from_fn`.
 
 ## 3. Initial Examples and Documentation
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -881,8 +881,44 @@ by implementing a pair of traits, analogous to Actix Web's `Transform` and
   returned service) and `#[inline]` for potential performance gains.
 - The `Service` trait would define the actual request/response processing
   logic. Middleware would operate on "wireframe's" internal request and
+
   response types, which could be raw frames at one level or deserialized
   messages at another, depending on the middleware's purpose.
+
+The relationships among these components are illustrated in the following
+diagram:
+
+```mermaid
+classDiagram
+    class ServiceRequest {
+    }
+    class ServiceResponse {
+    }
+    class Next {
+        +call(request: ServiceRequest): ServiceResponse
+    }
+    class Middleware {
+        <<interface>>
+        +call(request: ServiceRequest, next: Next): ServiceResponse
+    }
+    class Transform {
+        <<trait>>
+        +new_service(): Service
+    }
+    class Service {
+        <<trait>>
+        +call(request: ServiceRequest): ServiceResponse
+    }
+    class FromFn {
+        +from_fn(fn): Middleware
+    }
+    ServiceRequest <.. Next
+    ServiceResponse <.. Next
+    Middleware <|.. FromFn
+    Transform <|.. Middleware
+    Middleware <|.. Service
+    Next --> Middleware
+```
 
 A simplified functional middleware approach, similar to
 `actix_web::middleware::from_fn` 26, could also be provided for simpler use


### PR DESCRIPTION
## Summary
- flesh out middleware tasks in the project roadmap

## Testing
- `mdformat-all docs/roadmap.md`
- `markdownlint docs/roadmap.md`
- `nixie docs/roadmap.md`
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6853ec69352483229239a0438a93587d

## Summary by Sourcery

Update the project roadmap to add detailed middleware implementation, testing, and documentation tasks

Documentation:
- Flesh out middleware roadmap with ServiceRequest/ServiceResponse wrappers, Next helper, and from_fn helper
- Add tests for middleware to verify request modification and response observation
- Clarify middleware registration order and wrap chain execution behavior
- Include a logging example in the middleware use cases documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified the roadmap with more detailed subtasks for middleware and extractors.
  - Added clearer descriptions of middleware implementation steps and registration order.
  - Included an explicit example for logging middleware in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->