### PR TITLE
Add module docs to integration tests

### DIFF
--- a/tests/app_data.rs
+++ b/tests/app_data.rs
@@ -1,3 +1,7 @@
+//! Tests for extracting shared state from message requests.
+//!
+//! They verify successful extraction and error handling when state is missing.
+
 use std::{any::TypeId, collections::HashMap, sync::Arc};
 
 use wireframe::extractor::{

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -1,3 +1,7 @@
+//! Tests for message request extractors.
+//!
+//! Validate message parsing, connection info, and shared state behaviour.
+
 use std::{collections::HashMap, net::SocketAddr};
 
 use wireframe::{

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -1,3 +1,7 @@
+//! Tests for connection lifecycle callbacks.
+//!
+//! They check setup, teardown, and state propagation through helper utilities.
+
 use std::{
     future::Future,
     pin::Pin,

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,3 +1,7 @@
+//! Tests for frame metadata parsing using custom serializers.
+//!
+//! They ensure parse callbacks run before deserialization and errors fall back correctly.
+
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -1,3 +1,7 @@
+//! Tests for middleware transformations.
+//!
+//! Confirm that a custom middleware can modify requests and responses.
+
 use async_trait::async_trait;
 use wireframe::middleware::{Next, Service, ServiceRequest, ServiceResponse, Transform};
 

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -1,3 +1,7 @@
+//! Tests ensuring middleware registration order is reversed during execution.
+//!
+//! Verifies tags are applied in reverse to request and response bodies.
+
 use async_trait::async_trait;
 use bytes::BytesMut;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -1,3 +1,7 @@
+//! Tests for push queue routing and limits.
+//!
+//! They cover priority ordering, policy behaviour, and closed queue errors.
+
 use wireframe::push::{PushError, PushPolicy, PushPriority, PushQueues};
 
 #[tokio::test]

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -1,3 +1,7 @@
+//! Tests for routing behaviour in `WireframeApp`.
+//!
+//! They validate handler invocation, echo responses, and sequential processing.
+
 use std::sync::{
     Arc,
     atomic::{AtomicUsize, Ordering},


### PR DESCRIPTION
## Summary
- add module-level documentation to missing test modules

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685cf1a166508322accf55b4b5da71a1

## Summary by Sourcery

Add missing module-level documentation to all integration test modules

Documentation:
- Add module-level doc comments to integration test modules

Tests:
- Include top-level documentation in all integration test modules