### PR TITLE
Implement prioritized push queues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,6 @@ pub mod frame;
 pub mod message;
 pub mod middleware;
 pub mod preamble;
+pub mod push;
 pub mod rewind_stream;
 pub mod server;

--- a/src/push.rs
+++ b/src/push.rs
@@ -109,7 +109,7 @@ impl<F: FrameLike> PushHandle<F> {
                 PushPolicy::ReturnErrorIfFull => Err(PushError::QueueFull),
                 PushPolicy::DropIfFull => Ok(()),
                 PushPolicy::WarnAndDropIfFull => {
-                    log::warn!("push queue full; dropping frame");
+                    log::warn!("push queue full; dropping {priority:?} priority frame");
                     Ok(())
                 }
             },

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,0 +1,146 @@
+//! Prioritized queues used for asynchronously pushing frames to a connection.
+//!
+//! `PushQueues` maintain separate high- and low-priority channels so
+//! background tasks can send messages without blocking the request/response
+//! cycle. Producers interact with these queues through a cloneable
+//! [`PushHandle`]. Queued frames are delivered in FIFO order within each
+//! priority level.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+/// Messages can be sent through a [`PushHandle`].
+///
+/// The trait is intentionally empty: any type that is `Send` and `'static`
+/// is considered a valid frame for pushing to a connection.
+pub trait FrameLike: Send + 'static {}
+
+impl<T> FrameLike for T where T: Send + 'static {}
+
+/// Priority level for outbound messages.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PushPriority {
+    High,
+    Low,
+}
+
+/// Behaviour when a push queue is full.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PushPolicy {
+    /// Return an error to the caller if the queue is full.
+    ReturnErrorIfFull,
+    /// Silently drop the frame.
+    DropIfFull,
+    /// Drop the frame but emit a log warning.
+    WarnAndDropIfFull,
+}
+
+/// Errors that can occur when pushing a frame.
+#[derive(Debug)]
+pub enum PushError {
+    /// The queue was at capacity and the policy was `ReturnErrorIfFull`.
+    QueueFull,
+    /// The receiving end of the queue has been dropped.
+    Closed,
+}
+
+struct PushHandleInner<F> {
+    high_prio_tx: mpsc::Sender<F>,
+    low_prio_tx: mpsc::Sender<F>,
+}
+
+/// Cloneable handle used by producers to push frames to a connection.
+#[derive(Clone)]
+pub struct PushHandle<F>(Arc<PushHandleInner<F>>);
+
+impl<F: FrameLike> PushHandle<F> {
+    /// Push a high-priority frame.
+    ///
+    /// Awaits if the queue is full.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PushError::Closed`] if the receiving end has been dropped.
+    pub async fn push_high_priority(&self, frame: F) -> Result<(), PushError> {
+        self.0
+            .high_prio_tx
+            .send(frame)
+            .await
+            .map_err(|_| PushError::Closed)
+    }
+
+    /// Push a low-priority frame.
+    ///
+    /// Awaits if the queue is full.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PushError::Closed`] if the receiving end has been dropped.
+    pub async fn push_low_priority(&self, frame: F) -> Result<(), PushError> {
+        self.0
+            .low_prio_tx
+            .send(frame)
+            .await
+            .map_err(|_| PushError::Closed)
+    }
+
+    /// Attempt to push a frame with the given priority and policy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PushError::QueueFull`] if the queue is full and the policy is
+    /// [`PushPolicy::ReturnErrorIfFull`]. Returns [`PushError::Closed`] if the
+    /// receiving end has been dropped.
+    pub fn try_push(
+        &self,
+        frame: F,
+        priority: PushPriority,
+        policy: PushPolicy,
+    ) -> Result<(), PushError> {
+        let tx = match priority {
+            PushPriority::High => &self.0.high_prio_tx,
+            PushPriority::Low => &self.0.low_prio_tx,
+        };
+
+        match tx.try_send(frame) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(_f)) => match policy {
+                PushPolicy::ReturnErrorIfFull => Err(PushError::QueueFull),
+                PushPolicy::DropIfFull => Ok(()),
+                PushPolicy::WarnAndDropIfFull => {
+                    log::warn!("push queue full; dropping frame");
+                    Ok(())
+                }
+            },
+            Err(mpsc::error::TrySendError::Closed(_)) => Err(PushError::Closed),
+        }
+    }
+}
+
+/// Receiver ends of the push queues stored by the connection actor.
+pub struct PushQueues<F> {
+    pub high_priority_rx: mpsc::Receiver<F>,
+    pub low_priority_rx: mpsc::Receiver<F>,
+}
+
+impl<F: FrameLike> PushQueues<F> {
+    /// Create a new set of queues with the specified bound and return them along
+    /// with a [`PushHandle`] for producers.
+    #[must_use]
+    pub fn bounded(capacity: usize) -> (Self, PushHandle<F>) {
+        let (high_tx, high_rx) = mpsc::channel(capacity);
+        let (low_tx, low_rx) = mpsc::channel(capacity);
+        let inner = PushHandleInner {
+            high_prio_tx: high_tx,
+            low_prio_tx: low_tx,
+        };
+        (
+            Self {
+                high_priority_rx: high_rx,
+                low_priority_rx: low_rx,
+            },
+            PushHandle(Arc::new(inner)),
+        )
+    }
+}

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,0 +1,30 @@
+use wireframe::push::{PushPolicy, PushPriority, PushQueues};
+
+#[tokio::test]
+async fn push_queues_preserve_priority_order() {
+    let (mut queues, handle) = PushQueues::bounded(1);
+
+    handle.push_low_priority(1u8).await.unwrap();
+    handle.push_high_priority(2u8).await.unwrap();
+
+    let high = queues.high_priority_rx.recv().await;
+    let low = queues.low_priority_rx.recv().await;
+
+    assert_eq!(high, Some(2));
+    assert_eq!(low, Some(1));
+}
+
+#[tokio::test]
+async fn try_push_respects_policy() {
+    let (mut queues, handle) = PushQueues::bounded(1);
+
+    handle.push_high_priority(1u8).await.unwrap();
+    let result = handle.try_push(2u8, PushPriority::High, PushPolicy::ReturnErrorIfFull);
+    assert!(result.is_err());
+
+    // drain queue to allow new push
+    let _ = queues.high_priority_rx.recv().await;
+    handle.push_high_priority(3u8).await.unwrap();
+    let last = queues.high_priority_rx.recv().await;
+    assert_eq!(last, Some(3));
+}

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -2,36 +2,38 @@ use wireframe::push::{PushError, PushPolicy, PushPriority, PushQueues};
 
 #[tokio::test]
 async fn frames_routed_to_correct_priority_queues() {
-    let (mut queues, handle) = PushQueues::bounded(1);
+    let (mut queues, handle) = PushQueues::bounded(1, 1);
 
     handle.push_low_priority(1u8).await.unwrap();
     handle.push_high_priority(2u8).await.unwrap();
 
-    let high = queues.high_priority_rx.recv().await;
-    let low = queues.low_priority_rx.recv().await;
+    let (prio1, frame1) = queues.recv().await.unwrap();
+    let (prio2, frame2) = queues.recv().await.unwrap();
 
-    assert_eq!(high, Some(2));
-    assert_eq!(low, Some(1));
+    assert_eq!(prio1, PushPriority::High);
+    assert_eq!(frame1, 2);
+    assert_eq!(prio2, PushPriority::Low);
+    assert_eq!(frame2, 1);
 }
 
 #[tokio::test]
 async fn try_push_respects_policy() {
-    let (mut queues, handle) = PushQueues::bounded(1);
+    let (mut queues, handle) = PushQueues::bounded(1, 1);
 
     handle.push_high_priority(1u8).await.unwrap();
     let result = handle.try_push(2u8, PushPriority::High, PushPolicy::ReturnErrorIfFull);
     assert!(result.is_err());
 
     // drain queue to allow new push
-    let _ = queues.high_priority_rx.recv().await;
+    let _ = queues.recv().await;
     handle.push_high_priority(3u8).await.unwrap();
-    let last = queues.high_priority_rx.recv().await;
-    assert_eq!(last, Some(3));
+    let (_, last) = queues.recv().await.unwrap();
+    assert_eq!(last, 3);
 }
 
 #[tokio::test]
 async fn push_queues_error_on_closed() {
-    let (queues, handle) = PushQueues::bounded(1);
+    let (queues, handle) = PushQueues::bounded(1, 1);
 
     drop(queues.high_priority_rx);
     let res = handle.push_high_priority(42u8).await;

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,7 +1,7 @@
-use wireframe::push::{PushPolicy, PushPriority, PushQueues};
+use wireframe::push::{PushError, PushPolicy, PushPriority, PushQueues};
 
 #[tokio::test]
-async fn push_queues_preserve_priority_order() {
+async fn frames_routed_to_correct_priority_queues() {
     let (mut queues, handle) = PushQueues::bounded(1);
 
     handle.push_low_priority(1u8).await.unwrap();
@@ -27,4 +27,17 @@ async fn try_push_respects_policy() {
     handle.push_high_priority(3u8).await.unwrap();
     let last = queues.high_priority_rx.recv().await;
     assert_eq!(last, Some(3));
+}
+
+#[tokio::test]
+async fn push_queues_error_on_closed() {
+    let (queues, handle) = PushQueues::bounded(1);
+
+    drop(queues.high_priority_rx);
+    let res = handle.push_high_priority(42u8).await;
+    assert!(matches!(res, Err(PushError::Closed)));
+
+    drop(queues.low_priority_rx);
+    let res = handle.push_low_priority(24u8).await;
+    assert!(matches!(res, Err(PushError::Closed)));
 }


### PR DESCRIPTION
## Summary
- add PushHandle and PushQueues for asynchronous message pushes
- expose new push module publicly
- test push queue ordering and policy handling
- document push module purpose and usage

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6858c9e5e76c8322bf3233f243d846be

## Summary by Sourcery

Implement prioritized push queues to enable non-blocking, priority-aware message pushing with backpressure control

New Features:
- Introduce a `push` module providing `PushQueues` and `PushHandle` for prioritized asynchronous frame dispatch
- Add support for high- and low-priority message channels with configurable overflow policies (`PushPolicy`)

Documentation:
- Document the push module’s purpose and API with mermaid class and flowcharts in the design guide

Tests:
- Add tests to verify priority ordering, policy enforcement on full queues, and error handling on closed channels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced prioritised asynchronous queues for pushing frames, supporting high and low priority levels.
	- Added configurable policies for handling full queues, including error return, silent drop, or warning log.
	- Provided a cloneable handle for producers to asynchronously push frames with chosen priority and policy.
- **Tests**
	- Added tests to verify correct priority ordering and policy handling when queues are full.
- **Documentation**
	- Enhanced asynchronous outbound messaging design docs with diagrams illustrating API structure and runtime flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->