### PR TITLE
Add connection actor diagrams

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -156,9 +156,8 @@ classDiagram
         + register(connection_id, actor)
         + get_handle(connection_id): Option&lt;PushHandle&gt;
     }
-    ConnectionActor o-- PushHandle : exposes
+    ConnectionActor o-- PushHandle : exposes / queues frames
     SessionRegistry o-- PushHandle : provides
-    PushHandle ..> ConnectionActor : queues frames
 ```
 
 ```mermaid

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -81,7 +81,7 @@ available.
 
 The connection actor's write logic will be implemented within a `tokio::select!`
 loop. Crucially, this loop will use the `biased` keyword to ensure a strict,
-deterministic polling order. This prevents high-volume but critical control
+deterministic polling order. This prevents high-volume yet critical control
 messages from being starved by large data streams.
 
 The polling order will be:
@@ -167,11 +167,12 @@ classDiagram
 sequenceDiagram
     participant Client
     participant ConnectionActor
+    participant Queue as Outbox
     participant Socket
 
     Client->>ConnectionActor: Initiate connection/request
-    ConnectionActor->>ConnectionActor: enqueue outbound frame
-    Note over ConnectionActor: Manages high/low priority queues
+    ConnectionActor->>Queue: enqueue outbound frame
+    Note over ConnectionActor,Queue: Manages high/low priority queues
     ConnectionActor->>Socket: Write outbound frame (from queue)
     Socket-->>Client: Delivers outbound message
 ```


### PR DESCRIPTION
## Summary
- add class & sequence diagrams for the connection actor and push queues
- illustrate server-initiated MySQL packets
- show WebSocket heart-beats and MQTT fan-out

## Testing
- `make fmt`
- `make lint`
- `make test`
- `markdownlint docs/asynchronous-outbound-messaging-design.md`
- `nixie docs/asynchronous-outbound-messaging-design.md`


------
https://chatgpt.com/codex/tasks/task_e_685a9d7fdaac83229e958179f181f055

## Summary by Sourcery

Add visual diagrams and formatting refinements to the asynchronous outbound messaging design document to clarify the connection actor architecture, push-queue processing, WebSocket heart-beats, and MQTT fan-out behavior.

Enhancements:
- Adjust table header formatting for consistency.
- Revise phrasing in the prioritized write loop and sequence-id reset descriptions for clarity.

Documentation:
- Add class diagram detailing ConnectionActor, PushHandle, and SessionRegistry relationships.
- Add sequence diagrams for outbound frame flow, application push operations, WebSocket heart-beats, and MQTT PUBLISH fan-out.
- Illustrate server-initiated MySQL packets within the sequence flow.