### PR TITLE
Update CI workflow with rust cache step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
           override: true
           components: rustfmt, clippy
       - name: Cache ~/.cargo and target/
-        uses: Swatinem/rust-cache@v2
+        # v2.7.8
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
         with:
           override: true
           components: rustfmt, clippy
+      # Cache ~/.cargo and target/
+      - uses: Swatinem/rust-cache@v2
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           override: true
           components: rustfmt, clippy
-      # Cache ~/.cargo and target/
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache ~/.cargo and target/
+        uses: Swatinem/rust-cache@v2
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- speed up CI builds by adding Swatinem/rust-cache

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c8491e8e883228a8cef36ea177561

## Summary by Sourcery

CI:
- Introduce Swatinem/rust-cache@v2 to cache ~/.cargo and target/ directories for faster Rust CI runs.