### PR TITLE
Document wireframe-testing helper crate

### DIFF
--- a/docs/wireframe-testing-crate.md
+++ b/docs/wireframe-testing-crate.md
@@ -1,0 +1,87 @@
+# Testing Helpers for `wireframe`
+
+`wireframe-testing` is a proposed companion crate providing utilities for unit
+and integration tests. It focuses on driving `WireframeApp` instances with raw
+frames, enabling fast tests without opening real network connections.
+
+## Motivation
+
+The existing tests in [`tests/`](../tests) use helper functions such as
+`run_app_with_frame` and `run_app_with_frames` to feed length‑prefixed frames
+through an in‑memory duplex stream. These helpers simplify testing handlers by
+allowing assertions on encoded responses without spinning up a full server.
+Encapsulating this logic in a dedicated crate keeps test code concise and
+reusable across projects.
+
+## Crate Layout
+
+- `wireframe-testing`
+  - `Cargo.toml` enabling the `tokio` and `rstest` dependencies used by the
+    helpers.
+  - `src/lib.rs` exposing asynchronous functions for driving apps with raw
+    frames.
+
+The crate would live in a `wireframe-testing/` directory alongside the main
+`wireframe` crate.
+
+## Proposed API
+
+```rust
+use tokio::io::Result as IoResult;
+use wireframe::app::WireframeApp;
+
+/// Feed a single frame into `app` using an in-memory duplex stream.
+async fn drive_with_frame(app: WireframeApp, frame: Vec<u8>) -> IoResult<Vec<u8>>;
+
+/// Drive `app` with multiple frames, returning all bytes written by the app.
+async fn drive_with_frames(app: WireframeApp, frames: Vec<Vec<u8>>) -> IoResult<Vec<u8>>;
+```
+
+These functions mirror the behaviour of `run_app_with_frame` and
+`run_app_with_frames` found in the repository’s test utilities. They create a
+`tokio::io::duplex` stream, spawn the application as a background task, and
+write the provided frame(s) to the client side of the stream. After the app
+finishes processing, the helpers collect the bytes written back and return them
+for inspection.
+
+### Custom Buffer Capacity
+
+A variant accepting a buffer `capacity` allows fine‑tuning the size of the
+in‑memory duplex channel, matching the existing
+`run_app_with_frame_with_capacity` and `run_app_with_frames_with_capacity`
+helpers.
+
+## Example Usage
+
+```rust
+#[tokio::test]
+async fn handler_echoes_message() {
+    let app = WireframeApp::new()
+        .unwrap()
+        .frame_processor(LengthPrefixedProcessor::default())
+        .route(1, Arc::new(|_| Box::pin(async {})))
+        .unwrap();
+
+    let frame = build_test_frame();
+    let out = drive_with_frame(app, frame).await.unwrap();
+    assert_eq!(out, expected_bytes());
+}
+```
+
+This pattern mirrors the style of `tests/routes.rs`, where handlers are invoked
+with prebuilt frames and their responses decoded for assertions.
+
+## Benefits
+
+- **Isolation**: Handlers can be tested without spinning up a full server or
+  opening sockets.
+- **Reusability**: Projects consuming `wireframe` can depend on
+  `wireframe-testing` in their dev‑dependencies to leverage the same helpers.
+- **Clarity**: Abstracting the duplex stream logic keeps test cases focused on
+  behaviour instead of transport details.
+
+## Next Steps
+
+Implement the crate in a new directory, export the helper functions, and migrate
+existing tests to use them. Additional fixtures (e.g., prebuilt frame
+processors) can be added over time as test coverage grows.

--- a/docs/wireframe-testing-crate.md
+++ b/docs/wireframe-testing-crate.md
@@ -35,6 +35,11 @@ async fn drive_with_frame(app: WireframeApp, frame: Vec<u8>) -> IoResult<Vec<u8>
 
 /// Drive `app` with multiple frames, returning all bytes written by the app.
 async fn drive_with_frames(app: WireframeApp, frames: Vec<Vec<u8>>) -> IoResult<Vec<u8>>;
+
+/// Encode `msg` with `bincode`, wrap it in a frame, and drive the app.
+async fn drive_with_bincode<M>(app: WireframeApp, msg: M) -> IoResult<Vec<u8>>
+where
+    M: bincode::Encode;
 ```
 
 These functions mirror the behaviour of `run_app_with_frame` and
@@ -50,6 +55,14 @@ A variant accepting a buffer `capacity` allows fine‑tuning the size of the
 in‑memory duplex channel, matching the existing
 `run_app_with_frame_with_capacity` and `run_app_with_frames_with_capacity`
 helpers.
+
+### Bincode Convenience Wrapper
+
+For most tests the input frame is preassembled from raw bytes. A small wrapper
+can accept any `bincode::Encode` value and perform the encoding and framing
+before delegating to `drive_with_frame`. This mirrors the patterns in
+`tests/routes.rs` where structs are converted to bytes with `BincodeSerializer`
+and then wrapped in a length‑prefixed frame.
 
 ## Example Usage
 


### PR DESCRIPTION
## Summary
- design a `wireframe-testing` crate for driving handlers with raw frames

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685725041bec8322a70a65ccb9df0f64

## Summary by Sourcery

Documentation:
- Document the new `wireframe_testing` helper crate with its motivation, layout, API, usage examples, benefits, and next steps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new document outlining a proposed companion crate for testing `WireframeApp` instances, including API details, usage examples, and benefits of the approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->