### PR TITLE
Fix mermaid queue arrows

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -171,10 +171,11 @@ sequenceDiagram
     Client->>ConnectionActor: Initiate connection/request
     Note over ConnectionActor: Manages high/low priority queues
     ConnectionActor->>Outbox: enqueue outbound frame
-    ConnectionActor->>Outbox: dequeue frame
+    ConnectionActor->>Outbox: dequeue request
+    Outbox-->>ConnectionActor: frame
     ConnectionActor->>Socket: Write outbound frame
     Socket-->>Client: Delivers outbound message
-    Note over Outbox: Holds frames while the socket is busy
+    Note over Outbox: Holds frames while the socket is busy.
 ```
 
 ## 4. Public API Surface
@@ -429,7 +430,8 @@ sequenceDiagram
     AppTask->>SessionRegistry: get PushHandle for session
     AppTask->>ConnectionActor: push(OK packet or LOCAL INFILE)
     ConnectionActor->>Outbox: enqueue frame
-    ConnectionActor->>Outbox: dequeue frame
+    ConnectionActor->>Outbox: dequeue request
+    Outbox-->>ConnectionActor: frame
     ConnectionActor->>Socket: write frame (when idle or after command completes)
 ```
 
@@ -447,7 +449,8 @@ sequenceDiagram
     participant Socket
     Timer->>ConnectionActor: push_high_priority(Ping frame)
     ConnectionActor->>Outbox: enqueue Ping in high-priority queue
-    ConnectionActor->>Outbox: dequeue Ping
+    ConnectionActor->>Outbox: dequeue request
+    Outbox-->>ConnectionActor: Ping
     ConnectionActor->>Socket: write Ping frame (even during response stream)
 ```
 


### PR DESCRIPTION
## Summary
- fix en-GB style to Oxford -ize spelling
- escape generics inside Mermaid diagrams
- clarify enqueue and drop actions using an explicit `Outbox` participant

## Testing
- `markdownlint docs/asynchronous-outbound-messaging-design.md`
- `nixie *.md docs/*.md`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685af2732fe48322813b6d66c57526b4

## Summary by Sourcery

Refine the asynchronous outbound messaging design documentation by standardizing spelling, properly escaping generics, and introducing an explicit Outbox participant in sequence diagrams to clarify enqueue/dequeue semantics.

Documentation:
- Standardize British-style spellings to Oxford “-ize” form
- Escape generic type parameters in Mermaid diagrams
- Introduce an explicit Outbox participant and adjust arrows in sequence diagrams to clarify enqueue, dequeue, and drop actions