### PR TITLE
Implement connection protocol hooks

### DIFF
--- a/docs/asynchronous-outbound-messaging-roadmap.md
+++ b/docs/asynchronous-outbound-messaging-roadmap.md
@@ -13,7 +13,7 @@ design documents.
 - [x] **Connection actor** with a biased `select!` loop that polls for shutdown,
   high/low queues and response streams as described in
   [Design §3.2][design-write-loop].
-- [ ] **Internal protocol hooks** `before_send` and `on_command_end` invoked
+- [x] **Internal protocol hooks** `before_send` and `on_command_end` invoked
   from the actor ([Design §4.3][design-hooks]).
 
 ## 2. Public API and Ergonomics

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,44 @@
+//! Internal protocol hooks called by the connection actor.
+//!
+//! This module defines [`ProtocolHooks`], a container for optional callback
+//! functions invoked during connection output. The hooks are placeholders for
+//! the future `WireframeProtocol` trait described in the design documents.
+
+/// Type alias for the `before_send` callback.
+type BeforeSendHook<F> = Box<dyn FnMut(&mut F) + Send + 'static>;
+
+/// Type alias for the `on_command_end` callback.
+type OnCommandEndHook = Box<dyn FnMut() + Send + 'static>;
+
+/// Callbacks used by the connection actor.
+pub struct ProtocolHooks<F> {
+    /// Invoked before a frame is written to the socket.
+    pub before_send: Option<BeforeSendHook<F>>,
+    /// Invoked once a command completes.
+    pub on_command_end: Option<OnCommandEndHook>,
+}
+
+impl<F> Default for ProtocolHooks<F> {
+    fn default() -> Self {
+        Self {
+            before_send: None,
+            on_command_end: None,
+        }
+    }
+}
+
+impl<F> ProtocolHooks<F> {
+    /// Run the `before_send` hook if registered.
+    pub fn before_send(&mut self, frame: &mut F) {
+        if let Some(hook) = &mut self.before_send {
+            hook(frame);
+        }
+    }
+
+    /// Run the `on_command_end` hook if registered.
+    pub fn on_command_end(&mut self) {
+        if let Some(hook) = &mut self.on_command_end {
+            hook();
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use serializer::{BincodeSerializer, Serializer};
 pub mod connection;
 pub mod extractor;
 pub mod frame;
+pub mod hooks;
 pub mod message;
 pub mod middleware;
 pub mod preamble;
@@ -19,4 +20,5 @@ pub mod rewind_stream;
 pub mod server;
 
 pub use connection::ConnectionActor;
+pub use hooks::ProtocolHooks;
 pub use response::{FrameStream, Response, WireframeError};


### PR DESCRIPTION
## Summary
- add `ProtocolHooks` structure for connection callbacks
- invoke hooks in `ConnectionActor`
- test hook behaviour in `connection_actor` tests
- export `ProtocolHooks` via library module
- mark roadmap item complete

## Testing
- `cargo fmt --all`
- `mdformat-all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685ca1e53108832295f719eb4aef1e14

## Summary by Sourcery

Implement ProtocolHooks for connection actors by defining hook callbacks, integrating them into ConnectionActor, exposing them in the public API, and adding tests to validate hook execution.

New Features:
- Introduce ProtocolHooks struct for customizable connection callbacks
- Extend ConnectionActor with a with_hooks constructor to inject ProtocolHooks
- Expose ProtocolHooks in the public library API

Enhancements:
- Invoke before_send hooks before writing frames and on_command_end hooks after streaming responses

Documentation:
- Update roadmap documentation to mark internal protocol hooks as complete

Tests:
- Add tests in connection_actor to verify before_send and on_command_end hook behavior