### PR TITLE
Fix processor usage in routes test

### DIFF
--- a/src/frame.rs
+++ b/src/frame.rs
@@ -190,6 +190,7 @@ pub trait FrameProcessor: Send + Sync {
 }
 
 /// Simple length-prefixed framing using a configurable length prefix.
+#[derive(Clone)]
 pub struct LengthPrefixedProcessor {
     format: LengthFormat,
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -27,13 +27,13 @@ struct Echo(u8);
 
 #[rstest]
 #[tokio::test]
-async fn handler_receives_message_and_echoes_response(processor: LengthPrefixedProcessor) {
+async fn handler_receives_message_and_echoes_response() {
     let called = Arc::new(AtomicUsize::new(0));
     let called_clone = called.clone();
     let processor = default_processor();
     let app = WireframeApp::new()
         .unwrap()
-        .frame_processor(processor.clone())
+        .frame_processor(processor)
         .route(
             1,
             Box::new(move |_| {

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,5 +1,6 @@
+use rstest::fixture;
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt, duplex};
-use wireframe::app::WireframeApp;
+use wireframe::{app::WireframeApp, frame::LengthPrefixedProcessor};
 
 /// Feed a single frame into `app` and collect the response bytes.
 ///
@@ -12,6 +13,13 @@ use wireframe::app::WireframeApp;
 /// Panics if the spawned task running the application panics.
 /// Optional duplex buffer capacity for `run_app_with_frame`.
 const DEFAULT_CAPACITY: usize = 4096;
+
+/// Create a default length-prefixed frame processor for tests.
+#[fixture]
+#[rustfmt::skip]
+pub fn processor() -> LengthPrefixedProcessor {
+    LengthPrefixedProcessor::default()
+}
 
 /// Run `app` with a single input `frame` using the default buffer capacity.
 ///


### PR DESCRIPTION
## Summary
- implement `Clone` for `LengthPrefixedProcessor`
- create a `processor` fixture for tests
- reuse the same processor instance in the routes test

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68558c3a2f608322bcf8739c022f97b1

## Summary by Sourcery

Derive Clone for LengthPrefixedProcessor, add a reusable processor fixture, and refactor the routes test to consistently use the same processor instance for framing.

Bug Fixes:
- Fix routes test to use a cloned processor instance for both encoding and decoding frames.

Enhancements:
- Derive Clone on LengthPrefixedProcessor.

Tests:
- Introduce a rstest fixture for LengthPrefixedProcessor.
- Update routes test to inject and reuse the processor fixture instead of creating new instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test structure by introducing parameterised tests for message handling and echo response.
  - Added a reusable test fixture for the frame processor to streamline test setup.
- **Chores**
  - Enhanced internal consistency by allowing the frame processor to be cloned where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->