### PR TITLE
Fix route doc comment

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -271,13 +271,6 @@ where
     C: Send + 'static,
     E: Packet,
 {
-    /// Construct a new empty application builder.
-    ///
-    /// # Errors
-    ///
-    /// This function currently never returns an error but uses the
-    /// [`Result`] type for forward compatibility.
-    ///
     /// Register a route that maps `id` to `handler`.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary
- correct documentation for `route()` to remove unrelated builder text

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686720a2c370832290309100c1583420

## Summary by Sourcery

Documentation:
- Correct the `route()` doc comment by deleting deprecated builder text.