### PR TITLE
Implement connection actor with prioritised write loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +577,7 @@ dependencies = [
  "rstest",
  "serde",
  "tokio",
+ "tokio-util",
  "wireframe_testing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 serde = { version = "1", features = ["derive"] }
 bincode = "2"
 tokio = { version = "1", default-features = false, features = ["net", "signal", "rt-multi-thread", "macros", "sync", "time", "io-util"] }
+tokio-util = "0.7"
 futures = "0.3"
 async-trait = "0.1"
 bytes = "1"

--- a/docs/wireframe-1-0-detailed-development-roadmap.md
+++ b/docs/wireframe-1-0-detailed-development-roadmap.md
@@ -26,6 +26,7 @@ all public-facing features will be built.*
 | 1.4 | Initial FragmentStrategy Trait | Define the initial `FragmentStrategy` trait and the `FragmentMeta` struct. Focus on the core methods: `decode_header` and `encode_header`.                                                                               | Medium | -    |
 | 1.5 | Basic FragmentAdapter          | Implement the `FragmentAdapter` as a `FrameProcessor`. Build the inbound reassembly logic for a single, non-multiplexed stream of fragments and the outbound logic for splitting a single large frame.                   | Large  | #1.4 |
 | 1.6 | Internal Hook Plumbing         | Add the invocation points for the protocol-specific hooks (`before_send`, `on_command_end`, etc.) within the connection actor, even if the public trait is not yet defined.                                              | Small  | #1.3 |
+
 ## Phase 2: Public APIs & Developer Ergonomics
 
 *Focus: Exposing the new functionality to developers through a clean, ergonomic,
@@ -38,6 +39,7 @@ and intuitive.*
 | 2.4 | async-stream Integration & Docs   | Remove the proposed `FrameSink` from the design. Update the `Response::Stream` handling and write documentation recommending `async-stream` as the canonical way to create streams imperatively.                | Small  | #1.1             |
 | 2.5 | Initial Test Suite                | Write unit and integration tests for the new public APIs. Verify that `Response::Vec` and `Response::Stream` work, and that `PushHandle` can successfully send frames that are received by a client.            | Large  | #2.1, #2.3, #2.4 |
 | 2.6 | Basic Fragmentation Example       | Implement a simple `FragmentStrategy` (e.g. `LenFlag32K`) and an example showing the `FragmentAdapter` in use. This validates the adapter's basic functionality.                                                | Medium | #1.5, #2.5       |
+
 ## Phase 3: Production Hardening & Resilience
 
 *Focus: Adding the critical features required for robust, secure, and reliable

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,97 @@
+//! Connection actor responsible for outbound frames.
+//!
+//! The actor polls a shutdown token, high- and low-priority push queues,
+//! and an optional response stream using a `tokio::select!` loop. The
+//! `biased` keyword ensures high-priority messages are processed before
+//! low-priority ones, with streamed responses handled last.
+
+use futures::StreamExt;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    push::{FrameLike, PushQueues},
+    response::{FrameStream, WireframeError},
+};
+
+/// Actor driving outbound frame delivery for a connection.
+pub struct ConnectionActor<F, E> {
+    pub queues: PushQueues<F>,
+    pub response: Option<FrameStream<F, E>>, // current streaming response
+    pub shutdown: CancellationToken,
+}
+
+impl<F, E> ConnectionActor<F, E>
+where
+    F: FrameLike,
+{
+    /// Create a new `ConnectionActor` from the provided components.
+    #[must_use]
+    pub fn new(
+        queues: PushQueues<F>,
+        response: Option<FrameStream<F, E>>,
+        shutdown: CancellationToken,
+    ) -> Self {
+        Self {
+            queues,
+            response,
+            shutdown,
+        }
+    }
+
+    /// Drive the actor until all sources are exhausted or shutdown is triggered.
+    ///
+    /// Frames are appended to `out` in the order they are processed.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`WireframeError`] if the response stream yields an error.
+    pub async fn run(&mut self, out: &mut Vec<F>) -> Result<(), WireframeError<E>> {
+        let mut high_closed = false;
+        let mut low_closed = false;
+        let mut resp_closed = self.response.is_none();
+
+        loop {
+            tokio::select! {
+                biased;
+
+                () = self.shutdown.cancelled() => break,
+
+                res = self.queues.high_priority_rx.recv(), if !high_closed => {
+                    match res {
+                        Some(frame) => out.push(frame),
+                        None => high_closed = true,
+                    }
+                }
+
+                res = self.queues.low_priority_rx.recv(), if !low_closed => {
+                    match res {
+                        Some(frame) => out.push(frame),
+                        None => low_closed = true,
+                    }
+                }
+
+                res = async {
+                    if resp_closed {
+                        None
+                    } else if let Some(stream) = &mut self.response {
+                        stream.next().await
+                    } else {
+                        None
+                    }
+                } => {
+                    match res {
+                        Some(Ok(frame)) => out.push(frame),
+                        Some(Err(e)) => return Err(e),
+                        None => resp_closed = true,
+                    }
+                }
+            }
+
+            if high_closed && low_closed && resp_closed {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod app;
 pub mod serializer;
 pub use serializer::{BincodeSerializer, Serializer};
+pub mod connection;
 pub mod extractor;
 pub mod frame;
 pub mod message;
@@ -17,4 +18,5 @@ pub mod response;
 pub mod rewind_stream;
 pub mod server;
 
+pub use connection::ConnectionActor;
 pub use response::{FrameStream, Response, WireframeError};

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -1,0 +1,63 @@
+use futures::stream;
+use rstest::{fixture, rstest};
+use tokio_util::sync::CancellationToken;
+use wireframe::{connection::ConnectionActor, push::PushQueues};
+
+#[fixture]
+#[allow(unused_braces)]
+fn queues() -> (PushQueues<u8>, wireframe::push::PushHandle<u8>) { PushQueues::bounded(8, 8) }
+
+#[fixture]
+#[allow(unused_braces)]
+fn shutdown_token() -> CancellationToken { CancellationToken::new() }
+
+#[rstest]
+#[tokio::test]
+async fn high_priority_before_low_and_stream(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, handle) = queues;
+    handle.push_low_priority(2).await.unwrap();
+    handle.push_high_priority(1).await.unwrap();
+    drop(handle);
+
+    let stream = stream::iter(vec![Ok(3u8)]);
+    let mut actor: ConnectionActor<_, ()> =
+        ConnectionActor::new(queues, Some(Box::pin(stream)), shutdown_token);
+    let mut out = Vec::new();
+    actor.run(&mut out).await.unwrap();
+    assert_eq!(out, vec![1, 2, 3]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn shutdown_terminates_actor(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, _handle) = queues;
+    shutdown_token.cancel();
+    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, None, shutdown_token);
+    let mut out = Vec::new();
+    actor.run(&mut out).await.unwrap();
+    assert!(out.is_empty());
+}
+
+#[rstest]
+#[tokio::test]
+async fn actor_processes_until_sources_close(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, handle) = queues;
+    handle.push_high_priority(1).await.unwrap();
+    drop(handle);
+
+    let stream = stream::iter(vec![Ok(2u8), Ok(3u8)]);
+    let mut actor: ConnectionActor<_, ()> =
+        ConnectionActor::new(queues, Some(Box::pin(stream)), shutdown_token);
+    let mut out = Vec::new();
+    actor.run(&mut out).await.unwrap();
+    assert_eq!(out, vec![1, 2, 3]);
+}


### PR DESCRIPTION
## Summary
- add `ConnectionActor` for managing outbound frames
- expose actor from library
- add `tokio-util` for `CancellationToken`
- create tests covering push ordering and shutdown behaviour

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685b4579902c8322aee724c49f0ed82a