### PR TITLE
Add usage examples to public functions

### DIFF
--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -34,6 +34,22 @@ impl MessageRequest {
     /// Retrieve shared state of type `T` if available.
     ///
     /// Returns `None` when no value of type `T` was registered.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::{any::TypeId, collections::HashMap, sync::Arc};
+    ///
+    /// use wireframe::extractor::{MessageRequest, SharedState};
+    ///
+    /// let mut req = MessageRequest::default();
+    /// req.app_data.insert(
+    ///     TypeId::of::<u32>(),
+    ///     Arc::new(5u32) as Arc<dyn std::any::Any + Send + Sync>,
+    /// );
+    /// let val: Option<SharedState<u32>> = req.state();
+    /// assert_eq!(*val.unwrap(), 5);
+    /// ```
     #[must_use]
     pub fn state<T>(&self) -> Option<SharedState<T>>
     where
@@ -58,12 +74,33 @@ impl Payload<'_> {
     ///
     /// Consumes up to `count` bytes from the front of the slice, ensuring we
     /// never slice beyond the available buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::extractor::Payload;
+    ///
+    /// let mut payload = Payload { data: b"abcd" };
+    /// payload.advance(2);
+    /// assert_eq!(payload.data, b"cd" as &[u8]);
+    /// ```
     pub fn advance(&mut self, count: usize) {
         let n = count.min(self.data.len());
         self.data = &self.data[n..];
     }
 
     /// Returns the number of bytes remaining.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::extractor::Payload;
+    ///
+    /// let mut payload = Payload { data: b"bytes" };
+    /// assert_eq!(payload.remaining(), 5);
+    /// payload.advance(2);
+    /// assert_eq!(payload.remaining(), 3);
+    /// ```
     #[must_use]
     pub fn remaining(&self) -> usize { self.data.len() }
 }
@@ -246,6 +283,21 @@ pub struct ConnectionInfo {
 
 impl ConnectionInfo {
     /// Returns the peer's socket address for the current connection, if available.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::SocketAddr;
+    ///
+    /// use wireframe::extractor::{ConnectionInfo, FromMessageRequest, MessageRequest, Payload};
+    ///
+    /// let req = MessageRequest {
+    ///     peer_addr: Some("127.0.0.1:8080".parse::<SocketAddr>().unwrap()),
+    ///     ..Default::default()
+    /// };
+    /// let info = ConnectionInfo::from_message_request(&req, &mut Payload::default()).unwrap();
+    /// assert_eq!(info.peer_addr(), req.peer_addr);
+    /// ```
     #[must_use]
     pub fn peer_addr(&self) -> Option<SocketAddr> { self.peer_addr }
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -63,6 +63,21 @@ impl<F: FrameLike> PushHandle<F> {
     /// # Errors
     ///
     /// Returns [`PushError::Closed`] if the receiving end has been dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::push::{PushPriority, PushQueues};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut queues, handle) = PushQueues::bounded(1, 1);
+    ///     handle.push_high_priority(42u8).await.unwrap();
+    ///     let (priority, frame) = queues.recv().await.unwrap();
+    ///     assert_eq!(priority, PushPriority::High);
+    ///     assert_eq!(frame, 42);
+    /// }
+    /// ```
     pub async fn push_high_priority(&self, frame: F) -> Result<(), PushError> {
         self.0
             .high_prio_tx
@@ -78,6 +93,21 @@ impl<F: FrameLike> PushHandle<F> {
     /// # Errors
     ///
     /// Returns [`PushError::Closed`] if the receiving end has been dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::push::{PushPriority, PushQueues};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut queues, handle) = PushQueues::bounded(1, 1);
+    ///     handle.push_low_priority(10u8).await.unwrap();
+    ///     let (priority, frame) = queues.recv().await.unwrap();
+    ///     assert_eq!(priority, PushPriority::Low);
+    ///     assert_eq!(frame, 10);
+    /// }
+    /// ```
     pub async fn push_low_priority(&self, frame: F) -> Result<(), PushError> {
         self.0
             .low_prio_tx
@@ -93,6 +123,21 @@ impl<F: FrameLike> PushHandle<F> {
     /// Returns [`PushError::QueueFull`] if the queue is full and the policy is
     /// [`PushPolicy::ReturnErrorIfFull`]. Returns [`PushError::Closed`] if the
     /// receiving end has been dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::push::{PushPolicy, PushPriority, PushQueues};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut queues, handle) = PushQueues::bounded(1, 1);
+    ///     handle.push_high_priority(1u8).await.unwrap();
+    ///     let result = handle.try_push(2u8, PushPriority::High, PushPolicy::ReturnErrorIfFull);
+    ///     assert!(result.is_err());
+    ///     let _ = queues.recv().await;
+    /// }
+    /// ```
     pub fn try_push(
         &self,
         frame: F,
@@ -131,6 +176,21 @@ pub struct PushQueues<F> {
 impl<F: FrameLike> PushQueues<F> {
     /// Create a new set of queues with the specified bounds for each priority
     /// and return them along with a [`PushHandle`] for producers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::push::{PushPriority, PushQueues};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut queues, handle) = PushQueues::<u8>::bounded(1, 1);
+    ///     handle.push_high_priority(7u8).await.unwrap();
+    ///     let (priority, frame) = queues.recv().await.unwrap();
+    ///     assert_eq!(priority, PushPriority::High);
+    ///     assert_eq!(frame, 7);
+    /// }
+    /// ```
     #[must_use]
     pub fn bounded(high_capacity: usize, low_capacity: usize) -> (Self, PushHandle<F>) {
         let (high_tx, high_rx) = mpsc::channel(high_capacity);
@@ -151,6 +211,21 @@ impl<F: FrameLike> PushQueues<F> {
     /// Receive the next frame, preferring high priority frames when available.
     ///
     /// Returns `None` when both queues are closed and empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::push::{PushPriority, PushQueues};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut queues, handle) = PushQueues::bounded(1, 1);
+    ///     handle.push_high_priority(2u8).await.unwrap();
+    ///     let (priority, frame) = queues.recv().await.unwrap();
+    ///     assert_eq!(priority, PushPriority::High);
+    ///     assert_eq!(frame, 2);
+    /// }
+    /// ```
     pub async fn recv(&mut self) -> Option<(PushPriority, F)> {
         tokio::select! {
             biased;
@@ -163,6 +238,15 @@ impl<F: FrameLike> PushQueues<F> {
     ///
     /// This is primarily used in tests to release resources when no actor is
     /// draining the queues.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::push::PushQueues;
+    ///
+    /// let (mut queues, _handle) = PushQueues::<u8>::bounded(1, 1);
+    /// queues.close();
+    /// ```
     pub fn close(&mut self) {
         self.high_priority_rx.close();
         self.low_priority_rx.close();


### PR DESCRIPTION
## Summary
- add minimal usage examples for push queue APIs
- demonstrate use of extractor helpers

## Testing
- `make fmt`
- `make lint`
- `make test`
- `cargo test --doc`


------
https://chatgpt.com/codex/tasks/task_e_686720a89cd48322a2f82dbe55aa00a4