### PR TITLE
Document configurable framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ The builder supports methods like `frame_processor`, `route`, `app_data`, and
 `wrap` for middleware configuration. `app_data` stores any `Send + Sync` value
 keyed by type; registering another value of the same type overwrites the
 previous one. Handlers retrieve these values using the `SharedState<T>`
-extractor【F:docs/rust-binary-router-library-design.md†L616-L704】.
+extractor【F:docs/rust-binary-router-library-design.md†L622-L710】.
 
 Handlers are asynchronous functions whose parameters implement extractor traits
 and may return responses implementing the `Responder` trait. This pattern
 mirrors Actix Web handlers and keeps protocol logic
-concise【F:docs/rust-binary-router-library-design.md†L676-L704】.
+concise【F:docs/rust-binary-router-library-design.md†L682-L710】.
 
 ## Example
 
@@ -83,18 +83,25 @@ WireframeServer::new(|| {
 ```
 
 This example showcases how derive macros and the framing abstraction simplify a
-binary protocol server【F:docs/rust-binary-router-library-design.md†L1120-L1150】.
+binary protocol server【F:docs/rust-binary-router-library-design.md†L1126-L1156】.
 
 ## Response Serialization and Framing
 
 Handlers can return types implementing the `Responder` trait. These values are
 encoded using the application's configured serializer and written back through
-the `FrameProcessor`【F:docs/rust-binary-router-library-design.md†L718-L724】.
+the `FrameProcessor`【F:docs/rust-binary-router-library-design.md†L724-L730】.
 
 The included `LengthPrefixedProcessor` illustrates a simple framing strategy
 that prefixes each frame with its length. The format is configurable (prefix
 size and endianness) and defaults to a 4‑byte big‑endian length
-prefix【F:docs/rust-binary-router-library-design.md†L1076-L1117】.
+prefix【F:docs/rust-binary-router-library-design.md†L1082-L1123】.
+
+```rust
+use wireframe::frame::{LengthFormat, LengthPrefixedProcessor};
+
+let app = WireframeApp::new()?
+    .frame_processor(LengthPrefixedProcessor::new(LengthFormat::u16_le()));
+```
 
 ## Connection Lifecycle
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -402,7 +402,7 @@ way to define and process frames.
   example, `LengthFormat::u16_le()` or `LengthFormat::u32_be()`. Applications
   configure it via
   `WireframeApp::frame_processor(LengthPrefixedProcessor::new(format))`. The
-  `FrameProcessor` trait remains public so custom implementations can be
+  `FrameProcessor` trait remains public, so custom implementations can be
   supplied when required.
 
 - **Optional** `FrameMetadata` **Trait**: For protocols where routing decisions

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -397,7 +397,13 @@ way to define and process frames.
 
   "wireframe" could provide common `FrameProcessor` implementations (e.g., for
   length-prefixed frames) as part of its standard library, simplifying setup for
-  common protocol types.
+  common protocol types. The library ships with a `LengthPrefixedProcessor`. It
+  accepts a `LengthFormat` specifying the prefix size and byte order—for
+  example, `LengthFormat::u16_le()` or `LengthFormat::u32_be()`. Applications
+  configure it via
+  `WireframeApp::frame_processor(LengthPrefixedProcessor::new(format))`. The
+  `FrameProcessor` trait remains public so custom implementations can be
+  supplied when required.
 
 - **Optional** `FrameMetadata` **Trait**: For protocols where routing decisions
   or pre-handler middleware logic might depend on information in a frame header


### PR DESCRIPTION
## Summary
- demonstrate length prefix configuration with `LengthFormat`
- document built-in `LengthPrefixedProcessor` and custom `FrameProcessor`

## Testing
- `mdformat-all --version`
- `nixie AGENTS.md README.md docs/rust-binary-router-library-design.md`
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68558832c7f08322a24d31c6fb8faa6f

## Summary by Sourcery

Document configurable framing by adding examples and detailed descriptions for the built-in `LengthPrefixedProcessor` and its `LengthFormat` configuration.

Documentation:
- Add a Rust code snippet in the README showing how to set a custom length prefix (e.g., `u16_le`) with `LengthPrefixedProcessor`.
- Update the library design documentation to describe the `LengthPrefixedProcessor`, its `LengthFormat` options, and the public `FrameProcessor` trait for custom implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated references to design document line numbers for improved accuracy.
  - Added a Rust code example demonstrating configuration of the `WireframeApp` with a length-prefixed processor.
  - Clarified documentation on built-in frame processing options and how to customise framing strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->