### PR TITLE
Refactor routes test processor setup

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -190,6 +190,7 @@ pub trait FrameProcessor: Send + Sync {
 }
 
 /// Simple length-prefixed framing using a configurable length prefix.
+#[derive(Clone, Copy, Debug)]
 pub struct LengthPrefixedProcessor {
     format: LengthFormat,
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -51,3 +51,9 @@ pub async fn run_app_with_frame_with_capacity(
     server_task.await.unwrap();
     Ok(buf)
 }
+
+/// Convenience for constructing a default length-prefixed processor.
+#[must_use]
+pub fn default_processor() -> wireframe::frame::LengthPrefixedProcessor {
+    wireframe::frame::LengthPrefixedProcessor::default()
+}


### PR DESCRIPTION
## Summary
- derive `Clone` and `Copy` for `LengthPrefixedProcessor`
- add `default_processor` helper for tests
- reuse a single processor instance in `routes` test

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68559682e6308322855677dd8beb9990

## Summary by Sourcery

Refactor routes tests to share a default LengthPrefixedProcessor instance by introducing a default_processor helper and deriving Clone and Copy for LengthPrefixedProcessor.

New Features:
- Add default_processor helper to construct a default length-prefixed processor in tests

Enhancements:
- Derive Clone and Copy for LengthPrefixedProcessor to allow reusing processor instances

Tests:
- Refactor routes test to use a single default_processor instance instead of creating multiple processors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved code maintainability by introducing a utility function for creating default frame processor instances in tests.
  - Enhanced struct capabilities by enabling cloning, copying, and debugging for internal processor types.

- **Tests**
  - Updated test setup to use a new utility function for consistent processor instantiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->