### PR TITLE
Add fairness counter for low-priority queue

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -146,7 +146,7 @@ An optional time slice (for example 100 µs) can also be configured. When the
 elapsed time spent handling high-priority frames exceeds this slice, and the low
 queue is not empty, the actor yields to a low-priority frame. Application
 builders expose `with_fairness(FairnessConfig)` where `FairnessConfig` groups
-the counter threshold and an optional `time_slice`. The counter defaults to 16
+the counter threshold and an optional `time_slice`. The counter defaults to 8
 while `time_slice` is disabled. Setting the counter to zero disables the
 threshold logic and relies solely on `time_slice` for fairness, preserving
 strict high-priority ordering otherwise.

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -147,8 +147,9 @@ elapsed time spent handling high-priority frames exceeds this slice, and the low
 queue is not empty, the actor yields to a low-priority frame. Application
 builders expose `with_fairness(FairnessConfig)` where `FairnessConfig` groups
 the counter threshold and an optional `time_slice`. The counter defaults to 16
-while `time_slice` is disabled. Setting the counter to zero preserves the
-original strict ordering.
+while `time_slice` is disabled. Setting the counter to zero disables the
+threshold logic and relies solely on `time_slice` for fairness, preserving
+strict high-priority ordering otherwise.
 
 This fairness mechanism ensures low-priority traffic continues to progress even
 under sustained high-priority load.

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -181,6 +181,31 @@ flowchart TD
     K --> A
 ```
 
+The following sequence diagram illustrates the runtime behaviour:
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant ConnectionActor
+    participant HighQueue
+    participant LowQueue
+
+    loop While processing frames
+        ConnectionActor->>HighQueue: Poll high-priority frame
+        alt High-priority frame received
+            ConnectionActor->>ConnectionActor: after_high()
+            alt Max high before low or time slice reached
+                ConnectionActor->>LowQueue: Try receive low-priority frame
+                alt Low-priority frame available
+                    ConnectionActor->>ConnectionActor: after_low()
+                end
+            end
+        else No high-priority frame
+            ConnectionActor->>ConnectionActor: reset_high_counter()
+        end
+    end
+```
+
 ### 3.3 Connection Actor Overview
 
 ```mermaid

--- a/docs/asynchronous-outbound-messaging-roadmap.md
+++ b/docs/asynchronous-outbound-messaging-roadmap.md
@@ -13,7 +13,7 @@ design documents.
 - [x] **Connection actor** with a biased `select!` loop that polls for shutdown,
   high/low queues and response streams as described in
   [Design §3.2][design-write-loop].
-- [ ] **Fairness counter** to yield to the low-priority queue after bursts of
+- [x] **Fairness counter** to yield to the low-priority queue after bursts of
   high-priority frames ([Design §3.2.1][design-fairness]).
 - [ ] **Run state consolidation** using `Option` receivers and a closed source
   counter ([Design §3.4][design-actor-state]).

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,61 +1,59 @@
 # Documentation contents
 
-This page summarizes each file in the `docs/` directory.
-Use it as a quick reference when navigating the project's design and
-architecture material.
+This page summarizes each file in the `docs/` directory. Use it as a quick
+reference when navigating the project's design and architecture material.
 
 ## Design documents
 
-- [Outbound messaging design](asynchronous-outbound-messaging-design.md)  
+- [Outbound messaging design](asynchronous-outbound-messaging-design.md)\
   Comprehensive design for server-initiated pushes.
-- [Message fragments](generic-message-fragmentation-and-re-assembly-design.md)  
+- [Message fragments](generic-message-fragmentation-and-re-assembly-design.md)\
   Design for fragmenting and reassembling messages.
-- [Streaming response design](multi-packet-and-streaming-responses-design.md)  
+- [Streaming response design](multi-packet-and-streaming-responses-design.md)\
   Design for handling multi-packet and streaming responses.
-- [Router library design](rust-binary-router-library-design.md)  
+- [Router library design](rust-binary-router-library-design.md)\
   In-depth design of the binary router library.
-- [Client design](wireframe-client-design.md)  
+- [Client design](wireframe-client-design.md)\
   Proposal for adding client-side support.
-- [Frame metadata](frame-metadata.md)  
+- [Frame metadata](frame-metadata.md)\
   How frame metadata assists with routing decisions.
-- [Message versioning](message-versioning.md)  
+- [Message versioning](message-versioning.md)\
   Approaches to message versioning and compatibility.
-- [Preamble validator](preamble-validator.md)  
+- [Preamble validator](preamble-validator.md)\
   Validating client connection preambles.
 
 ## Roadmaps
 
-- [Outbound messaging roadmap](asynchronous-outbound-messaging-roadmap.md)  
+- [Outbound messaging roadmap](asynchronous-outbound-messaging-roadmap.md)\
   Task list for implementing asynchronous outbound messaging.
-- [Wireframe 1.0 roadmap](wireframe-1-0-detailed-development-roadmap.md)  
+- [Wireframe 1.0 roadmap](wireframe-1-0-detailed-development-roadmap.md)\
   Detailed tasks leading to Wireframe 1.0.
-- [Project roadmap](roadmap.md)  
+- [Project roadmap](roadmap.md)\
   High-level development roadmap.
-- [1.0 philosophy](the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md)  
+- [1.0 philosophy](the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md)\
   Philosophy and feature set for Wireframe 1.0.
 
 ## Testing
 
-- [Multi-layered testing strategy](multi-layered-testing-strategy.md)  
+- [Multi-layered testing strategy](multi-layered-testing-strategy.md)\
   Overview of the library's testing approach.
-- [RSTest fixtures](rust-testing-with-rstest-fixtures.md)  
+- [RSTest fixtures](rust-testing-with-rstest-fixtures.md)\
   Using `rstest` fixtures for clean tests.
-- [Mocking network outages](mocking-network-outages-in-rust.md)  
+- [Mocking network outages](mocking-network-outages-in-rust.md)\
   Tutorial for simulating network outages in tests.
-- [Testing helpers](wireframe-testing-crate.md)  
+- [Testing helpers](wireframe-testing-crate.md)\
   Planned companion crate with testing helpers.
 
 ## Operations and resilience
 
-- [Resilience guide](hardening-wireframe-a-guide-to-production-resilience.md)  
+- [Resilience guide](hardening-wireframe-a-guide-to-production-resilience.md)\
   Guidance on achieving production resilience.
-- [Observability and operability](observability-operability-and-maturity.md)  
+- [Observability and operability](observability-operability-and-maturity.md)\
   Guide to observability and operational maturity.
 
 ## Reference guides
 
-- [Refactoring guide](complexity-antipatterns-and-refactoring-strategies.md)  
+- [Refactoring guide](complexity-antipatterns-and-refactoring-strategies.md)\
   Strategies for taming code complexity and refactoring.
-- [Documentation style guide](documentation-style-guide.md)  
+- [Documentation style guide](documentation-style-guide.md)\
   Conventions for writing project documentation.
-

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -5,55 +5,54 @@ reference when navigating the project's design and architecture material.
 
 ## Design documents
 
-- [Outbound messaging design](asynchronous-outbound-messaging-design.md)\
+- [Outbound messaging design](asynchronous-outbound-messaging-design.md)
   Comprehensive design for server-initiated pushes.
-- [Message fragments](generic-message-fragmentation-and-re-assembly-design.md)\
+- [Message fragments](generic-message-fragmentation-and-re-assembly-design.md)
   Design for fragmenting and reassembling messages.
-- [Streaming response design](multi-packet-and-streaming-responses-design.md)\
+- [Streaming response design](multi-packet-and-streaming-responses-design.md)
   Design for handling multi-packet and streaming responses.
-- [Router library design](rust-binary-router-library-design.md)\
-  In-depth design of the binary router library.
-- [Client design](wireframe-client-design.md)\
-  Proposal for adding client-side support.
-- [Frame metadata](frame-metadata.md)\
-  How frame metadata assists with routing decisions.
-- [Message versioning](message-versioning.md)\
-  Approaches to message versioning and compatibility.
-- [Preamble validator](preamble-validator.md)\
-  Validating client connection preambles.
+- [Router library design](rust-binary-router-library-design.md) In-depth design
+  of the binary router library.
+- [Client design](wireframe-client-design.md) Proposal for adding client-side
+  support.
+- [Frame metadata](frame-metadata.md) How frame metadata assists with routing
+  decisions.
+- [Message versioning](message-versioning.md) Approaches to message versioning
+  and compatibility.
+- [Preamble validator](preamble-validator.md) Validating client connection
+  preambles.
 
 ## Roadmaps
 
-- [Outbound messaging roadmap](asynchronous-outbound-messaging-roadmap.md)\
-  Task list for implementing asynchronous outbound messaging.
-- [Wireframe 1.0 roadmap](wireframe-1-0-detailed-development-roadmap.md)\
+- [Outbound messaging roadmap](asynchronous-outbound-messaging-roadmap.md) Task
+  list for implementing asynchronous outbound messaging.
+- [Wireframe 1.0 roadmap](wireframe-1-0-detailed-development-roadmap.md)
   Detailed tasks leading to Wireframe 1.0.
-- [Project roadmap](roadmap.md)\
-  High-level development roadmap.
-- [1.0 philosophy](the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md)\
+- [Project roadmap](roadmap.md) High-level development roadmap.
+- [1.0 philosophy](the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md)
   Philosophy and feature set for Wireframe 1.0.
 
 ## Testing
 
-- [Multi-layered testing strategy](multi-layered-testing-strategy.md)\
-  Overview of the library's testing approach.
-- [RSTest fixtures](rust-testing-with-rstest-fixtures.md)\
-  Using `rstest` fixtures for clean tests.
-- [Mocking network outages](mocking-network-outages-in-rust.md)\
-  Tutorial for simulating network outages in tests.
-- [Testing helpers](wireframe-testing-crate.md)\
-  Planned companion crate with testing helpers.
+- [Multi-layered testing strategy](multi-layered-testing-strategy.md) Overview
+  of the library's testing approach.
+- [RSTest fixtures](rust-testing-with-rstest-fixtures.md) Using `rstest`
+  fixtures for clean tests.
+- [Mocking network outages](mocking-network-outages-in-rust.md) Tutorial for
+  simulating network outages in tests.
+- [Testing helpers](wireframe-testing-crate.md) Planned companion crate with
+  testing helpers.
 
 ## Operations and resilience
 
-- [Resilience guide](hardening-wireframe-a-guide-to-production-resilience.md)\
+- [Resilience guide](hardening-wireframe-a-guide-to-production-resilience.md)
   Guidance on achieving production resilience.
-- [Observability and operability](observability-operability-and-maturity.md)\
+- [Observability and operability](observability-operability-and-maturity.md)
   Guide to observability and operational maturity.
 
 ## Reference guides
 
-- [Refactoring guide](complexity-antipatterns-and-refactoring-strategies.md)\
+- [Refactoring guide](complexity-antipatterns-and-refactoring-strategies.md)
   Strategies for taming code complexity and refactoring.
-- [Documentation style guide](documentation-style-guide.md)\
-  Conventions for writing project documentation.
+- [Documentation style guide](documentation-style-guide.md) Conventions for
+  writing project documentation.


### PR DESCRIPTION
## Summary
- implement fairness counter to yield to low-priority queue
- allow configuring fairness behaviour
- test fairness counter
- mark roadmap item complete

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685f1ebd24108322b4214a341609e5d3

## Summary by Sourcery

Introduce a configurable fairness counter in ConnectionActor to balance processing between high- and low-priority queues, add corresponding tests, and update documentation.

New Features:
- Introduce FairnessConfig to parameterize low-priority queue yielding behavior
- Integrate fairness logic into ConnectionActor to pause high-priority bursts and serve low-priority frames
- Expose set_fairness method on ConnectionActor to customize fairness settings

Documentation:
- Mark the fairness counter item as complete in the asynchronous outbound messaging roadmap

Tests:
- Add a test verifying that low-priority frames are yielded to after a burst of high-priority frames