### PR TITLE
Expand examples with routing and middleware demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,37 @@ let logging = from_fn(|req, next| async move {
 });
 ```
 
+## Examples
+
+Example programs are available in the `examples/` directory:
+
+- `echo.rs` — minimal echo server using routing
+- `ping_pong.rs` — showcases serialization and middleware in a ping/pong
+  protocol. See [examples/ping_pong.md](examples/ping_pong.md) for a detailed
+  overview.
+
+Run an example with Cargo:
+
+```bash
+cargo run --example echo
+```
+
+Try the echo server with netcat:
+
+```bash
+$ cargo run --example echo
+# in another terminal
+$ printf '\x00\x00\x00\x00\x01\x00\x00\x00' | nc 127.0.0.1 7878 | xxd
+```
+
+Try the ping‑pong server with netcat:
+
+```bash
+$ cargo run --example ping_pong
+# in another terminal
+$ printf '\x00\x00\x00\x08\x01\x00\x00\x00\x2a\x00\x00\x00' | nc 127.0.0.1 7878 | xxd
+```
+
 ## Current Limitations
 
 Connection handling now processes frames and routes messages, but the server is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -117,7 +117,7 @@ after formatting. Line numbers below refer to that file.
 
 ## 3. Initial Examples and Documentation
 
-- [ ] Provide examples demonstrating routing, serialization, and middleware.
+- [x] Provide examples demonstrating routing, serialization, and middleware.
   Document configuration and usage reflecting the API design section.
 
 ## 4. Extended Features

--- a/examples/ping_pong.md
+++ b/examples/ping_pong.md
@@ -1,0 +1,53 @@
+# Ping-Pong Example
+
+This example demonstrates routing, serialization, and middleware usage in a
+small ping/pong protocol. The server accepts a `Ping` message containing a
+counter and responds with a `Pong` containing the incremented value. Logging
+middleware prints each request and response.
+
+```mermaid
+classDiagram
+    class Ping {
+        +u32 0
+        +to_bytes()
+        +from_bytes()
+    }
+    class Pong {
+        +u32 0
+        +to_bytes()
+        +from_bytes()
+    }
+    class ErrorMsg {
+        +String 0
+        +to_bytes()
+        +from_bytes()
+    }
+    class PongMiddleware {
+    }
+    class PongService {
+        +inner: S
+        +call(req: ServiceRequest) Result<ServiceResponse, Infallible>
+    }
+    class Logging {
+    }
+    class LoggingService {
+        +inner: S
+        +call(req: ServiceRequest) Result<ServiceResponse, Infallible>
+    }
+    class HandlerService {
+        +id()
+        +from_service(id, service)
+    }
+    PongMiddleware --|> Transform
+    PongService --|> Service
+    Logging --|> Transform
+    LoggingService --|> Service
+    HandlerService <.. PongService : inner
+    HandlerService <.. LoggingService : inner
+    PongMiddleware ..> HandlerService : transform
+    Logging ..> HandlerService : transform
+    WireframeApp <.. build_app : factory
+    WireframeServer <.. main : uses
+    build_app --> WireframeApp
+    main --> WireframeServer
+```

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -1,0 +1,148 @@
+use std::{io, net::SocketAddr, sync::Arc};
+
+use async_trait::async_trait;
+use wireframe::{
+    app::{Result as AppResult, WireframeApp},
+    message::Message,
+    middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
+    serializer::BincodeSerializer,
+    server::WireframeServer,
+};
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+struct Ping(u32);
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+struct Pong(u32);
+
+#[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+struct ErrorMsg(String);
+
+fn encode_error(msg: impl Into<String>) -> Vec<u8> {
+    let err = ErrorMsg(msg.into());
+    match err.to_bytes() {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!("failed to encode error: {e:?}");
+            Vec::new()
+        }
+    }
+}
+
+const PING_ID: u32 = 1;
+
+/// Handler invoked for `PING_ID` messages.
+///
+/// The middleware chain generates the actual response, so this
+/// handler intentionally performs no work.
+#[allow(clippy::unused_async)]
+async fn ping_handler() {}
+
+struct PongMiddleware;
+
+struct PongService<S> {
+    inner: S,
+}
+
+#[async_trait]
+impl<S> Service for PongService<S>
+where
+    S: Service<Error = std::convert::Infallible> + Send + Sync + 'static,
+{
+    type Error = std::convert::Infallible;
+
+    async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
+        let (ping_req, _) = match Ping::from_bytes(req.frame()) {
+            Ok(val) => val,
+            Err(e) => {
+                eprintln!("failed to decode ping: {e:?}");
+                return Ok(ServiceResponse::new(encode_error(format!(
+                    "decode error: {e:?}"
+                ))));
+            }
+        };
+        let mut response = self.inner.call(req).await?;
+        let pong_resp = if let Some(v) = ping_req.0.checked_add(1) {
+            Pong(v)
+        } else {
+            eprintln!("ping overflowed at {}", ping_req.0);
+            return Ok(ServiceResponse::new(encode_error("overflow")));
+        };
+        match pong_resp.to_bytes() {
+            Ok(bytes) => *response.frame_mut() = bytes,
+            Err(e) => {
+                eprintln!("failed to encode pong: {e:?}");
+                return Ok(ServiceResponse::new(encode_error(format!(
+                    "encode error: {e:?}"
+                ))));
+            }
+        }
+        Ok(response)
+    }
+}
+
+#[async_trait]
+impl Transform<HandlerService> for PongMiddleware {
+    type Output = HandlerService;
+
+    // `HandlerService` is a boxed trait object without generic parameters,
+    // so the transform signature uses the concrete type directly.
+    async fn transform(&self, service: HandlerService) -> Self::Output {
+        let id = service.id();
+        HandlerService::from_service(id, PongService { inner: service })
+    }
+}
+
+struct Logging;
+
+struct LoggingService<S> {
+    inner: S,
+}
+
+#[async_trait]
+impl<S> Service for LoggingService<S>
+where
+    S: Service<Error = std::convert::Infallible> + Send + Sync + 'static,
+{
+    type Error = std::convert::Infallible;
+
+    async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
+        println!("request: {:?}", req.frame());
+        let resp = self.inner.call(req).await?;
+        println!("response: {:?}", resp.frame());
+        Ok(resp)
+    }
+}
+
+#[async_trait]
+impl Transform<HandlerService> for Logging {
+    type Output = HandlerService;
+
+    // `HandlerService` is a concrete type, not a generic wrapper.
+    async fn transform(&self, service: HandlerService) -> Self::Output {
+        let id = service.id();
+        HandlerService::from_service(id, LoggingService { inner: service })
+    }
+}
+
+fn build_app() -> AppResult<WireframeApp> {
+    WireframeApp::new()?
+        .serializer(BincodeSerializer)
+        .route(PING_ID, Arc::new(|_| Box::pin(ping_handler())))?
+        .wrap(PongMiddleware)?
+        .wrap(Logging)
+}
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let factory = || build_app().expect("app build failed");
+
+    let default_addr = "127.0.0.1:7878";
+    let addr_str = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| default_addr.into());
+    let addr: SocketAddr = addr_str
+        .parse()
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
+    WireframeServer::new(factory).bind(addr)?.run().await
+}


### PR DESCRIPTION
## Summary
- add run instructions for echo example
- avoid duplication when encoding error messages
- allow bind address override when running ping-pong example
- document ping_pong example structure in examples/ping_pong.md
- link ping_pong docs from README and use em dashes
- clarify that `HandlerService` isn’t generic when wrapping services
- show netcat usage for the echo example

## Testing
- `mdformat-all README.md docs/*.md examples/ping_pong.rs examples/echo.rs examples/ping_pong.md`
- `markdownlint --fix AGENTS.md CHANGELOG.md README.md docs/mocking-network-outages-in-rust.md docs/preamble-validator.md docs/roadmap.md docs/rust-binary-router-library-design.md docs/rust-testing-with-rstest-fixtures.md examples/ping_pong.md`
- `nixie README.md docs/*.md examples/ping_pong.md`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6857265325588322a829a52b18a77a13

## Summary by Sourcery

Provide a new ping-pong example with configurable server address and improved error handling, enhance the echo example instructions, and update related documentation accordingly.

New Features:
- Add a new ping-pong example demonstrating routing, serialization, and middleware

Enhancements:
- Allow overriding the bind address via command-line argument in the ping-pong example
- Centralize error message encoding into a helper to avoid duplication

Documentation:
- Introduce an examples section in README with run instructions and netcat usage for echo and ping-pong servers
- Add detailed documentation for the ping-pong example in examples/ping_pong.md
- Update the project roadmap to mark the initial examples as completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an "Examples" section to the documentation, providing guidance on running and testing example programmes.
  - Introduced a detailed example file demonstrating a ping/pong protocol with routing, serialisation, and middleware, including class diagrams and usage explanations.
  - Updated the project roadmap to reflect completion of initial examples and documentation tasks.

- **New Features**
  - Added a ping-pong server example showcasing message handling, middleware, and logging for users to reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->