### PR TITLE
Update docs for from_fn middleware

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -72,27 +72,27 @@ after formatting. Line numbers below refer to that file.
 
 ## 2. Middleware and Extractors
 
-- [ ] Develop a minimal middleware system and extractor traits for payloads,
+- [x] Develop a minimal middleware system and extractor traits for payloads,
   connection metadata, and shared state.
-  - [ ] Define `FromMessageRequest` for extractor types (lines 760-782). See
+  - [x] Define `FromMessageRequest` for extractor types (lines 760-782). See
     [`FromMessageRequest`][from-message-request] in
     [`src/extractor.rs`](../src/extractor.rs).
 
-  - [ ] Provide built-in extractors `Message<T>`, `ConnectionInfo`, and
+  - [x] Provide built-in extractors `Message<T>`, `ConnectionInfo`, and
     `SharedState<T>` (lines 792-840). `SharedState<T>` is defined in
     [`src/extractor.rs`](../src/extractor.rs#L54-L87).
 
-  - [ ] Support custom extractors implementing `FromMessageRequest` (lines
+  - [x] Support custom extractors implementing `FromMessageRequest` (lines
     842-858). Refer again to [`src/extractor.rs`](../src/extractor.rs#L39-L52).
 
   - [x] Implement middleware using `Transform`/`Service` traits.
 
-  - [x] Implement `ServiceRequest` and `ServiceResponse` wrappers
-    (lines 866-899) and introduce a `Next` helper to build the
-    asynchronous call chain. Trait definitions live in
+  - [x] Implement `ServiceRequest` and `ServiceResponse` wrappers (lines
+    866-899) and introduce a `Next` helper to build the asynchronous call chain.
+    Trait definitions live in
     [`src/middleware.rs`](../src/middleware.rs#L71-L84).
 
-    - [ ] Provide a `from_fn` helper for functional middleware.
+    - [x] Provide a `from_fn` helper for functional middleware.
     - [x] Add tests verifying middleware can modify requests and observe
       responses.
 
@@ -101,7 +101,7 @@ after formatting. Line numbers below refer to that file.
     on responses (lines 900-919). See the
     [`wrap` method](../src/app.rs#L73-L84).
 
-  - [ ] Document common middleware use cases like logging and authentication
+  - [x] Document common middleware use cases like logging and authentication
     (lines 920-935). Include a logging example using `from_fn`:
 
     ```rust

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -896,9 +896,9 @@ written as an async function or closure:
 use wireframe::middleware::from_fn;
 
 let logging = from_fn(|req, next| async move {
-    println!("--> received: {:?}", req.frame());
+    tracing::info!("--> received: {:?}", req.frame());
     let mut res = next.call(req).await?;
-    println!("<-- sending: {:?}", res.frame());
+    tracing::info!("<-- sending: {:?}", res.frame());
     Ok(res)
 });
 ```


### PR DESCRIPTION
## Summary
- document how to build middleware with `from_fn`
- mark middleware roadmap items complete

## Testing
- `mdformat-all`
- `markdownlint`
- `nixie docs/rust-binary-router-library-design.md`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855fff50a8c8322880e612f2362b0f4

## Summary by Sourcery

Update the documentation to showcase building middleware with `from_fn`, refine the example usage and execution order, and mark related middleware and extractor roadmap tasks as complete.

Documentation:
- Document functional middleware creation using `from_fn` with async closures
- Clarify middleware registration example and execution order in the design guide
- Mark middleware and extractor roadmap items as completed in the project roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the roadmap to mark all "Middleware and Extractors" tasks as completed.
  - Simplified the middleware example in the design documentation, demonstrating usage with concise closures and clarifying middleware registration and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->