### PR TITLE
Fix connection actor compile errors

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -105,15 +105,15 @@ where
             }
 
             res = Self::recv_push(&mut self.queues.high_priority_rx), if !state.push.high => {
-                Self::handle_push(res, &mut state.push.high, out);
+                self.handle_push(res, &mut state.push.high, out);
             }
 
             res = Self::recv_push(&mut self.queues.low_priority_rx), if !state.push.low => {
-                Self::handle_push(res, &mut state.push.low, out);
+                self.handle_push(res, &mut state.push.low, out);
             }
 
             res = Self::next_response(&mut self.response), if !state.shutting_down && !state.resp_closed => {
-                Self::handle_response(res, &mut state.resp_closed, out)?;
+                self.handle_response(res, &mut state.resp_closed, out)?;
                 if state.resp_closed {
                     self.response = None;
                 }
@@ -163,12 +163,15 @@ where
         Ok(())
     }
 
+    /// Await cancellation on the provided shutdown token.
     #[inline]
     async fn wait_shutdown(token: CancellationToken) { token.cancelled_owned().await; }
 
+    /// Receive the next frame from a push queue.
     #[inline]
     async fn recv_push(rx: &mut mpsc::Receiver<F>) -> Option<F> { rx.recv().await }
 
+    /// Poll the current streaming response for the next frame.
     #[inline]
     async fn next_response(
         stream: &mut Option<FrameStream<F, E>>,


### PR DESCRIPTION
## Summary
- fix calls to instance methods in `ConnectionActor`
- document helper methods in `connection.rs`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685d983e64a4832292e7d4a21fc1a734

## Summary by Sourcery

Fix compilation issues in the ConnectionActor by converting static calls to instance method invocations and add documentation for helper methods in connection.rs.

Bug Fixes:
- Replace `Self::handle_push` and `Self::handle_response` calls with `self.handle_push` and `self.handle_response` in the actor loop.

Documentation:
- Add doc comments for `wait_shutdown`, `recv_push`, and `next_response` helper methods in connection.rs.