### PR TITLE
Fix missing Arc in middleware

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -4,6 +4,8 @@
 //! the underlying [`Service`]. Implement [`Transform`] to wrap services or use
 //! [`from_fn`] to create middleware from an async function.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 
 /// Incoming request wrapper passed through middleware.
@@ -78,7 +80,7 @@ where
     /// # impl Service for MyService {
     /// #     type Error = std::convert::Infallible;
     /// #     async fn call(&self, _req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
-    /// #         Ok(ServiceResponse)
+    /// #         Ok(ServiceResponse::default())
     /// #     }
     /// # }
     /// let service = MyService;
@@ -163,7 +165,7 @@ impl<F> FromFn<F> {
 /// # impl wireframe::middleware::Service for MyService {
 /// #     type Error = std::convert::Infallible;
 /// #     async fn call(&self, _req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
-/// #         Ok(ServiceResponse)
+/// #         Ok(ServiceResponse::default())
 /// #     }
 /// # }
 /// let mw = from_fn(logging);


### PR DESCRIPTION
## Summary
- import `Arc` for middleware
- fix doctest examples returning `ServiceResponse`

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68554da446088322bc0e956d14d3b549

## Summary by Sourcery

Fix missing Arc import in middleware and correct doctest examples to return `ServiceResponse::default()`

Bug Fixes:
- Import `Arc` in middleware for proper shared ownership
- Fix doctest examples to return `ServiceResponse::default()` instead of `ServiceResponse`

Tests:
- Update inline doctests to use `ServiceResponse::default()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation examples to use the correct return value in code snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->