### PR TITLE
Implement extractor types and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ app state or expose peer information.
 Custom extractors let you centralize parsing and validation logic that would
 otherwise be duplicated across handlers. A session token parser, for example,
 can verify the token before any route-specific code executes
-【F:docs/rust-binary-router-library-design.md†L842-L858】.
+[Design Guide: Data Extraction and Type Safety](docs/rust-binary-router-library-design.md#53-data-extraction-and-type-safety).
 
 ```rust
 use wireframe::extractor::{ConnectionInfo, FromMessageRequest, MessageRequest, Payload};
@@ -150,7 +150,7 @@ async fn handle_ping(token: SessionToken, info: ConnectionInfo) {
 ## Current Limitations
 
 Connection handling now processes frames and routes messages, but the
-server is still experimental. Release builds fail to compile so the
+server is still experimental. Release builds fail to compile, so the
 library cannot be used accidentally in production.
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -99,19 +99,59 @@ produced by `on_connection_setup` is passed to `on_connection_teardown` when the
 connection ends.
 
 ```rust
-let app = WireframeApp::new()
-    .on_connection_setup(|| async { 42u32 })
-    .on_connection_teardown(|state| async move {
-        println!("closing with {state}");
-    });
+    let app = WireframeApp::new()
+        .on_connection_setup(|| async { 42u32 })
+        .on_connection_teardown(|state| async move {
+            println!("closing with {state}");
+        });
+```
+
+## Custom Extractors
+
+Extractors are types that implement `FromMessageRequest`. When a handler lists
+an extractor as a parameter, `wireframe` automatically constructs it using the
+incoming \[`MessageRequest`\] and remaining \[`Payload`\]. Built‑in extractors like
+`Message<T>`, `SharedState<T>` and `ConnectionInfo` decode the payload, access
+app state or expose peer information.
+
+Custom extractors let you centralize parsing and validation logic that would
+otherwise be duplicated across handlers. A session token parser, for example,
+can verify the token before any route-specific code executes
+【F:docs/rust-binary-router-library-design.md†L842-L858】.
+
+```rust
+use wireframe::extractor::{ConnectionInfo, FromMessageRequest, MessageRequest, Payload};
+
+pub struct SessionToken(String);
+
+impl FromMessageRequest for SessionToken {
+    type Error = std::convert::Infallible;
+
+    fn from_message_request(
+        _req: &MessageRequest,
+        payload: &mut Payload<'_>,
+    ) -> Result<Self, Self::Error> {
+        let len = payload.data[0] as usize;
+        let token = std::str::from_utf8(&payload.data[1..=len]).unwrap().to_string();
+        payload.advance(1 + len);
+        Ok(Self(token))
+    }
+}
+```
+
+Custom extractors integrate seamlessly with other parameters:
+
+```rust
+async fn handle_ping(token: SessionToken, info: ConnectionInfo) {
+    println!("{} from {:?}", token.0, info.peer_addr());
+}
 ```
 
 ## Current Limitations
 
-Connection processing is not implemented yet. After the optional
-preamble is read, the server logs a warning and immediately closes the
-stream. Release builds fail to compile to prevent accidental production
-use.
+Connection handling now processes frames and routes messages, but the
+server is still experimental. Release builds fail to compile so the
+library cannot be used accidentally in production.
 
 ## Roadmap
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -855,16 +855,50 @@ its context. For example, a custom extractor could parse a session token from
 a specific field in all messages, validate it, and provide a `UserSession`
 object to the handler.
 
+
 This extractor system, backed by Rust's strong type system, ensures that
 handlers receive correctly typed and validated data, significantly reducing the
 likelihood of runtime errors and boilerplate parsing code within the handler
 logic itself. Custom extractors are particularly valuable as they allow common,
-protocol-specific data extraction and validation logic (e.g., extracting and
-verifying a session token from a custom frame header) to be encapsulated into
-reusable components. This further reduces code duplication across multiple
+protocol-specific data extraction and validation logic (for example extracting
+and verifying a session token from a custom frame header) to be encapsulated
+into reusable components. This further reduces code duplication across multiple
 handlers and keeps the handler functions lean and focused on their specific
 business tasks, mirroring the benefits seen with Actix Web's `FromRequest`
 trait.24
+
+```mermaid
+classDiagram
+    class FromMessageRequest {
+        <<trait>>
+        +from_message_request(req: &MessageRequest, payload: &mut Payload) Result<Self, Self::Error>
+        +Error
+    }
+    class Message~T~ {
+        +Message(T)
+        +into_inner() T
+        +deref() &T
+    }
+    class ConnectionInfo {
+        +peer_addr: Option<SocketAddr>
+        +peer_addr() Option<SocketAddr>
+    }
+    class SharedState~T~ {
+        +deref() &T
+    }
+    class ExtractError {
+        +MissingState(&'static str)
+        +Deserialize(DecodeError)
+    }
+    FromMessageRequest <|.. Message
+    FromMessageRequest <|.. ConnectionInfo
+    FromMessageRequest <|.. SharedState
+    SharedState --> ExtractError
+    ExtractError o-- DecodeError
+    Message o-- T
+    SharedState o-- T
+    ConnectionInfo o-- SocketAddr
+```
 
 ### 5.4. Middleware and Extensibility
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -888,7 +888,7 @@ classDiagram
     }
     class ExtractError {
         +MissingState(&'static str)
-        +Deserialize(DecodeError)
+        +InvalidPayload(DecodeError)
     }
     FromMessageRequest <|.. Message
     FromMessageRequest <|.. ConnectionInfo

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -25,10 +25,7 @@ impl<'a, S> Next<'a, S>
 where
     S: Service + ?Sized,
 {
-    /// Create a new [`Next`] wrapping the given service.
-    #[inline]
-    #[must_use]
-    /// Creates a new `Next` instance wrapping a reference to the given service.
+    /// Creates a new [`Next`] instance wrapping a reference to the given service.
     ///
     /// # Examples
     ///
@@ -46,6 +43,8 @@ where
     /// let service = MyService;
     /// let next = Next::new(&service);
     /// ```
+    #[inline]
+    #[must_use]
     pub fn new(service: &'a S) -> Self { Self { service } }
 
     /// Call the next service with the provided request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -183,9 +183,6 @@ where
         self
     }
 
-    /// Get the configured worker count.
-    #[inline]
-    #[must_use]
     /// Returns the configured number of worker tasks for the server.
     ///
     /// # Examples
@@ -197,6 +194,8 @@ where
     /// let server = WireframeServer::new(factory);
     /// assert!(server.worker_count() >= 1);
     /// ```
+    #[inline]
+    #[must_use]
     pub const fn worker_count(&self) -> usize { self.workers }
 
     /// Get the socket address the server is bound to, if available.

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -9,6 +9,11 @@ use wireframe::{
 struct TestMsg(u8);
 
 #[test]
+/// Tests that a message can be extracted from a payload and that the payload cursor advances fully.
+///
+/// Verifies that a `TestMsg` instance serialised into bytes can be correctly extracted from a
+/// `Payload` using `Message::<TestMsg>::from_message_request`, and asserts that the payload has no
+/// remaining unread data after extraction.
 fn message_extractor_parses_and_advances() {
     let msg = TestMsg(42);
     let bytes = msg.to_bytes().unwrap();
@@ -23,6 +28,8 @@ fn message_extractor_parses_and_advances() {
 }
 
 #[test]
+/// Tests that `ConnectionInfo` correctly reports the peer socket address extracted from a
+/// `MessageRequest`.
 fn connection_info_reports_peer() {
     let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
     let req = MessageRequest {
@@ -35,6 +42,11 @@ fn connection_info_reports_peer() {
 }
 
 #[test]
+/// Tests that shared state of type `u8` can be successfully extracted from a `MessageRequest`'s
+/// `app_data`.
+///
+/// Inserts an `Arc<u8>` into the request's shared state, extracts it using the `SharedState`
+/// extractor, and asserts that the extracted value matches the original.
 fn shared_state_extractor() {
     let mut data = HashMap::default();
     data.insert(
@@ -53,6 +65,11 @@ fn shared_state_extractor() {
 }
 
 #[test]
+/// Tests that extracting a missing shared state from a `MessageRequest`
+/// returns an `ExtractError::MissingState` containing the type name.
+///
+/// Ensures that when no shared state of the requested type is present,
+/// the correct error is produced and includes the expected type information.
 fn shared_state_missing_error() {
     let req = MessageRequest::default();
     let mut payload = Payload::default();

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -33,3 +33,38 @@ fn connection_info_reports_peer() {
     let info = ConnectionInfo::from_message_request(&req, &mut payload).unwrap();
     assert_eq!(info.peer_addr(), Some(addr));
 }
+
+#[test]
+fn shared_state_extractor() {
+    let mut data = HashMap::default();
+    data.insert(
+        std::any::TypeId::of::<u8>(),
+        std::sync::Arc::new(42u8) as std::sync::Arc<dyn std::any::Any + Send + Sync>,
+    );
+    let req = MessageRequest {
+        peer_addr: None,
+        app_data: data,
+    };
+    let mut payload = Payload::default();
+
+    let state =
+        wireframe::extractor::SharedState::<u8>::from_message_request(&req, &mut payload).unwrap();
+    assert_eq!(*state, 42);
+}
+
+#[test]
+fn shared_state_missing_error() {
+    let req = MessageRequest::default();
+    let mut payload = Payload::default();
+    let Err(err) =
+        wireframe::extractor::SharedState::<u8>::from_message_request(&req, &mut payload)
+    else {
+        panic!("expected error");
+    };
+    match err {
+        wireframe::extractor::ExtractError::MissingState(name) => {
+            assert!(name.contains("u8"));
+        }
+        _ => panic!("unexpected error"),
+    }
+}

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -1,0 +1,35 @@
+use std::{collections::HashMap, net::SocketAddr};
+
+use wireframe::{
+    extractor::{ConnectionInfo, FromMessageRequest, Message, MessageRequest, Payload},
+    message::Message as MessageTrait,
+};
+
+#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
+struct TestMsg(u8);
+
+#[test]
+fn message_extractor_parses_and_advances() {
+    let msg = TestMsg(42);
+    let bytes = msg.to_bytes().unwrap();
+    let mut payload = Payload {
+        data: bytes.as_slice(),
+    };
+    let req = MessageRequest::default();
+
+    let extracted = Message::<TestMsg>::from_message_request(&req, &mut payload).unwrap();
+    assert_eq!(*extracted, msg);
+    assert_eq!(payload.remaining(), 0);
+}
+
+#[test]
+fn connection_info_reports_peer() {
+    let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
+    let req = MessageRequest {
+        peer_addr: Some(addr),
+        app_data: HashMap::default(),
+    };
+    let mut payload = Payload::default();
+    let info = ConnectionInfo::from_message_request(&req, &mut payload).unwrap();
+    assert_eq!(info.peer_addr(), Some(addr));
+}


### PR DESCRIPTION
## Summary
- implement `Message<T>` and `ConnectionInfo` extractors
- extend `SharedState<T>` error handling
- document custom extractor usage
- add tests for extractor functionality
- clarify current limitations in README

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6853d8dc92588322bce4f3c5a60cf379

## Summary by Sourcery

Implement typed extractors for deserializing message payloads and exposing connection metadata, extend shared state error handling, update documentation on custom extractors and library limitations, and add tests for extractor functionality.

New Features:
- Add Message<T> extractor for payload deserialization
- Introduce ConnectionInfo extractor for peer address metadata

Enhancements:
- Extend ExtractError with a Deserialize variant and implement its source
- Enhance SharedState extractor error handling for missing and decode failures

Documentation:
- Document custom extractor usage and update README with examples
- Add extractor class diagram and expand design guide
- Clarify experimental limitations in README

Tests:
- Add tests for Message, ConnectionInfo, and SharedState extractors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new extractors for message payload deserialization and connection metadata access, including `Message<T>` and `ConnectionInfo`.
- **Bug Fixes**
  - Improved error reporting for payload deserialization failures.
- **Documentation**
  - Expanded documentation with detailed explanations and diagrams for custom extractors and their usage.
  - Enhanced README with a new section on custom extractors and updated information on current limitations.
- **Tests**
  - Added unit tests to validate extractor behaviour and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->