### PR TITLE
Fix asynchronous push docs diagrams

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -211,7 +211,7 @@ treats angle brackets as HTML.
 ```mermaid
 flowchart TD
     Producer[Producer]
-    Handle[PushHandle<F>]
+    Handle[PushHandle~F~]
     HighQueue[High Priority Queue]
     LowQueue[Low Priority Queue]
     Policy[PushPolicy]

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -182,41 +182,46 @@ classDiagram
         high_prio_tx: mpsc::Sender<F>
         low_prio_tx: mpsc::Sender<F>
     }
-    class PushHandle {
+    class PushHandle~F~ {
         +push_high_priority(frame: F): Result<(), PushError>
         +push_low_priority(frame: F): Result<(), PushError>
         +try_push(frame: F, priority: PushPriority, policy: PushPolicy): Result<(), PushError>
     }
-    class PushQueues {
+    class PushQueues~F~ {
         +high_priority_rx: mpsc::Receiver<F>
         +low_priority_rx: mpsc::Receiver<F>
-        +bounded(high_capacity: usize, low_capacity: usize): (PushQueues, PushHandle)
+        +bounded(high_capacity: usize, low_capacity: usize): (PushQueues, PushHandle~F~)
         +recv(): Option<(PushPriority, F)>
     }
 
-    PushHandleInner <.. PushHandle : contains
-    PushQueues o-- PushHandle : bounded()
+    PushHandleInner <.. PushHandle~F~ : contains
+    PushQueues~F~ o-- PushHandle~F~ : bounded(capacity: usize)
     PushHandle --> PushPriority
     PushHandle --> PushPolicy
     PushHandle --> PushError
-    PushQueues --> PushHandle
-    PushQueues --> FrameLike
-    PushHandle --> FrameLike
+    PushQueues~F~ --> PushHandle~F~
+    PushQueues~F~ --> FrameLike
+    PushHandle~F~ --> FrameLike
 ```
 
 ```mermaid
 flowchart TD
     Producer[Producer]
-    PushHandle[PushHandle]
+    Handle[PushHandle]
     HighQueue[High Priority Queue]
     LowQueue[Low Priority Queue]
     Policy[PushPolicy]
     Error[PushError or Drop]
 
-    Producer -->|push_high_priority / push_low_priority / try_push| PushHandle
-    PushHandle -->|High| HighQueue
-    PushHandle -->|Low| LowQueue
-    PushHandle -->|If queue full| Policy
+    Producer -->|push_high_priority| Handle
+    Handle --> HighQueue
+    Producer -->|push_low_priority| Handle
+    Handle --> LowQueue
+
+    Producer -->|try_push| Policy
+    Policy -->|Queue available| Handle
+    Handle -->|High| HighQueue
+    Handle -->|Low| LowQueue
     Policy -->|ReturnErrorIfFull| Error
     Policy -->|DropIfFull| Error
     Policy -->|WarnAndDropIfFull| Error

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -24,12 +24,12 @@ protocols.
 
 The implementation must satisfy the following core requirements:
 
-| ID | Requirement                                                                                                                                            |
-| G1 | Any async task must be able to push frames to a live connection.                                                                                       |
-| G2 | Ordering-safety: Pushed frames must interleave correctly with normal request/response traffic and respect any per-message sequencing rules.            |
-| G3 | Back-pressure: Writers must block (or fail fast) when the peer cannot drain the socket, preventing unbounded memory consumption.                       |
-| G4 | Generic—independent of any particular protocol; usable by both servers and clients built on wireframe.                                                 |
-| G5 | Preserve the simple “return a reply” path for code that does not need pushes, ensuring backward compatibility and low friction for existing users.     |
+| ID | Requirement |
+| G1 | Any async task must be able to push frames to a live connection. |
+| G2 | Ordering-safety: Pushed frames must interleave correctly with normal request/response traffic and respect any per-message sequencing rules. |
+| G3 | Back-pressure: Writers must block (or fail fast) when the peer cannot drain the socket, preventing unbounded memory consumption. |
+| G4 | Generic—independent of any particular protocol; usable by both servers and clients built on wireframe. |
+| G5 | Preserve the simple “return a reply” path for code that does not need pushes, ensuring backward compatibility and low friction for existing users. |
 
 ## 3. Core Architecture: The Connection Actor
 
@@ -47,7 +47,7 @@ manage two distinct, bounded `tokio::mpsc` channels for pushed frames:
    messages like heartbeats, session control notifications, or protocol-level
    pings.
 
-2. `low_priority_push_rx: mpsc::Receiver<F>`: For standard, non-urgent
+1. `low_priority_push_rx: mpsc::Receiver<F>`: For standard, non-urgent
    background messages like log forwarding or secondary status updates.
 
 The bounded nature of these channels provides an inherent and robust
@@ -67,13 +67,13 @@ The polling order will be:
 1. **Graceful Shutdown Signal:** The `CancellationToken` will be checked first
    to ensure immediate reaction to a server-wide shutdown request.
 
-2. **High-Priority Push Channel:** Messages from `high_priority_push_rx` will be
+1. **High-Priority Push Channel:** Messages from `high_priority_push_rx` will be
    drained next.
 
-3. **Low-Priority Push Channel:** Messages from `low_priority_push_rx` will be
+1. **Low-Priority Push Channel:** Messages from `low_priority_push_rx` will be
    processed after all high-priority messages.
 
-4. **Handler Response Stream:** Frames from the active request's
+1. **Handler Response Stream:** Frames from the active request's
    `Response::Stream` will be processed last.
 
 Rust
@@ -153,8 +153,8 @@ impl<F: FrameLike> PushHandle<F> {
         &self,
         frame: F,
         priority: PushPriority,
-        policy: PushPolicy
-) -> Result<(), PushError>;
+        policy: PushPolicy,
+    ) -> Result<(), PushError>;
 }
 ```
 
@@ -195,7 +195,7 @@ classDiagram
     }
 
     PushHandleInner <.. PushHandle~F~ : contains
-    PushQueues~F~ o-- PushHandle~F~ : bounded(capacity: usize)
+    PushQueues~F~ o-- PushHandle~F~ : bounded(capacity&#58; usize)
     PushHandle --> PushPriority
     PushHandle --> PushPolicy
     PushHandle --> PushError
@@ -347,10 +347,10 @@ features of the 1.0 release.
 
 ## 7. Measurable Objectives & Success Criteria
 
-| Category        | Objective                                                                                                           | Success Metric                                                                                                                                                                              |
-| API Correctness | The PushHandle, SessionRegistry, and WireframeProtocol trait are implemented exactly as specified in this document. | 100% of the public API surface is present and correctly typed.                                                                                                                              |
-| Functionality   | Pushed frames are delivered reliably and in the correct order of priority.                                          | A test with concurrent high-priority, low-priority, and streaming producers must show that all frames are delivered and that the final written sequence respects the strict priority order. |
-| Back-pressure   | A slow consumer must cause producer tasks to suspend without consuming unbounded memory.                            | A test with a slow consumer and a fast producer must show the producer's push().await call blocks, and the process memory usage remains stable.                                             |
-| Resilience      | The SessionRegistry must not leak memory when connections are terminated.                                           | A long-running test that creates and destroys thousands of connections must show no corresponding growth in the SessionRegistry's size or the process's overall memory footprint.           |
-| Performance     | The overhead of the push mechanism should be minimal for connections that do not use it.                            | A benchmark of a simple request-response workload with the push feature enabled (but unused) should show < 2% performance degradation compared to a build without the feature.              |
-| Performance     | The latency for a high-priority push under no contention should be negligible.                                      | The time from push_high_priority().await returning to the frame being written to the socket buffer should be < 10µs.                                                                        |
+| Category | Objective | Success Metric |
+| API Correctness | The PushHandle, SessionRegistry, and WireframeProtocol trait are implemented exactly as specified in this document. | 100% of the public API surface is present and correctly typed. |
+| Functionality | Pushed frames are delivered reliably and in the correct order of priority. | A test with concurrent high-priority, low-priority, and streaming producers must show that all frames are delivered and that the final written sequence respects the strict priority order. |
+| Back-pressure | A slow consumer must cause producer tasks to suspend without consuming unbounded memory. | A test with a slow consumer and a fast producer must show the producer's push().await call blocks, and the process memory usage remains stable. |
+| Resilience | The SessionRegistry must not leak memory when connections are terminated. | A long-running test that creates and destroys thousands of connections must show no corresponding growth in the SessionRegistry's size or the process's overall memory footprint. |
+| Performance | The overhead of the push mechanism should be minimal for connections that do not use it. | A benchmark of a simple request-response workload with the push feature enabled (but unused) should show < 2% performance degradation compared to a build without the feature. |
+| Performance | The latency for a high-priority push under no contention should be negligible. | The time from push_high_priority().await returning to the frame being written to the socket buffer should be < 10µs. |


### PR DESCRIPTION
## Summary
- clarify generics in the push queue class diagram
- show blocking vs non-blocking push flows

## Testing
- `make lint`
- `make test`
- `markdownlint docs/asynchronous-outbound-messaging-design.md` *(fails: MD013 line length)*
- `nixie docs/asynchronous-outbound-messaging-design.md` *(fails: Parse error)*

------
https://chatgpt.com/codex/tasks/task_e_6859a6628b448322a4b7e5bb40396cee

## Summary by Sourcery

Update asynchronous outbound messaging design documentation to improve clarity and formatting

Documentation:
- Add markdownlint MD013 disable/enable directives around tables and code blocks to suppress line-length warnings
- Use `~F~` placeholder instead of angle brackets in class diagrams to represent generics for Mermaid compatibility
- Revise class and flowchart diagrams to explicitly show high-priority, low-priority, and non-blocking push flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated diagrams and flowcharts to clarify the use of generic types in the asynchronous outbound messaging design.
	- Improved visual representation of method flows and decision points for message handling.
	- Enhanced clarity on the interaction between producers, handles, and policies in the documentation.
	- Improved formatting and readability in key sections, including detailed notes on generic parameter notation in diagrams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->