### PR TITLE
Fix FrameProcessor instantiation in tests

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -9,7 +9,7 @@ async fn main() -> io::Result<()> {
             .unwrap()
             .route(
                 1,
-                Box::new(|_| {
+                std::sync::Arc::new(|_| {
                     Box::pin(async move {
                         println!("echo request received");
                         // `WireframeApp` automatically echoes the envelope back.

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -63,7 +63,8 @@ async fn middleware_applied_in_reverse_order() {
     let env = Envelope::new(1, vec![b'X']);
     let serializer = BincodeSerializer;
     let bytes = serializer.serialize(&env).unwrap();
-    let processor = LengthPrefixedProcessor;
+    // Use the default 4-byte big-endian length prefix for framing
+    let processor = LengthPrefixedProcessor::default();
     let mut buf = BytesMut::new();
     processor.encode(&bytes, &mut buf).unwrap();
     client.write_all(&buf).await.unwrap();

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -35,7 +35,7 @@ async fn handler_receives_message_and_echoes_response() {
         .frame_processor(LengthPrefixedProcessor::default())
         .route(
             1,
-            Box::new(move |_| {
+            std::sync::Arc::new(move |_| {
                 let called_inner = called_clone.clone();
                 Box::pin(async move {
                     called_inner.fetch_add(1, Ordering::SeqCst);
@@ -75,7 +75,7 @@ async fn multiple_frames_processed_in_sequence() {
     let app = WireframeApp::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())
-        .route(1, Box::new(|_| Box::pin(async {})))
+        .route(1, std::sync::Arc::new(|_| Box::pin(async {})))
         .unwrap();
 
     let frames: Vec<Vec<u8>> = (1u8..=2)


### PR DESCRIPTION
## Summary
- create a `LengthPrefixedProcessor` instance instead of referring to the type
- update tests and example to use `Arc` handlers

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855eb853cf083229cb2a874281748fd

## Summary by Sourcery

Fix FrameProcessor instantiation and unify route handler wrapper in tests and example

Tests:
- Replace direct LengthPrefixedProcessor type usage with LengthPrefixedProcessor::default() in tests and example
- Wrap all route handler closures in std::sync::Arc instead of Box to match updated API