### PR TITLE
Add module level docs

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,3 +1,8 @@
+//! Minimal echo server example using `WireframeApp`.
+//!
+//! The application listens for incoming frames and simply echoes each
+//! envelope back to the client.
+
 use std::io;
 
 use wireframe::{app::WireframeApp, server::WireframeServer};

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -1,3 +1,8 @@
+//! Demonstrates routing based on frame metadata.
+//!
+//! Frames include a small header defining the message id and flags
+//! which is used by `WireframeApp` to dispatch handlers.
+
 use std::{io, sync::Arc};
 
 use bytes::BytesMut;

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -1,7 +1,7 @@
 //! Demonstrates routing based on frame metadata.
 //!
-//! Frames include a small header defining the message id and flags
-//! which is used by `WireframeApp` to dispatch handlers.
+//! Frames include a small header containing the message ID and flags,
+//! which are used by `WireframeApp` to dispatch handlers.
 
 use std::{io, sync::Arc};
 

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -1,3 +1,8 @@
+//! Example demonstrating enumerated packet types with middleware routing.
+//!
+//! The application defines an enum representing different packet variants and
+//! shows how to dispatch handlers based on the variant received.
+
 use std::{collections::HashMap, future::Future, io, pin::Pin};
 
 use async_trait::async_trait;

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -1,3 +1,8 @@
+//! Ping/pong example exchanging typed request and response packets.
+//!
+//! Demonstrates custom packet structs and middleware that maps `Ping` to
+//! `Pong` responses.
+
 use std::{io, net::SocketAddr, sync::Arc};
 
 use async_trait::async_trait;

--- a/wireframe_testing/src/helpers.rs
+++ b/wireframe_testing/src/helpers.rs
@@ -1,3 +1,8 @@
+//! Helper utilities for driving `WireframeApp` instances in tests.
+//!
+//! These functions spin up an application on an in-memory duplex stream and
+//! collect the bytes written back by the app for assertions.
+
 use bincode::config;
 use bytes::BytesMut;
 use rstest::fixture;


### PR DESCRIPTION
## Summary
- add `//!` comments to all missing modules in examples and testing helpers

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68630f35bb548322b68e4f053207c6bc

## Summary by Sourcery

Add module-level documentation comments to all example and testing helper modules.

Documentation:
- Add module-level `//!` comments to echo.rs, metadata_routing.rs, packet_enum.rs, and ping_pong.rs examples.
- Add module-level `//!` comments to the wireframe_testing/src/helpers.rs testing helper module.