### PR TITLE
Move function attributes below doc comments

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -95,7 +95,7 @@ pub trait FromMessageRequest: Sized {
 pub struct SharedState<T: Send + Sync>(Arc<T>);
 
 impl<T: Send + Sync> SharedState<T> {
-    /// Construct a new [`SharedState`].
+    /// Creates a new [`SharedState`] instance wrapping the provided `Arc<T>`.
     ///
     /// # Examples
     ///
@@ -109,19 +109,6 @@ impl<T: Send + Sync> SharedState<T> {
     /// assert_eq!(*state, 5);
     /// ```
     #[must_use]
-    /// Creates a new `SharedState` instance wrapping the provided `Arc<T>`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use std::sync::Arc;
-    ///
-    /// use wireframe::extractor::SharedState;
-    ///
-    /// let state = Arc::new(42);
-    /// let shared: SharedState<u32> = state.clone().into();
-    /// assert_eq!(*shared, 42);
-    /// ```
     #[deprecated(since = "0.2.0", note = "construct via `inner.into()` instead")]
     pub fn new(inner: Arc<T>) -> Self { Self(inner) }
 }
@@ -204,9 +191,7 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
     /// let state = Arc::new(42);
     /// let shared: SharedState<u32> = state.clone().into();
     /// assert_eq!(*shared, 42);
-    /// Returns a reference to the inner value.
-///
-/// This enables transparent access to the wrapped type via dereferencing.
+    /// ```
     fn deref(&self) -> &Self::Target { &self.0 }
 }
 
@@ -215,19 +200,18 @@ impl<T: Send + Sync> std::ops::Deref for SharedState<T> {
 pub struct Message<T>(T);
 
 impl<T> Message<T> {
-    /// Consume the extractor, returning the inner message.
-    #[must_use]
     /// Consumes the extractor and returns the inner deserialised message value.
-pub fn into_inner(self) -> T { self.0 }
+    #[must_use]
+    pub fn into_inner(self) -> T { self.0 }
 }
 
 impl<T> std::ops::Deref for Message<T> {
     type Target = T;
 
     /// Returns a reference to the inner value.
-///
-/// This enables transparent access to the wrapped type via dereferencing.
-fn deref(&self) -> &Self::Target { &self.0 }
+    ///
+    /// This enables transparent access to the wrapped type via dereferencing.
+    fn deref(&self) -> &Self::Target { &self.0 }
 }
 
 impl<T> FromMessageRequest for Message<T>
@@ -238,7 +222,7 @@ where
 
     /// Attempts to extract and deserialize a message of type `T` from the payload.
     ///
-    /// Advances the payload by the number of bytes consumed during deserialization.  
+    /// Advances the payload by the number of bytes consumed during deserialization.
     /// Returns an error if the payload cannot be decoded into the target type.
     ///
     /// # Returns
@@ -261,10 +245,9 @@ pub struct ConnectionInfo {
 }
 
 impl ConnectionInfo {
-    /// Returns the peer's socket address, if known.
-    #[must_use]
     /// Returns the peer's socket address for the current connection, if available.
-pub fn peer_addr(&self) -> Option<SocketAddr> { self.peer_addr }
+    #[must_use]
+    pub fn peer_addr(&self) -> Option<SocketAddr> { self.peer_addr }
 }
 
 impl FromMessageRequest for ConnectionInfo {
@@ -272,7 +255,8 @@ impl FromMessageRequest for ConnectionInfo {
 
     /// Extracts connection metadata from the message request.
     ///
-    /// Returns a `ConnectionInfo` containing the peer's socket address, if available. This extraction is infallible.
+    /// Returns a `ConnectionInfo` containing the peer's socket address, if available. This
+    /// extraction is infallible.
     fn from_message_request(
         req: &MessageRequest,
         _payload: &mut Payload<'_>,

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -25,10 +25,7 @@ impl<'a, S> Next<'a, S>
 where
     S: Service + ?Sized,
 {
-    /// Create a new [`Next`] wrapping the given service.
-    #[inline]
-    #[must_use]
-    /// Creates a new `Next` instance wrapping a reference to the given service.
+    /// Creates a new [`Next`] instance wrapping a reference to the given service.
     ///
     /// # Examples
     ///
@@ -46,6 +43,8 @@ where
     /// let service = MyService;
     /// let next = Next::new(&service);
     /// ```
+    #[inline]
+    #[must_use]
     pub fn new(service: &'a S) -> Self { Self { service } }
 
     /// Call the next service with the provided request.

--- a/src/server.rs
+++ b/src/server.rs
@@ -183,9 +183,6 @@ where
         self
     }
 
-    /// Get the configured worker count.
-    #[inline]
-    #[must_use]
     /// Returns the configured number of worker tasks for the server.
     ///
     /// # Examples
@@ -197,6 +194,8 @@ where
     /// let server = WireframeServer::new(factory);
     /// assert!(server.worker_count() >= 1);
     /// ```
+    #[inline]
+    #[must_use]
     pub const fn worker_count(&self) -> usize { self.workers }
 
     /// Get the socket address the server is bound to, if available.

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -11,8 +11,9 @@ struct TestMsg(u8);
 #[test]
 /// Tests that a message can be extracted from a payload and that the payload cursor advances fully.
 ///
-/// Verifies that a `TestMsg` instance serialised into bytes can be correctly extracted from a `Payload`
-/// using `Message::<TestMsg>::from_message_request`, and asserts that the payload has no remaining unread data after extraction.
+/// Verifies that a `TestMsg` instance serialised into bytes can be correctly extracted from a
+/// `Payload` using `Message::<TestMsg>::from_message_request`, and asserts that the payload has no
+/// remaining unread data after extraction.
 fn message_extractor_parses_and_advances() {
     let msg = TestMsg(42);
     let bytes = msg.to_bytes().unwrap();
@@ -27,7 +28,8 @@ fn message_extractor_parses_and_advances() {
 }
 
 #[test]
-/// Tests that `ConnectionInfo` correctly reports the peer socket address extracted from a `MessageRequest`.
+/// Tests that `ConnectionInfo` correctly reports the peer socket address extracted from a
+/// `MessageRequest`.
 fn connection_info_reports_peer() {
     let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
     let req = MessageRequest {
@@ -40,10 +42,11 @@ fn connection_info_reports_peer() {
 }
 
 #[test]
-/// Tests that shared state of type `u8` can be successfully extracted from a `MessageRequest`'s `app_data`.
+/// Tests that shared state of type `u8` can be successfully extracted from a `MessageRequest`'s
+/// `app_data`.
 ///
-/// Inserts an `Arc<u8>` into the request's shared state, extracts it using the `SharedState` extractor,
-/// and asserts that the extracted value matches the original.
+/// Inserts an `Arc<u8>` into the request's shared state, extracts it using the `SharedState`
+/// extractor, and asserts that the extracted value matches the original.
 fn shared_state_extractor() {
     let mut data = HashMap::default();
     data.insert(


### PR DESCRIPTION
## Summary
- reorder attributes after doc comments for consistency
- fix doctest formatting and run `cargo fmt`

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68549eda70748322bbffb4f0040af296