### PR TITLE
Add ping-pong example with middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ let logging = from_fn(|req, next| async move {
 });
 ```
 
+## Examples
+
+Example programs are available in the `examples/` directory:
+
+- `echo.rs` – minimal echo server using routing
+- `ping_pong.rs` – showcases serialization and middleware in a ping/pong
+  protocol
+
 ## Current Limitations
 
 Connection handling now processes frames and routes messages, but the server is

--- a/README.md
+++ b/README.md
@@ -153,9 +153,10 @@ incoming \[`MessageRequest`\] and remaining \[`Payload`\]. Built‑in extractors
 like `Message<T>`, `SharedState<T>` and `ConnectionInfo` decode the payload,
 access app state or expose peer information.
 
-Custom extractors let you centralize parsing and validation logic that would
-otherwise be duplicated across handlers. A session token parser, for example,
-can verify the token before any route-specific code executes
+- `echo.rs` — minimal echo server using routing
+- `ping_pong.rs` — showcases serialization and middleware in a ping/pong
+  protocol. See [examples/ping_pong.md](examples/ping_pong.md) for a detailed
+  overview.
 [Design Guide: Data Extraction and Type Safety][data-extraction-guide].
 
 ```rust

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ Example programs are available in the `examples/` directory:
 Run an example with Cargo:
 
 ```bash
+cargo run --example echo
+```
+
+Try the ping‑pong server with netcat:
+
+```bash
 $ cargo run --example ping_pong
 # in another terminal
 $ printf '\x00\x00\x00\x08\x01\x00\x00\x00\x2a\x00\x00\x00' | nc 127.0.0.1 7878 | xxd

--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ Example programs are available in the `examples/` directory:
 - `ping_pong.rs` – showcases serialization and middleware in a ping/pong
   protocol
 
+Run an example with Cargo:
+
+```bash
+$ cargo run --example ping_pong
+# in another terminal
+$ printf '\x00\x00\x00\x08\x01\x00\x00\x00\x2a\x00\x00\x00' | nc 127.0.0.1 7878 | xxd
+```
+
 ## Current Limitations
 
 Connection handling now processes frames and routes messages, but the server is

--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ use wireframe::extractor::{ConnectionInfo, FromMessageRequest, MessageRequest, P
 
 pub struct SessionToken(String);
 
+Try the echo server with netcat:
+
+```bash
+$ cargo run --example echo
+# in another terminal
+$ printf '\x00\x00\x00\x00\x01\x00\x00\x00' | nc 127.0.0.1 7878 | xxd
+```
+
 impl FromMessageRequest for SessionToken {
     type Error = std::convert::Infallible;
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,7 @@ after formatting. Line numbers below refer to that file.
 
 ## 3. Initial Examples and Documentation
 
-- [ ] Provide examples demonstrating routing, serialization, and middleware.
+- [x] Provide examples demonstrating routing, serialization, and middleware.
   Document configuration and usage reflecting the API design section.
 
 ## 4. Extended Features

--- a/examples/ping_pong.md
+++ b/examples/ping_pong.md
@@ -1,0 +1,53 @@
+# Ping-Pong Example
+
+This example demonstrates routing, serialization, and middleware usage in a
+small ping/pong protocol. The server accepts a `Ping` message containing a
+counter and responds with a `Pong` containing the incremented value. Logging
+middleware prints each request and response.
+
+```mermaid
+classDiagram
+    class Ping {
+        +u32 0
+        +to_bytes()
+        +from_bytes()
+    }
+    class Pong {
+        +u32 0
+        +to_bytes()
+        +from_bytes()
+    }
+    class ErrorMsg {
+        +String 0
+        +to_bytes()
+        +from_bytes()
+    }
+    class PongMiddleware {
+    }
+    class PongService {
+        +inner: S
+        +call(req: ServiceRequest) Result<ServiceResponse, Infallible>
+    }
+    class Logging {
+    }
+    class LoggingService {
+        +inner: S
+        +call(req: ServiceRequest) Result<ServiceResponse, Infallible>
+    }
+    class HandlerService {
+        +id()
+        +from_service(id, service)
+    }
+    PongMiddleware --|> Transform
+    PongService --|> Service
+    Logging --|> Transform
+    LoggingService --|> Service
+    HandlerService <.. PongService : inner
+    HandlerService <.. LoggingService : inner
+    PongMiddleware ..> HandlerService : transform
+    Logging ..> HandlerService : transform
+    WireframeApp <.. build_app : factory
+    WireframeServer <.. main : uses
+    build_app --> WireframeApp
+    main --> WireframeServer
+```

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -2,7 +2,7 @@ use std::{io, sync::Arc};
 
 use async_trait::async_trait;
 use wireframe::{
-    app::WireframeApp,
+    app::{Result as AppResult, WireframeApp},
     message::Message,
     middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
     serializer::BincodeSerializer,
@@ -106,21 +106,17 @@ impl Transform<HandlerService> for Logging {
     }
 }
 
-fn build_app() -> WireframeApp {
-    WireframeApp::new()
-        .expect("failed to create app")
+fn build_app() -> AppResult<WireframeApp> {
+    WireframeApp::new()?
         .serializer(BincodeSerializer)
-        .route(PING_ID, Arc::new(|_| Box::pin(ping_handler())))
-        .expect("failed to register ping handler")
-        .wrap(PongMiddleware)
-        .expect("failed to apply PongMiddleware")
+        .route(PING_ID, Arc::new(|_| Box::pin(ping_handler())))?
+        .wrap(PongMiddleware)?
         .wrap(Logging)
-        .expect("failed to apply Logging middleware")
 }
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let factory = || build_app();
+    let factory = || build_app().expect("app build failed");
 
     let addr = "127.0.0.1:7878"
         .parse()

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -1,0 +1,107 @@
+use std::{io, sync::Arc};
+
+use async_trait::async_trait;
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    message::Message,
+    middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
+    serializer::BincodeSerializer,
+    server::WireframeServer,
+};
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+struct Ping(u32);
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+struct Pong(u32);
+
+const PING_ID: u32 = 1;
+
+fn ping_handler(
+    _env: &Envelope,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+    Box::pin(async {})
+}
+
+struct PongMiddleware;
+
+struct PongService<S> {
+    inner: S,
+}
+
+#[async_trait]
+impl<S> Service for PongService<S>
+where
+    S: Service<Error = std::convert::Infallible> + Send + Sync + 'static,
+{
+    type Error = std::convert::Infallible;
+
+    async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
+        let (ping_req, _) = Ping::from_bytes(req.frame()).unwrap();
+        let mut response = self.inner.call(req).await?;
+        let pong_resp = Pong(ping_req.0 + 1);
+        *response.frame_mut() = pong_resp.to_bytes().unwrap();
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl Transform<HandlerService> for PongMiddleware {
+    type Output = HandlerService;
+
+    async fn transform(&self, service: HandlerService) -> Self::Output {
+        let id = service.id();
+        HandlerService::from_service(id, PongService { inner: service })
+    }
+}
+
+struct Logging;
+
+struct LoggingService<S> {
+    inner: S,
+}
+
+#[async_trait]
+impl<S> Service for LoggingService<S>
+where
+    S: Service<Error = std::convert::Infallible> + Send + Sync + 'static,
+{
+    type Error = std::convert::Infallible;
+
+    async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
+        println!("request: {:?}", req.frame());
+        let resp = self.inner.call(req).await?;
+        println!("response: {:?}", resp.frame());
+        Ok(resp)
+    }
+}
+
+#[async_trait]
+impl Transform<HandlerService> for Logging {
+    type Output = HandlerService;
+
+    async fn transform(&self, service: HandlerService) -> Self::Output {
+        let id = service.id();
+        HandlerService::from_service(id, LoggingService { inner: service })
+    }
+}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let factory = || {
+        WireframeApp::new()
+            .unwrap()
+            .serializer(BincodeSerializer)
+            .route(PING_ID, Arc::new(ping_handler))
+            .unwrap()
+            .wrap(PongMiddleware)
+            .unwrap()
+            .wrap(Logging)
+            .unwrap()
+    };
+
+    WireframeServer::new(factory)
+        .bind("127.0.0.1:7878".parse().unwrap())?
+        .run()
+        .await
+}

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -85,6 +85,8 @@ where
 impl Transform<HandlerService> for PongMiddleware {
     type Output = HandlerService;
 
+    // `HandlerService` is a boxed trait object without generic parameters,
+    // so the transform signature uses the concrete type directly.
     async fn transform(&self, service: HandlerService) -> Self::Output {
         let id = service.id();
         HandlerService::from_service(id, PongService { inner: service })
@@ -116,6 +118,7 @@ where
 impl Transform<HandlerService> for Logging {
     type Output = HandlerService;
 
+    // `HandlerService` is a concrete type, not a generic wrapper.
     async fn transform(&self, service: HandlerService) -> Self::Output {
         let id = service.id();
         HandlerService::from_service(id, LoggingService { inner: service })

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -9,6 +9,14 @@ use wireframe::{
     server::WireframeServer,
 };
 
+/// Convenience helper to convert a service into a `HandlerService`.
+fn wrap_service<S>(id: u32, svc: S) -> HandlerService
+where
+    S: Service<Error = std::convert::Infallible> + Send + Sync + 'static,
+{
+    HandlerService::from_service(id, svc)
+}
+
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
 struct Ping(u32);
 
@@ -17,6 +25,10 @@ struct Pong(u32);
 
 const PING_ID: u32 = 1;
 
+/// Handler invoked for `PING_ID` messages.
+///
+/// The middleware chain generates the actual response, so this
+/// handler intentionally performs no work.
 fn ping_handler(
     _env: &Envelope,
 ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
@@ -37,10 +49,22 @@ where
     type Error = std::convert::Infallible;
 
     async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
-        let (ping_req, _) = Ping::from_bytes(req.frame()).unwrap();
+        let (ping_req, _) = match Ping::from_bytes(req.frame()) {
+            Ok(val) => val,
+            Err(e) => {
+                eprintln!("failed to decode ping: {e:?}");
+                return Ok(ServiceResponse::default());
+            }
+        };
         let mut response = self.inner.call(req).await?;
         let pong_resp = Pong(ping_req.0 + 1);
-        *response.frame_mut() = pong_resp.to_bytes().unwrap();
+        match pong_resp.to_bytes() {
+            Ok(bytes) => *response.frame_mut() = bytes,
+            Err(e) => {
+                eprintln!("failed to encode pong: {e:?}");
+                return Ok(ServiceResponse::default());
+            }
+        }
         Ok(response)
     }
 }
@@ -51,7 +75,7 @@ impl Transform<HandlerService> for PongMiddleware {
 
     async fn transform(&self, service: HandlerService) -> Self::Output {
         let id = service.id();
-        HandlerService::from_service(id, PongService { inner: service })
+        wrap_service(id, PongService { inner: service })
     }
 }
 
@@ -82,7 +106,7 @@ impl Transform<HandlerService> for Logging {
 
     async fn transform(&self, service: HandlerService) -> Self::Output {
         let id = service.id();
-        HandlerService::from_service(id, LoggingService { inner: service })
+        wrap_service(id, LoggingService { inner: service })
     }
 }
 


### PR DESCRIPTION
## Summary
- add ping_pong.rs demonstrating routing, serialization and middleware
- list example files in README
- mark roadmap item about examples as complete

## Testing
- `mdformat-all README.md docs/*.md examples/ping_pong.rs examples/echo.rs`
- `markdownlint --fix AGENTS.md CHANGELOG.md README.md docs/mocking-network-outages-in-rust.md docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md`
- `nixie README.md docs/*.md`
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857265325588322a829a52b18a77a13

## Summary by Sourcery

Introduce a new ping-pong example showcasing middleware chaining and Bincode serialization, update the README to list examples with usage commands, and mark the related roadmap task as done.

New Features:
- Add ping_pong.rs example demonstrating serialization and middleware in a ping/pong protocol

Documentation:
- Update README examples section with usage instructions and list of available examples
- Mark the routing, serialization, and middleware examples item as complete in the roadmap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new ping-pong server example demonstrating asynchronous middleware, message serialization, and server setup.
- **Documentation**
  - Expanded and clarified the "Examples" section in the README with detailed descriptions and usage instructions.
  - Updated the roadmap to mark the initial examples and documentation as complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->