### PR TITLE
Remove stray citation markers

### DIFF
--- a/docs/multi-packet-and-streaming-responses-design.md
+++ b/docs/multi-packet-and-streaming-responses-design.md
@@ -40,7 +40,7 @@ The implementation must satisfy the following core requirements:
 The cornerstone of this design is a move to a purely **declarative streaming
 model**. Instead of providing handlers with an imperative `FrameSink` to push
 frames into, handlers will declaratively return a description of the entire
-response. 5 This approach significantly simplifies the API surface, improves
+response. This approach significantly simplifies the API surface, improves
 testability, and eliminates a class of resource management issues associated
 with sink-based designs.
 
@@ -62,7 +62,7 @@ explicit channel management.
 
 To provide an ergonomic way for developers to generate streams using
 imperative-style logic (e.g., inside a `for` loop), `wireframe` will adopt and
-recommend the `async-stream` crate. 9 This crate provides macros (
+recommend the `async-stream` crate. This crate provides macros (
 
 `stream!` and `try_stream!`) that transform imperative `yield` statements into a
 fully compliant `Stream` object. This gives developers the best of both worlds:

--- a/docs/multi-packet-and-streaming-responses-design.md
+++ b/docs/multi-packet-and-streaming-responses-design.md
@@ -62,11 +62,10 @@ explicit channel management.
 
 To provide an ergonomic way for developers to generate streams using
 imperative-style logic (e.g., inside a `for` loop), `wireframe` will adopt and
-recommend the `async-stream` crate. This crate provides macros (
-
-`stream!` and `try_stream!`) that transform imperative `yield` statements into a
-fully compliant `Stream` object. This gives developers the best of both worlds:
-the intuitive feel of imperative code generation without the API complexity of a
+recommend the `async-stream` crate. This crate provides macros (`stream!` and
+`try_stream!`) that transform imperative `yield` statements into a fully
+compliant `Stream` object. This gives developers the best of both worlds: the
+intuitive feel of imperative code generation without the API complexity of a
 separate `FrameSink` type.
 
 ## 4. Public API Surface


### PR DESCRIPTION
## Summary
- fix leftover numeric markers in multi-packet/streaming doc

## Testing
- `mdformat-all`
- `markdownlint --fix AGENTS.md ...`
- `nixie *.md **/*.md`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685e3597a434832284b847fb27e6ed85

## Summary by Sourcery

Documentation:
- Remove leftover numeric citation markers in multi-packet and streaming documentation