### PR TITLE
Fix compilation errors in routes tests

### DIFF
--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -7,13 +7,13 @@ use bytes::BytesMut;
 use wireframe::{
     Serializer,
     app::WireframeApp,
-    frame::FrameProcessor,
+    frame::{FrameProcessor, LengthPrefixedProcessor},
     message::Message,
     serializer::BincodeSerializer,
 };
 
 mod util;
-use util::{default_processor, run_app_with_frame, run_app_with_frames};
+use util::{run_app_with_frame, run_app_with_frames};
 
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
 struct TestEnvelope {
@@ -28,7 +28,6 @@ struct Echo(u8);
 async fn handler_receives_message_and_echoes_response() {
     let called = Arc::new(AtomicUsize::new(0));
     let called_clone = called.clone();
-    let processor = default_processor();
     let app = WireframeApp::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -80,9 +80,3 @@ pub async fn run_app_with_frames_with_capacity(
     server_task.await.unwrap();
     Ok(buf)
 }
-
-/// Convenience for constructing a default length-prefixed processor.
-#[must_use]
-pub fn default_processor() -> wireframe::frame::LengthPrefixedProcessor {
-    wireframe::frame::LengthPrefixedProcessor::default()
-}


### PR DESCRIPTION
## Summary
- import `LengthPrefixedProcessor` in route tests
- drop unused helper and import to eliminate warnings

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6855e1dc01588322a2fc064c78702e1c

## Summary by Sourcery

Fix compilation errors in route tests by importing the missing LengthPrefixedProcessor and removing the unused default_processor helper.

Bug Fixes:
- Import LengthPrefixedProcessor in tests/routes.rs to resolve missing type errors.
- Remove unused default_processor helper and its import from tests/util.rs to eliminate warnings.