### PR TITLE
Add logger fixture for push policy tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +214,19 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+dependencies = [
+ "value-bag",
+]
+
+[[package]]
+name = "logtest"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3e43a8657c1d64516dcc9db8ca03826a4aceaf89d5ce1b37b59f6ff0e43026"
+dependencies = [
+ "lazy_static",
+ "log",
+]
 
 [[package]]
 name = "memchr"
@@ -459,6 +478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+
+[[package]]
 name = "virtue"
 version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +586,7 @@ dependencies = [
  "bytes",
  "futures",
  "log",
+ "logtest",
  "rstest",
  "serde",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4"
 [dev-dependencies]
 rstest = "0.18.2"
 wireframe_testing = { path = "./wireframe_testing" }
-logtest = "2"
+logtest = "^2.0"
 
 [lints.clippy]
 pedantic = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 [dev-dependencies]
 rstest = "0.18.2"
 wireframe_testing = { path = "./wireframe_testing" }
+logtest = "2"
 
 [lints.clippy]
 pedantic = "warn"

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1241,8 +1241,14 @@ runs, making it easier to get consistent log output from tests.
 
 `logtest` provides a lightweight logger that records emitted log records during
 tests. This makes it trivial to assert on log messages without interfering with
-other tests. Add it under `[dev-dependencies]` and start a `Logger` before
-running the code under test:
+other tests. Add it under `[dev-dependencies]` using an explicit version range:
+
+```toml
+[dev-dependencies]
+logtest = "^2.0"
+```
+
+Start a `Logger` before running the code under test:
 
 ```rust
 use logtest::Logger;

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1237,7 +1237,25 @@ proper initialization. `rstest-log` likely provides attributes or wrappers to
 ensure that logging is correctly set up before each `rstest`-generated test case
 runs, making it easier to get consistent log output from tests.
 
-### B. `test-with`: Conditional Testing with `rstest`
+### B. `logtest`: Verifying Log Output
+
+`logtest` provides a lightweight logger that records emitted log records during
+tests. This makes it trivial to assert on log messages without interfering with
+other tests. Add it under `[dev-dependencies]` and start a `Logger` before
+running the code under test:
+
+```rust
+use logtest::Logger;
+
+let mut logger = Logger::start();
+my_async_fn().await;
+assert!(logger.pop().is_some());
+```
+
+This crate complements `rstest` nicely when verifying that warnings or errors
+are logged under specific conditions.
+
+### C. `test-with`: Conditional Testing with `rstest`
 
 The `test-with` crate allows for conditional execution of tests based on various
 runtime conditions, such as the presence of environment variables, the existence

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -1,6 +1,6 @@
 //! Tests for push queue policy behaviour.
 
-use std::sync::{Mutex, Once};
+use std::sync::{Mutex, OnceLock};
 
 use logtest::Logger;
 use rstest::{fixture, rstest};
@@ -8,79 +8,61 @@ use wireframe::push::{PushPolicy, PushPriority, PushQueues};
 
 /// Handle to the global logger with exclusive access.
 struct LoggerHandle {
-    _guard: std::sync::MutexGuard<'static, ()>,
-    logger: Logger,
+    guard: std::sync::MutexGuard<'static, Logger>,
 }
 
 impl LoggerHandle {
     fn new() -> Self {
-        static INIT: Once = Once::new();
-        static LOCK: Mutex<()> = Mutex::new(());
+        static LOGGER: OnceLock<Mutex<Logger>> = OnceLock::new();
 
-        let guard = LOCK.lock().expect("lock logger");
-        INIT.call_once(|| {
-            Logger::start();
-        });
+        let logger = LOGGER.get_or_init(|| Mutex::new(Logger::start()));
+        let mut guard = logger.lock().expect("lock logger");
+        while guard.pop().is_some() {}
 
-        let mut logger = Logger;
-        while logger.pop().is_some() {}
-
-        Self {
-            _guard: guard,
-            logger,
-        }
+        Self { guard }
     }
 }
 
 impl std::ops::Deref for LoggerHandle {
     type Target = Logger;
 
-    fn deref(&self) -> &Self::Target { &self.logger }
+    fn deref(&self) -> &Self::Target { &self.guard }
 }
 
 impl std::ops::DerefMut for LoggerHandle {
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.logger }
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.guard }
 }
 
-#[fixture]
-fn rt() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("runtime")
-}
 #[allow(unused_braces)]
 #[fixture]
 fn logger() -> LoggerHandle { LoggerHandle::new() }
 
 #[rstest]
-fn drop_if_full_discards_frame(rt: tokio::runtime::Runtime, mut logger: LoggerHandle) {
-    rt.block_on(async {
-        let (mut queues, handle) = PushQueues::bounded(1, 1);
-        handle.push_high_priority(1u8).await.unwrap();
-        handle
-            .try_push(2u8, PushPriority::High, PushPolicy::DropIfFull)
-            .unwrap();
-        let (_, val) = queues.recv().await.unwrap();
-        assert_eq!(val, 1);
-        assert!(queues.high_priority_rx.try_recv().is_err());
-    });
+#[tokio::test]
+async fn drop_if_full_discards_frame(mut logger: LoggerHandle) {
+    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    handle.push_high_priority(1u8).await.unwrap();
+    handle
+        .try_push(2u8, PushPriority::High, PushPolicy::DropIfFull)
+        .unwrap();
+    let (_, val) = queues.recv().await.unwrap();
+    assert_eq!(val, 1);
+    assert!(queues.high_priority_rx.try_recv().is_err());
 
     assert!(logger.pop().is_none());
 }
 
 #[rstest]
-fn warn_and_drop_if_full_logs_warning(rt: tokio::runtime::Runtime, mut logger: LoggerHandle) {
-    rt.block_on(async {
-        let (mut queues, handle) = PushQueues::bounded(1, 1);
-        handle.push_low_priority(3u8).await.unwrap();
-        handle
-            .try_push(4u8, PushPriority::Low, PushPolicy::WarnAndDropIfFull)
-            .unwrap();
-        let (_, val) = queues.recv().await.unwrap();
-        assert_eq!(val, 3);
-        assert!(queues.low_priority_rx.try_recv().is_err());
-    });
+#[tokio::test]
+async fn warn_and_drop_if_full_logs_warning(mut logger: LoggerHandle) {
+    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    handle.push_low_priority(3u8).await.unwrap();
+    handle
+        .try_push(4u8, PushPriority::Low, PushPolicy::WarnAndDropIfFull)
+        .unwrap();
+    let (_, val) = queues.recv().await.unwrap();
+    assert_eq!(val, 3);
+    assert!(queues.low_priority_rx.try_recv().is_err());
 
     let record = logger.pop().expect("expected warning");
     assert_eq!(record.level(), log::Level::Warn);

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -4,8 +4,10 @@ use std::sync::{Mutex, OnceLock};
 
 use logtest::Logger;
 use rstest::{fixture, rstest};
-use tokio::runtime::Runtime;
-use tokio::time::{timeout, Duration};
+use tokio::{
+    runtime::Runtime,
+    time::{Duration, timeout},
+};
 use wireframe::push::{PushPolicy, PushPriority, PushQueues};
 
 /// Handle to the global logger with exclusive access.
@@ -20,7 +22,7 @@ impl LoggerHandle {
         let logger = LOGGER.get_or_init(|| Mutex::new(Logger::start()));
         let guard = logger
             .lock()
-            .expect("failed to acquire global logger lock when starting capture");
+            .expect("failed to acquire global logger lock; a previous test may still hold it");
 
         Self { guard }
     }

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -1,0 +1,89 @@
+//! Tests for push queue policy behaviour.
+
+use std::sync::{Mutex, Once};
+
+use logtest::Logger;
+use rstest::{fixture, rstest};
+use wireframe::push::{PushPolicy, PushPriority, PushQueues};
+
+/// Handle to the global logger with exclusive access.
+struct LoggerHandle {
+    _guard: std::sync::MutexGuard<'static, ()>,
+    logger: Logger,
+}
+
+impl LoggerHandle {
+    fn new() -> Self {
+        static INIT: Once = Once::new();
+        static LOCK: Mutex<()> = Mutex::new(());
+
+        let guard = LOCK.lock().expect("lock logger");
+        INIT.call_once(|| {
+            Logger::start();
+        });
+
+        let mut logger = Logger;
+        while logger.pop().is_some() {}
+
+        Self {
+            _guard: guard,
+            logger,
+        }
+    }
+}
+
+impl std::ops::Deref for LoggerHandle {
+    type Target = Logger;
+
+    fn deref(&self) -> &Self::Target { &self.logger }
+}
+
+impl std::ops::DerefMut for LoggerHandle {
+    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.logger }
+}
+
+#[fixture]
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime")
+}
+#[allow(unused_braces)]
+#[fixture]
+fn logger() -> LoggerHandle { LoggerHandle::new() }
+
+#[rstest]
+fn drop_if_full_discards_frame(rt: tokio::runtime::Runtime, mut logger: LoggerHandle) {
+    rt.block_on(async {
+        let (mut queues, handle) = PushQueues::bounded(1, 1);
+        handle.push_high_priority(1u8).await.unwrap();
+        handle
+            .try_push(2u8, PushPriority::High, PushPolicy::DropIfFull)
+            .unwrap();
+        let (_, val) = queues.recv().await.unwrap();
+        assert_eq!(val, 1);
+        assert!(queues.high_priority_rx.try_recv().is_err());
+    });
+
+    assert!(logger.pop().is_none());
+}
+
+#[rstest]
+fn warn_and_drop_if_full_logs_warning(rt: tokio::runtime::Runtime, mut logger: LoggerHandle) {
+    rt.block_on(async {
+        let (mut queues, handle) = PushQueues::bounded(1, 1);
+        handle.push_low_priority(3u8).await.unwrap();
+        handle
+            .try_push(4u8, PushPriority::Low, PushPolicy::WarnAndDropIfFull)
+            .unwrap();
+        let (_, val) = queues.recv().await.unwrap();
+        assert_eq!(val, 3);
+        assert!(queues.low_priority_rx.try_recv().is_err());
+    });
+
+    let record = logger.pop().expect("expected warning");
+    assert_eq!(record.level(), log::Level::Warn);
+    assert!(record.args().contains("push queue full"));
+    assert!(logger.pop().is_none());
+}

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -16,7 +16,9 @@ impl LoggerHandle {
         static LOGGER: OnceLock<Mutex<Logger>> = OnceLock::new();
 
         let logger = LOGGER.get_or_init(|| Mutex::new(Logger::start()));
-        let mut guard = logger.lock().expect("lock logger");
+        let mut guard = logger
+            .lock()
+            .expect("failed to acquire global logger lock when starting capture");
         while guard.pop().is_some() {}
 
         Self { guard }


### PR DESCRIPTION
## Summary
- ensure push queue policy tests use a logger fixture for exclusive access
- keep drop and warn policies as separate tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `markdownlint --fix *.md **/*.md` *(fails: violations in existing files)*
- `nixie docs/rust-testing-with-rstest-fixtures.md`


------
https://chatgpt.com/codex/tasks/task_e_6859b5beecc0832292e48a740eb40b9a

## Summary by Sourcery

Integrate the logtest crate and a LoggerHandle fixture to enable exclusive, verifiable log capture in push queue policy tests and update documentation accordingly

New Features:
- Introduce a global LoggerHandle fixture using logtest for exclusive log capture in rstest tests

Enhancements:
- Add a dedicated logtest section to the Rust testing guide for verifying log output

Build:
- Add logtest as a dev-dependency in Cargo.toml

Documentation:
- Document logtest usage and setup in the rust-testing-with-rstest-fixtures guide

Tests:
- Add async push policy tests that verify DropIfFull and WarnAndDropIfFull behavior with log assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new tests to verify push queue policies, including log output assertions for different queue behaviours.
- **Documentation**
  - Updated documentation to introduce the use of the `logtest` crate for verifying log output during tests, with usage examples and setup instructions.
- **Chores**
  - Added `logtest` as a development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->