### PR TITLE
Update README with WireframeProtocol integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ impl WireframeProtocol for MySqlProtocolImpl {
     fn on_command_end(&self, _ctx: &mut ConnectionContext) {}
 }
 
+```
+
+```rust
 let app = WireframeApp::new().with_protocol(MySqlProtocolImpl);
 ```
 


### PR DESCRIPTION
## Summary
- document new `WireframeProtocol` trait in the Connection Lifecycle section
- illustrate registering a protocol with `with_protocol`

## Testing
- `make fmt`
- `make lint`
- `make test`
- `markdownlint README.md docs/asynchronous-outbound-messaging-design.md`
- `nixie README.md docs/asynchronous-outbound-messaging-design.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686088eb3a5c8322a2dad1fc34dcc5ba

## Summary by Sourcery

Update README to describe the new WireframeProtocol trait for connection lifecycle callbacks and show protocol registration using with_protocol

Documentation:
- Document the WireframeProtocol trait replacing on_connection_setup/on_connection_teardown closures
- Add an example of registering a protocol implementation with WireframeApp via with_protocol