### PR TITLE
Enable release mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ let logging = from_fn(|req, next| async move {
 
 ## Current Limitations
 
-Connection handling now processes frames and routes messages, but the server is
-still experimental. Release builds fail to compile, so the library cannot be
-used accidentally in production.
+Connection handling now processes frames and routes messages. Although the
+server is still experimental, it now compiles in release mode for evaluation or
+production use.
 
 ## Roadmap
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,14 +4,9 @@
 //! optionally decoding a connection preamble before handing the
 //! stream to the application.
 
-use std::io;
-
-#[cfg(not(debug_assertions))]
-compile_error!(
-    "`wireframe` server functionality is experimental and not intended for production use"
-);
 use core::marker::PhantomData;
 use std::{
+    io,
     net::{SocketAddr, TcpListener as StdTcpListener},
     sync::Arc,
 };


### PR DESCRIPTION
## Summary
- remove compile_error guard in server
- document that release mode now compiles

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6857262988388322be0ef2a21c9722ff

## Summary by Sourcery

Enable compilation and use of the server in release mode by removing the compile-time guard and updating documentation to reflect release support.

Enhancements:
- Remove compile_error guard in server.rs to allow release builds.
- Update README to state that the server now compiles in release mode for evaluation or production use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "Current Limitations" section to clarify that the server now compiles in release mode and can be used for evaluation or production deployment, while still being experimental.

- **Refactor**
  - Improved internal code formatting with no impact on functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->