### PR TITLE
Fix markdown linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ access app state or expose peer information.
 Custom extractors let you centralize parsing and validation logic that would
 otherwise be duplicated across handlers. A session token parser, for example,
 can verify the token before any route-specific code executes
-[Design Guide: Data Extraction and Type Safety](docs/rust-binary-router-library-design.md#53-data-extraction-and-type-safety).
+[Design Guide: Data Extraction and Type Safety][data-extraction-guide].
 
 ```rust
 use wireframe::extractor::{ConnectionInfo, FromMessageRequest, MessageRequest, Payload};
@@ -190,3 +190,5 @@ extractor traits, and providing example applications【F:docs/roadmap.md†L1-L2
 
 Wireframe is distributed under the terms of the ISC license. See
 [LICENSE](LICENSE) for details.
+
+[data-extraction-guide]: docs/rust-binary-router-library-design.md#53-data-extraction-and-type-safety

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1,4 +1,4 @@
-# Design of "wireframe": A Rust Router for Binary Protocols
+# Design of `wireframe`: A Rust Router for Binary Protocols
 
 ## 1. Introduction
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1,4 +1,4 @@
-# Design of "wireframe": A Rust Router Library for Arbitrary Frame-Based Binary Protocols
+# Design of "wireframe": A Rust Router for Binary Protocols
 
 ## 1. Introduction
 

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -572,7 +572,7 @@ a tuple or struct and the test only cares about some parts or wants to use more
 idiomatic names for destructured elements, `#[from]` is essential to link the
 argument pattern to the correct source fixture.12
 
-### D. Partial Fixture Injection and Default Arguments: `#[with]` and `#[default]`
+### D. Partial Fixture Injection & Default Arguments
 
 `rstest` provides mechanisms for creating highly configurable "template"
 fixtures using `#[default(...)]` for fixture arguments and `#[with(...)]` to


### PR DESCRIPTION
## Summary
- wrap README link with footnote reference
- shorten lengthy headings

## Testing
- `make fmt`
- `make lint`
- `make test`
- `markdownlint README.md docs/*.md`


------
https://chatgpt.com/codex/tasks/task_e_685725101cd083229efb7fc00f3cb10a

## Summary by Sourcery

Fix markdown linting errors by converting inline links to footnote references and shortening overly long headings in documentation.

Bug Fixes:
- Convert inline README link to a footnote reference for lint compliance
- Shorten lengthy headings in design and testing docs for markdownlint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README to use reference-style links for improved maintainability.
  - Simplified the title in the design guide for the Rust router to broaden its scope.
  - Shortened a section header in the Rust testing guide for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->