### PR TITLE
Enable responses in preamble callback

### DIFF
--- a/docs/preamble-validator.md
+++ b/docs/preamble-validator.md
@@ -21,6 +21,7 @@ sequenceDiagram
     alt Decode success
         PreambleDecoder-->>Server: Decoded preamble (T)
         Server->>SuccessCallback: Invoke with preamble data
+        SuccessCallback-->>Client: Optional response
     else Decode failure
         PreambleDecoder-->>Server: DecodeError
         Server->>FailureCallback: Invoke with error
@@ -28,9 +29,12 @@ sequenceDiagram
     Server-->>Client: (Continues or closes connection)
 ```
 
-In the tests, a `HotlinePreamble` struct illustrates the pattern, but any
-preamble type may be used. Register callbacks via `on_preamble_decode_success`
-and `on_preamble_decode_failure` on `WireframeServer`.
+The success callback receives the decoded preamble and a mutable `TcpStream`. It
+may write a handshake response before the connection is passed to
+`WireframeApp`. In the tests, a `HotlinePreamble` struct illustrates the
+pattern, but any preamble type may be used. Register callbacks via
+`on_preamble_decode_success` and `on_preamble_decode_failure` on
+`WireframeServer`.
 
 ## Call Order
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -17,9 +17,17 @@ use std::{
 };
 
 use bincode::error::DecodeError;
+use futures::future::BoxFuture;
 
 /// Callback invoked when a connection preamble decodes successfully.
-pub type PreambleCallback<T> = Arc<dyn Fn(&T) + Send + Sync>;
+///
+/// The callback may perform asynchronous I/O on the provided stream before the
+/// connection is handed off to [`WireframeApp`].
+pub type PreambleCallback<T> = Arc<
+    dyn for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
+        + Send
+        + Sync,
+>;
 
 /// Callback invoked when decoding a connection preamble fails.
 pub type PreambleErrorCallback = Arc<dyn Fn(&DecodeError) + Send + Sync>;
@@ -167,7 +175,10 @@ where
     #[must_use]
     pub fn on_preamble_decode_success<H>(mut self, handler: H) -> Self
     where
-        H: Fn(&T) + Send + Sync + 'static,
+        H: for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
+            + Send
+            + Sync
+            + 'static,
     {
         self.on_preamble_success = Some(Arc::new(handler));
         self
@@ -420,8 +431,10 @@ async fn process_stream<F, T>(
 {
     match read_preamble::<_, T>(&mut stream).await {
         Ok((preamble, leftover)) => {
-            if let Some(handler) = on_success.as_ref() {
-                handler(&preamble);
+            if let Some(handler) = on_success.as_ref()
+                && let Err(e) = handler(&preamble, &mut stream).await
+            {
+                eprintln!("preamble callback error: {e}");
             }
             let stream = RewindStream::new(leftover, stream);
             // Hand the connection to the application for processing.
@@ -597,8 +610,12 @@ mod tests {
         let counter_clone = callback_counter.clone();
 
         let server = server_with_preamble(factory).on_preamble_decode_success(
-            move |_preamble: &TestPreamble| {
-                counter_clone.fetch_add(1, Ordering::SeqCst);
+            move |_preamble: &TestPreamble, _| {
+                let cnt = counter_clone.clone();
+                Box::pin(async move {
+                    cnt.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
             },
         );
 
@@ -636,8 +653,12 @@ mod tests {
         let server = WireframeServer::new(factory)
             .workers(2)
             .with_preamble::<TestPreamble>()
-            .on_preamble_decode_success(move |_: &TestPreamble| {
-                counter_clone.fetch_add(1, Ordering::SeqCst);
+            .on_preamble_decode_success(move |_: &TestPreamble, _| {
+                let cnt = counter_clone.clone();
+                Box::pin(async move {
+                    cnt.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                })
             })
             .on_preamble_decode_failure(|_: &DecodeError| {
                 eprintln!("Preamble decode failed");
@@ -781,7 +802,7 @@ mod tests {
         factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
     ) {
         let server = WireframeServer::new(factory)
-            .on_preamble_decode_success(|&()| {})
+            .on_preamble_decode_success(|&(), _| Box::pin(async { Ok(()) }))
             .on_preamble_decode_failure(|_: &DecodeError| {});
 
         assert!(server.on_preamble_success.is_some());


### PR DESCRIPTION
## Summary
- support async preamble success callbacks that can write to the stream
- document the new callback behaviour in preamble-validator
- test writing to the connection during the preamble phase
- extract server factory fixture in preamble tests for brevity
- simplify preamble tests with helper functions

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685729a4c1748322a90aa31ac01264ff

## Summary by Sourcery

Enable asynchronous preamble success callbacks to send responses on the stream before handing off connections and update related tests and documentation.

Enhancements:
- Allow preamble success callbacks to perform async I/O on the TCP stream and return a future
- Change PreambleCallback signature to accept a mutable Tokio TcpStream and return a BoxFuture
- Modify process_stream to await the callback and log any errors

Documentation:
- Update sequence diagram and narrative in preamble-validator documentation to describe optional callback responses

Tests:
- Refactor preamble tests with fixtures and helper functions for server setup and execution
- Add a test to verify that a success callback can write data back to the client during the preamble phase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated sequence diagram and expanded explanation to clarify that the success callback can send an optional response to the client after decoding the preamble.
- **New Features**
	- The success callback for preamble decoding is now asynchronous and can perform I/O on the TCP stream, such as sending a handshake response before connection handoff.
- **Tests**
	- Refactored and extended preamble tests to support asynchronous callbacks and verify that responses can be written in the success callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->