### PR TITLE
Add echo example and route test utilities

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,0 +1,26 @@
+use std::io;
+
+use wireframe::{
+    app::{Middleware, WireframeApp},
+    server::WireframeServer,
+};
+
+struct Logger;
+impl Middleware for Logger {}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let factory = || {
+        WireframeApp::new()
+            .unwrap()
+            .wrap(Logger)
+            .unwrap()
+            .route(1, Box::new(|_env| Box::pin(async {})))
+            .unwrap()
+    };
+
+    WireframeServer::new(factory)
+        .bind("127.0.0.1:7878".parse().unwrap())?
+        .run()
+        .await
+}

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -1,0 +1,65 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use bytes::BytesMut;
+use wireframe::{
+    Serializer,
+    app::WireframeApp,
+    frame::{FrameProcessor, LengthPrefixedProcessor},
+    message::Message,
+    serializer::BincodeSerializer,
+};
+
+mod util;
+use util::run_app_with_frame;
+
+#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
+struct TestEnvelope {
+    id: u32,
+    msg: Vec<u8>,
+}
+
+#[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
+struct Echo(u8);
+
+#[tokio::test]
+async fn handler_receives_message_and_echoes_response() {
+    let called = Arc::new(AtomicUsize::new(0));
+    let called_clone = called.clone();
+    let app = WireframeApp::new()
+        .unwrap()
+        .frame_processor(LengthPrefixedProcessor)
+        .route(
+            1,
+            Box::new(move |_| {
+                let called_inner = called_clone.clone();
+                Box::pin(async move {
+                    called_inner.fetch_add(1, Ordering::SeqCst);
+                })
+            }),
+        )
+        .unwrap();
+    let msg_bytes = Echo(42).to_bytes().unwrap();
+    let env = TestEnvelope {
+        id: 1,
+        msg: msg_bytes,
+    };
+    let env_bytes = BincodeSerializer.serialize(&env).unwrap();
+    let mut framed = BytesMut::new();
+    LengthPrefixedProcessor
+        .encode(&env_bytes, &mut framed)
+        .unwrap();
+
+    let out = run_app_with_frame(app, framed.to_vec()).await.unwrap();
+
+    let mut buf = BytesMut::from(&out[..]);
+    let frame = LengthPrefixedProcessor.decode(&mut buf).unwrap().unwrap();
+    let (resp_env, _) = BincodeSerializer
+        .deserialize::<TestEnvelope>(&frame)
+        .unwrap();
+    let (echo, _) = Echo::from_bytes(&resp_env.msg).unwrap();
+    assert_eq!(echo, Echo(42));
+    assert_eq!(called.load(Ordering::SeqCst), 1);
+}

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,0 +1,27 @@
+use tokio::io::{self, AsyncReadExt, AsyncWriteExt, duplex};
+use wireframe::app::WireframeApp;
+
+/// Feed a single frame into `app` and collect the response bytes.
+///
+/// # Errors
+///
+/// Propagates I/O errors from the in-memory connection.
+///
+/// # Panics
+///
+/// Panics if the spawned task running the application panics.
+pub async fn run_app_with_frame(app: WireframeApp, frame: Vec<u8>) -> io::Result<Vec<u8>> {
+    let (mut client, server) = duplex(1024);
+    let server_task = tokio::spawn(async move {
+        app.handle_connection(server).await;
+    });
+
+    client.write_all(&frame).await?;
+    client.shutdown().await?;
+
+    let mut buf = Vec::new();
+    client.read_to_end(&mut buf).await?;
+
+    server_task.await.unwrap();
+    Ok(buf)
+}


### PR DESCRIPTION
## Summary
- add `examples/echo.rs` showing basic server setup
- introduce test utility to run an app with frames
- test routing logic with serialized request/response

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68555d3a96408322bdbe678fd8da1844