### PR TITLE
Document actor state consolidation

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -180,10 +180,10 @@ sequenceDiagram
 
 ### 3.4 Actor state management
 
-The connection actor polls four sources: a shutdown token, high and low priority
-push channels, and an optional response stream. Earlier drafts tracked a boolean
-for each source, leading to verbose state updates. The actor now stores each
-receiver as an `Option` and counts how many sources have closed.
+The connection actor polls four sources: a shutdown token, high- and
+low-priority push channels, and an optional response stream. Earlier drafts
+tracked a boolean for each source, leading to verbose state updates. The actor
+now stores each receiver as an `Option` and counts how many sources have closed.
 
 ```rust
 enum RunState {
@@ -194,13 +194,13 @@ enum RunState {
 
 struct ActorState {
     run_state: RunState,
-    closed_sources: u8,
-    total_sources: u8,
+    closed_sources: usize,
+    total_sources: usize,
 }
 ```
 
 `total_sources` is calculated when the actor starts. Whenever a receiver returns
-`None` it is set to `None` and `closed_sources` increments. When
+`None`, it is set to `None` and `closed_sources` increments. When
 `closed_sources == total_sources` the loop exits. This consolidation clarifies
 progress through the actor lifecycle and reduces manual flag management.
 

--- a/docs/asynchronous-outbound-messaging-roadmap.md
+++ b/docs/asynchronous-outbound-messaging-roadmap.md
@@ -13,6 +13,8 @@ design documents.
 - [x] **Connection actor** with a biased `select!` loop that polls for shutdown,
   high/low queues and response streams as described in
   [Design §3.2][design-write-loop].
+- [ ] **Run state consolidation** using `Option` receivers and a closed source
+  counter ([Design §3.4][design-actor-state]).
 - [ ] **Internal protocol hooks** `before_send` and `on_command_end` invoked
   from the actor ([Design §4.3][design-hooks]).
 
@@ -52,6 +54,7 @@ design documents.
 - [ ] **User guides and examples** demonstrating server-initiated messaging
   ([Design §7][design-use-cases]).
 
+[design-actor-state]: asynchronous-outbound-messaging-design.md#34-actor-state-management
 [design-dlq]: asynchronous-outbound-messaging-design.md#52-optional-dead-letter-queue-dlq-for-critical-messages
 [design-errors]: asynchronous-outbound-messaging-design.md#5-error-handling--resilience
 [design-hooks]: asynchronous-outbound-messaging-design.md#43-configuration-via-the-wireframeprotocol-trait


### PR DESCRIPTION
## Summary
- outline the actor state model using `RunState` and a closed source counter
- add roadmap task for implementing the new state management

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c7ee189f883228e371991682ea7e2

## Summary by Sourcery

Document the consolidated actor state model and update the project roadmap accordingly

Documentation:
- Add an Actor State Management section detailing the RunState enum and source-count-based shutdown logic
- Add a roadmap task for implementing run state consolidation referencing the new design section