### PR TITLE
Add packet enum example

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ let logging = from_fn(|req, next| async move {
 });
 ```
 
+## Examples
+
+The `examples/` directory contains runnable demos illustrating different
+protocol designs:
+
+- `echo.rs` – minimal server that echoes incoming frames.
+- `packet_enum.rs` – shows packet type discrimination with a bincode enum and a
+  frame containing container types like `HashMap` and `Vec`.
+
 ## Current Limitations
 
 Connection handling now processes frames and routes messages, but the server is

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -1,0 +1,84 @@
+use std::{collections::HashMap, io};
+
+use async_trait::async_trait;
+use wireframe::{
+    app::WireframeApp,
+    frame::{LengthFormat, LengthPrefixedProcessor},
+    message::Message,
+    middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
+    server::WireframeServer,
+};
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+enum Packet {
+    Ping,
+    Chat { user: String, msg: String },
+    Stats(Vec<u32>),
+}
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+struct Frame {
+    headers: HashMap<String, String>,
+    packet: Packet,
+}
+
+struct DecodeMiddleware;
+
+struct DecodeService<S> {
+    inner: S,
+}
+
+#[async_trait]
+impl<S> Service for DecodeService<S>
+where
+    S: Service<Error = std::convert::Infallible> + Send + Sync,
+{
+    type Error = S::Error;
+
+    async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
+        if let Ok((frame, _)) = Frame::from_bytes(req.frame()) {
+            match frame.packet {
+                Packet::Ping => println!("ping: {:?}", frame.headers),
+                Packet::Chat { user, msg } => println!("{user} says: {msg}"),
+                Packet::Stats(values) => println!("stats: {values:?}"),
+            }
+        }
+        let response = self.inner.call(req).await?;
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl Transform<HandlerService> for DecodeMiddleware {
+    type Output = HandlerService;
+
+    async fn transform(&self, service: HandlerService) -> Self::Output {
+        let id = service.id();
+        HandlerService::from_service(id, DecodeService { inner: service })
+    }
+}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let factory = || {
+        WireframeApp::new()
+            .unwrap()
+            .frame_processor(LengthPrefixedProcessor::new(LengthFormat::u16_le()))
+            .wrap(DecodeMiddleware)
+            .unwrap()
+            .route(
+                1,
+                std::sync::Arc::new(|_| {
+                    Box::pin(async move {
+                        println!("packet received");
+                    })
+                }),
+            )
+            .unwrap()
+    };
+
+    WireframeServer::new(factory)
+        .bind("127.0.0.1:7879".parse().unwrap())?
+        .run()
+        .await
+}


### PR DESCRIPTION
## Summary
- showcase packet type discrimination with a bincode enum
- describe available examples in the README

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573b3f4ca083229578068e331c383a

## Summary by Sourcery

Add a packet_enum example showcasing bincode enum-based packet discrimination and update README to list available examples

Enhancements:
- Add a packet_enum example demonstrating packet type discrimination using a bincode enum with containers like HashMap and Vec

Documentation:
- Add an Examples section to README detailing runnable demos including echo.rs and the new packet_enum.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new example demonstrating packet type handling and deserialisation using enums and container types in a network server.
- **Documentation**
  - Introduced an "Examples" section in the README, describing available demo programmes and their functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->