### PR TITLE
Add generic envelope support

### DIFF
--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -364,6 +364,24 @@ handling to be managed and customized independently.
    payload. c. This payload is given to the **Framing Layer** to be encapsulated
    in a frame. d. The framed bytes are sent via the **Transport Layer Adapter**.
 
+```mermaid
+sequenceDiagram
+    participant Client
+    participant WireframeApp
+    participant Middleware
+    participant HandlerService
+    participant Handler
+
+    Client->>WireframeApp: Send frame (bytes)
+    WireframeApp->>WireframeApp: Deserialize to E: Packet
+    WireframeApp->>Middleware: Pass envelope (E)
+    Middleware->>HandlerService: Pass envelope (E)
+    HandlerService->>Handler: Call handler with &E
+    Handler-->>HandlerService: Return response (bytes)
+    HandlerService->>WireframeApp: Construct response envelope (E::from_parts)
+    WireframeApp->>Client: Send response frame (bytes)
+```
+
 This layered architecture mirrors the conceptual separation found in network
 protocol stacks, such as the OSI or TCP/IP models.28 Each component addresses a
 distinct set of problems. This modularity is fundamental to managing the overall

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,8 +139,35 @@ impl From<io::Error> for SendError {
 
 /// Envelope-like type used to wrap incoming and outgoing messages.
 ///
-/// Custom envelope types must implement this trait so `WireframeApp` can route
-/// messages and construct responses.
+/// Custom envelope types must implement this trait so [`WireframeApp`] can
+/// route messages and construct responses.
+///
+/// # Example
+///
+/// ```
+/// use wireframe::{app::Packet, message::Message};
+///
+/// #[derive(bincode::Decode, bincode::Encode)]
+/// struct CustomEnvelope {
+///     id: u32,
+///     payload: Vec<u8>,
+///     timestamp: u64,
+/// }
+///
+/// impl Packet for CustomEnvelope {
+///     fn id(&self) -> u32 { self.id }
+///
+///     fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.payload) }
+///
+///     fn from_parts(id: u32, msg: Vec<u8>) -> Self {
+///         Self {
+///             id,
+///             payload: msg,
+///             timestamp: 0,
+///         }
+///     }
+/// }
+/// ```
 pub trait Packet: Message + Send + Sync + 'static {
     /// Return the message identifier used for routing.
     fn id(&self) -> u32;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -220,6 +220,7 @@ use crate::app::{Handler, Packet};
 pub struct HandlerService<E: Packet> {
     id: u32,
     svc: Box<dyn Service<Error = Infallible> + Send + Sync>,
+    /// Marker to bind the generic parameter `E` without storing a value.
     _marker: std::marker::PhantomData<E>,
 }
 

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -31,10 +31,10 @@ where
 }
 
 #[async_trait]
-impl Transform<HandlerService> for TagMiddleware {
-    type Output = HandlerService;
+impl Transform<HandlerService<Envelope>> for TagMiddleware {
+    type Output = HandlerService<Envelope>;
 
-    async fn transform(&self, service: HandlerService) -> Self::Output {
+    async fn transform(&self, service: HandlerService<Envelope>) -> Self::Output {
         let id = service.id();
         HandlerService::from_service(
             id,
@@ -48,7 +48,7 @@ impl Transform<HandlerService> for TagMiddleware {
 
 #[tokio::test]
 async fn middleware_applied_in_reverse_order() {
-    let handler: Handler = std::sync::Arc::new(|_env: &Envelope| Box::pin(async {}));
+    let handler: Handler<Envelope> = std::sync::Arc::new(|_env: &Envelope| Box::pin(async {}));
     let app = WireframeApp::new()
         .unwrap()
         .route(1, handler)

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,6 +1,10 @@
 use rstest::fixture;
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt, duplex};
-use wireframe::{app::WireframeApp, frame::LengthPrefixedProcessor};
+use wireframe::{
+    app::{Packet, WireframeApp},
+    frame::LengthPrefixedProcessor,
+    serializer::Serializer,
+};
 
 /// Feed a single frame into `app` and collect the response bytes.
 ///
@@ -27,7 +31,15 @@ pub fn processor() -> LengthPrefixedProcessor {
 ///
 /// Returns any I/O errors encountered while interacting with the in-memory
 /// duplex stream.
-pub async fn run_app_with_frame(app: WireframeApp, frame: Vec<u8>) -> io::Result<Vec<u8>> {
+pub async fn run_app_with_frame<S, C, E>(
+    app: WireframeApp<S, C, E>,
+    frame: Vec<u8>,
+) -> io::Result<Vec<u8>>
+where
+    S: Serializer + Send + Sync + 'static,
+    C: Send + 'static,
+    E: Packet,
+{
     run_app_with_frame_with_capacity(app, frame, DEFAULT_CAPACITY).await
 }
 
@@ -40,11 +52,16 @@ pub async fn run_app_with_frame(app: WireframeApp, frame: Vec<u8>) -> io::Result
 /// # Panics
 ///
 /// Panics if the spawned task running the application panics.
-pub async fn run_app_with_frame_with_capacity(
-    app: WireframeApp,
+pub async fn run_app_with_frame_with_capacity<S, C, E>(
+    app: WireframeApp<S, C, E>,
     frame: Vec<u8>,
     capacity: usize,
-) -> io::Result<Vec<u8>> {
+) -> io::Result<Vec<u8>>
+where
+    S: Serializer + Send + Sync + 'static,
+    C: Send + 'static,
+    E: Packet,
+{
     run_app_with_frames_with_capacity(app, vec![frame], capacity).await
 }
 
@@ -54,7 +71,15 @@ pub async fn run_app_with_frame_with_capacity(
 ///
 /// Returns any I/O errors encountered while interacting with the in-memory
 /// duplex stream.
-pub async fn run_app_with_frames(app: WireframeApp, frames: Vec<Vec<u8>>) -> io::Result<Vec<u8>> {
+pub async fn run_app_with_frames<S, C, E>(
+    app: WireframeApp<S, C, E>,
+    frames: Vec<Vec<u8>>,
+) -> io::Result<Vec<u8>>
+where
+    S: Serializer + Send + Sync + 'static,
+    C: Send + 'static,
+    E: Packet,
+{
     run_app_with_frames_with_capacity(app, frames, DEFAULT_CAPACITY).await
 }
 
@@ -67,11 +92,16 @@ pub async fn run_app_with_frames(app: WireframeApp, frames: Vec<Vec<u8>>) -> io:
 /// # Panics
 ///
 /// Panics if the spawned task running the application panics.
-pub async fn run_app_with_frames_with_capacity(
-    app: WireframeApp,
+pub async fn run_app_with_frames_with_capacity<S, C, E>(
+    app: WireframeApp<S, C, E>,
     frames: Vec<Vec<u8>>,
     capacity: usize,
-) -> io::Result<Vec<u8>> {
+) -> io::Result<Vec<u8>>
+where
+    S: Serializer + Send + Sync + 'static,
+    C: Send + 'static,
+    E: Packet,
+{
     let (mut client, server) = duplex(capacity);
     let server_task = tokio::spawn(async move {
         app.handle_connection(server).await;


### PR DESCRIPTION
## Summary
- make envelope type generic via `Packet` trait
- provide `new_with_envelope` constructor
- update middleware and tests for generic envelopes
- document custom envelopes in README

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6857449705c08322bd5082fc1489fb35

## Summary by Sourcery

Enable custom envelope formats by defining a Packet trait and making the application, handlers, middleware, and utilities generic over that trait; provide a new_with_envelope constructor and document the feature with examples.

New Features:
- Introduce Packet trait for generic envelope types.
- Parameterize WireframeApp, Handler, Middleware, and related components over a Packet type.
- Add new_with_envelope constructor to support custom envelope types.

Enhancements:
- Refactor frame deserialization and response serialization to use the Packet trait generically.
- Generalize middleware, handler service, and utility functions to be generic over envelope types.
- Update tests and utilities to accept WireframeApp with custom envelope parameter.

Documentation:
- Document custom envelope usage and examples in README and architecture design docs.

Tests:
- Extend test routes and middleware tests to verify custom Packet implementations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for custom envelope types, allowing applications to use their own packet formats by implementing a new trait.
- **Documentation**
  - Added a comprehensive section to the README explaining how to use custom envelopes, including example code and integration guidance.
- **Refactor**
  - Generalised core types and methods to support arbitrary envelope types, enhancing flexibility across the application and middleware layers.
- **Tests**
  - Updated and extended tests to validate functionality with custom envelope types and ensure compatibility with the new trait-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->