### PR TITLE
Add client support design

### DIFF
--- a/docs/wireframe-client-design.md
+++ b/docs/wireframe-client-design.md
@@ -23,7 +23,7 @@ A new `WireframeClient` type manages a single connection to a server. It mirrors
 `WireframeServer` but operates in the opposite direction:
 
 - Connect to a `TcpStream`.
-- Optionally send a preamble using the existing `Preamble` helpers.
+- Optionally, send a preamble using the existing `Preamble` helpers.
 - Encode outgoing messages using the selected `Serializer` and `FrameProcessor`.
 - Decode incoming frames into typed responses.
 - Expose async `send` and `receive` operations.

--- a/docs/wireframe-client-design.md
+++ b/docs/wireframe-client-design.md
@@ -1,0 +1,95 @@
+# Client Support in Wireframe
+
+This document proposes an initial design for adding client-side protocol support
+to `wireframe`. The goal is to reuse the existing framing, serialization, and
+message abstractions while providing a small API for connecting to a server and
+exchanging messages.
+
+## Motivation
+
+The library currently focuses on server development. However, the core layers
+are intentionally generic: transport adapters, framing, serialization, routing,
+and middleware form a pipeline that is largely independent of server-specific
+logic. The design document outlines these layers, which process frames from raw
+bytes to typed messages and back
+again【F:docs/rust-binary-router-library-design.md†L316-L371】. By reusing these
+pieces, we can implement a lightweight client without duplicating protocol code.
+
+## Core Components
+
+### `WireframeClient`
+
+A new `WireframeClient` type manages a single connection to a server. It mirrors
+`WireframeServer` but operates in the opposite direction:
+
+- Connect to a `TcpStream`.
+- Optionally send a preamble using the existing `Preamble` helpers.
+- Encode outgoing messages using the selected `Serializer` and `FrameProcessor`.
+- Decode incoming frames into typed responses.
+- Expose async `send` and `receive` operations.
+
+### Builder Pattern
+
+A `WireframeClient::builder()` method configures the client:
+
+```rust
+let client = WireframeClient::builder()
+    .frame_processor(LengthPrefixedProcessor::new(LengthFormat::u32_be()))
+    .serializer(BincodeSerializer)
+    .connect("127.0.0.1:7878")
+    .await?;
+```
+
+The same `FrameProcessor` and `Serializer` traits used by the server are reused
+here, ensuring messages are framed and encoded consistently.
+
+### Request/Response Helpers
+
+To keep the API simple, `WireframeClient` offers a `call` method that sends a
+message implementing `Message` and waits for the next response frame:
+
+```rust
+let request = Login { username: "guest".into() };
+let response: LoginAck = client.call(request).await?;
+```
+
+Internally, this uses the `Serializer` to encode the request, writes it through
+the `FrameProcessor`, then waits for a frame, decodes it, and deserializes the
+response type.
+
+### Connection Lifecycle
+
+Like the server, the client should expose hooks for connection setup and
+teardown. These mirror the server’s lifecycle callbacks so both sides can share
+initialization logic.
+
+## Example Usage
+
+```rust
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut client = WireframeClient::builder()
+        .frame_processor(LengthPrefixedProcessor::new(LengthFormat::u32_be()))
+        .serializer(BincodeSerializer)
+        .connect("127.0.0.1:7878")
+        .await?;
+
+    let login = Login { username: "guest".into() };
+    let ack: LoginAck = client.call(login).await?;
+    println!("logged in: {:?}", ack);
+    Ok(())
+}
+```
+
+## Future Work
+
+This initial design focuses on a basic request/response workflow. Future
+extensions might include:
+
+- Middleware support for outgoing and incoming frames.
+- Connection pooling for protocols that open multiple simultaneous connections.
+- Helper traits for streaming or multiplexed protocols.
+
+By leveraging the existing abstractions for framing and serialization, client
+support can share most of the server’s implementation while providing a small
+ergonomic API.

--- a/docs/wireframe-testing-crate.md
+++ b/docs/wireframe-testing-crate.md
@@ -71,10 +71,10 @@ write the provided frame(s) to the client side of the stream. After the app
 finishes processing, the helpers collect the bytes written back and return them
 for inspection.
 
-Any I/O errors surfaced by the duplex stream or failures while decoding a
-length prefix propagate through the returned `IoResult`. Malformed or
-truncated frames therefore cause the future to resolve with an error,
-allowing tests to assert on these failure conditions directly.
+Any I/O errors surfaced by the duplex stream or failures while decoding a length
+prefix propagate through the returned `IoResult`. Malformed or truncated frames
+therefore cause the future to resolve with an error, allowing tests to assert on
+these failure conditions directly.
 
 ### Custom Buffer Capacity
 

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -55,10 +55,10 @@ where
 }
 
 #[async_trait]
-impl Transform<HandlerService> for DecodeMiddleware {
-    type Output = HandlerService;
+impl Transform<HandlerService<Envelope>> for DecodeMiddleware {
+    type Output = HandlerService<Envelope>;
 
-    async fn transform(&self, service: HandlerService) -> Self::Output {
+    async fn transform(&self, service: HandlerService<Envelope>) -> Self::Output {
         let id = service.id();
         HandlerService::from_service(id, DecodeService { inner: service })
     }


### PR DESCRIPTION
## Summary
- document proposed design for client support
- fix example compile error
- update docs formatting

## Testing
- `mdformat-all`
- `markdownlint --fix`
- `nixie docs/wireframe-client-design.md`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6857f0ca578c832289a329aeb510ad5a

## Summary by Sourcery

Propose initial client-side support design via a new documentation file, correct an example’s type parameters, and refine existing docs formatting

Bug Fixes:
- Fix example compile error in packet_enum.rs by specifying HandlerService<Envelope> generic

Enhancements:
- Reflow and wrap paragraphs in wireframe-testing-crate documentation

Documentation:
- Add design document for client-side wireframe support detailing WireframeClient API, builder pattern, request/response helpers, and lifecycle hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new design proposal document outlining client-side protocol support for the library, including the introduction of a `WireframeClient` type and example usage.
  - Improved formatting in the testing documentation for better readability.

- **Refactor**
  - Updated trait implementations in the example to improve type safety and clarity by making them generic over specific handler types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->