### PR TITLE
Fix routes test imports

### DIFF
--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -27,13 +27,13 @@ struct Echo(u8);
 
 #[rstest]
 #[tokio::test]
-async fn handler_receives_message_and_echoes_response(processor: LengthPrefixedProcessor) {
+async fn handler_receives_message_and_echoes_response() {
     let called = Arc::new(AtomicUsize::new(0));
     let called_clone = called.clone();
     let processor = default_processor();
     let app = WireframeApp::new()
         .unwrap()
-        .frame_processor(processor.clone())
+        .frame_processor(processor)
         .route(
             1,
             Box::new(move |_| {


### PR DESCRIPTION
## Summary
- bring LengthPrefixed frame processor into scope
- use default processor directly in routes test

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855e0be31f08322a13c85fdd48011ec

## Summary by Sourcery

Fix the routes test by importing and using the default frame processor directly instead of accepting a LengthPrefixedProcessor parameter.

Bug Fixes:
- Update the route handler test to instantiate the processor via default_processor() rather than relying on an external LengthPrefixedProcessor argument.

Tests:
- Remove the unused test parameter and inline processor creation in the routes test.
- Drop the unnecessary .clone() call when passing the processor to frame_processor.