### PR TITLE
Add post-1.0 note for message versioning

### DIFF
--- a/docs/message-versioning.md
+++ b/docs/message-versioning.md
@@ -1,10 +1,11 @@
 # Message Versioning and Compatibility
 
-> **Status:** Targeted for a post-1.0 release
+> **Status:** Targeted for a post-1.0 release — see the
+> [schema evolution roadmap item](roadmap.md#4-extended-features) for progress.
 
 ## Motivation
 
-Binary protocols often evolve over time. New features require changes to message
+Binary protocols often evolve. New features require changes to message
 structures, while older clients may still be deployed in the field. `wireframe`
 needs a strategy to support multiple message versions without breaking
 compatibility.
@@ -13,8 +14,7 @@ compatibility.
 
 - **Version negotiation**: Determine a mutually supported protocol version when
   a client connects.
-- **Per-message versions**: Allow individual message types to define their own
-  version numbers.
+- **Per-message versions**: Allow message types to define version numbers.
 - **Compatibility checks**: Detect incompatible versions at runtime and surface
   meaningful errors.
 - **Ergonomic API**: Provide Actix-like helpers for routing and version guards.
@@ -45,13 +45,13 @@ Extend `Envelope` with an optional `version` field:
 ```rust
 pub struct Envelope {
     id: u32,
-    version: u16,
+    version: Option<u16>,
     msg: Vec<u8>,
 }
 ```
 
 The serializer will encode and decode this field transparently. Older clients
-that lack a version field will default to `0`.
+that lack a version field will represent it as `None`.
 
 ### 3. Version Guards
 

--- a/docs/message-versioning.md
+++ b/docs/message-versioning.md
@@ -1,0 +1,96 @@
+# Message Versioning and Compatibility
+
+> **Status:** Targeted for a post-1.0 release
+
+## Motivation
+
+Binary protocols often evolve over time. New features require changes to message
+structures, while older clients may still be deployed in the field. `wireframe`
+needs a strategy to support multiple message versions without breaking
+compatibility.
+
+## Goals
+
+- **Version negotiation**: Determine a mutually supported protocol version when
+  a client connects.
+- **Per-message versions**: Allow individual message types to define their own
+  version numbers.
+- **Compatibility checks**: Detect incompatible versions at runtime and surface
+  meaningful errors.
+- **Ergonomic API**: Provide Actix-like helpers for routing and version guards.
+
+## Actix Web Inspiration
+
+Actix Web uses "scopes" and guards to group endpoints by path or header values.
+A similar approach can work for binary protocols: routes can be grouped under a
+`VersionScope`, and a custom guard can inspect a version field before dispatch.
+
+## Proposed Design
+
+### 1. VersionedMessage Trait
+
+```rust
+pub trait VersionedMessage: Message {
+    const VERSION: u16;
+}
+```
+
+Derive macros will implement this trait for message structs. Handlers can then
+declare their expected version by accepting `VersionedMessage` types.
+
+### 2. Envelope Extensions
+
+Extend `Envelope` with an optional `version` field:
+
+```rust
+pub struct Envelope {
+    id: u32,
+    version: u16,
+    msg: Vec<u8>,
+}
+```
+
+The serializer will encode and decode this field transparently. Older clients
+that lack a version field will default to `0`.
+
+### 3. Version Guards
+
+Introduce a `version_guard` method on `WireframeApp` to register handlers for a
+specific version. Internally this works like Actix Web's `scope` with a guard:
+
+```rust
+app.version_guard(2).route(MessageId::Login, handle_login_v2);
+```
+
+If a message's version does not match any registered guard, a configurable
+fallback handler can respond with an error.
+
+### 4. Compatibility Checks
+
+Handlers for newer versions can implement `From<OldVersion>` to convert legacy
+messages. A helper `ensure_compatible` function will attempt the conversion when
+a mismatched version is received.
+
+```rust
+async fn handle_login_v2(req: Message<LoginV2>) { /* ... */ }
+
+app.version_guard(1).route(MessageId::Login, |m: Message<LoginV1>| {
+    let upgraded: LoginV2 = m.into();
+    handle_login_v2(Message(upgraded))
+});
+```
+
+### 5. Handshake Negotiation
+
+During the optional connection preamble, both sides can exchange the highest
+protocol version they support. The server selects a version and stores it in the
+connection state so extractors and middleware can access it. If no compatible
+version exists, the connection is rejected early.
+
+## Future Work
+
+- The features described in this document are considered post-1.0 scope.
+- Tooling to generate migration code between versions.
+- Optional compile-time features for strict version matching or automatic
+  upgrades.
+- Documentation examples showing how to deprecate old versions gracefully.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,8 +124,8 @@ after formatting. Line numbers below refer to that file.
 
 - [ ] Add UDP and other transport implementations (lines 1366-1379).
 - [ ] Develop built-in `FrameProcessor` variants (lines 1381-1389).
-- [ ] Address schema evolution and versioning strategies (post-1.0, lines
-  1394-1409).
+- [ ] Address schema evolution and versioning strategies
+  ([design](message-versioning.md), post-1.0, lines 1394-1409).
 - [ ] Investigate multiplexing and flow control mechanisms (lines 1411-1422).
 
 ## 5. Developer Tooling

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,7 +124,8 @@ after formatting. Line numbers below refer to that file.
 
 - [ ] Add UDP and other transport implementations (lines 1366-1379).
 - [ ] Develop built-in `FrameProcessor` variants (lines 1381-1389).
-- [ ] Address schema evolution and versioning strategies (lines 1394-1409).
+- [ ] Address schema evolution and versioning strategies (post-1.0, lines
+  1394-1409).
 - [ ] Investigate multiplexing and flow control mechanisms (lines 1411-1422).
 
 ## 5. Developer Tooling


### PR DESCRIPTION
## Summary
- mark versioning design as post-1.0
- update roadmap item for schema evolution

## Testing
- `mdformat-all docs/message-versioning.md docs/*.md`
- `markdownlint --fix AGENTS.md CHANGELOG.md README.md docs/message-versioning.md docs/mocking-network-outages-in-rust.md docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md`
- `nixie docs/preamble-validator.md docs/rust-binary-router-library-design.md docs/message-versioning.md`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685725cf009c8322bd4fc20315c16dc7

## Summary by Sourcery

Document the message versioning and compatibility strategy as a post-1.0 feature and update the roadmap accordingly.

Documentation:
- Mark the schema evolution and versioning roadmap item as post-1.0
- Add a new "Message Versioning and Compatibility" guide outlining version negotiation, per-message versions, compatibility checks, API design, handshake negotiation, and future work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Introduced a new design document detailing message versioning and compatibility strategies for future releases, including version negotiation, per-message versioning, and compatibility checks.
  - Updated the roadmap to clarify that schema evolution and versioning strategies are planned for after the 1.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->