### PR TITLE
Refactor LengthFormat helpers to remove duplication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,6 +1205,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bincode",
+ "byteorder",
  "bytes",
  "dashmap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ tokio-util = "0.7"
 futures = "0.3"
 async-trait = "0.1"
 bytes = "1"
+byteorder = "1"
 log = "0.4"
 dashmap = "5"
 

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1130,6 +1130,8 @@ examples are invaluable. They make the abstract design tangible and showcase how
   use byteorder::{BigEndian, ReadBytesExt};
   use std::io;
 
+  const MAX_FRAME_LEN: usize = 16 * 1024 * 1024; // 16 MiB upper limit
+
   pub struct LengthPrefixedCodec;
 
   impl Decoder for LengthPrefixedCodec {
@@ -1142,6 +1144,10 @@ examples are invaluable. They make the abstract design tangible and showcase how
           let length = (&src[..4])
               .read_u32::<BigEndian>()
               .expect("slice length checked") as usize;
+
+          if length > MAX_FRAME_LEN {
+              return Err(io::Error::new(io::ErrorKind::InvalidInput, "frame too large"));
+          }
 
           if src.len() < 4 + length {
               src.reserve(4 + length - src.len());

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1123,50 +1123,51 @@ examples are invaluable. They make the abstract design tangible and showcase how
   2. **Frame Processor Implementation** (Simple Length-Prefixed Framing using
      `tokio-util`):
 
-     ```rust
-     // Crate: my_frame_processor.rs
-     use bytes::{BytesMut, Buf, BufMut};
-     use tokio_util::codec::{Encoder, Decoder};
-     use std::io;
+  ```rust
+  // Crate: my_frame_processor.rs
+  use bytes::{BytesMut, Buf, BufMut};
+  use tokio_util::codec::{Decoder, Encoder};
+  use byteorder::{BigEndian, ReadBytesExt};
+  use std::io;
 
-     pub struct LengthPrefixedCodec;
+  pub struct LengthPrefixedCodec;
 
-     impl Decoder for LengthPrefixedCodec {
-         type Item = BytesMut; // Raw frame payload
-         type Error = io::Error;
+  impl Decoder for LengthPrefixedCodec {
+      type Item = BytesMut; // Raw frame payload
+      type Error = io::Error;
 
-         fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-             if src.len() < 4 { return Ok(None); } // Not enough data for length prefix
+      fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+          if src.len() < 4 { return Ok(None); } // Not enough data for length prefix
 
-             let mut length_bytes = [0u8; 4];
-             length_bytes.copy_from_slice(&src[..4]);
-             let length = u32::from_be_bytes(length_bytes) as usize;
+          let length = (&src[..4])
+              .read_u32::<BigEndian>()
+              .expect("slice length checked") as usize;
 
-             if src.len() < 4 + length {
-                 src.reserve(4 + length - src.len());
-                 return Ok(None); // Not enough data for full frame
-             }
+          if src.len() < 4 + length {
+              src.reserve(4 + length - src.len());
+              return Ok(None); // Not enough data for full frame
+          }
 
-             src.advance(4); // Consume length prefix
-             Ok(Some(src.split_to(length)))
-         }
-     }
+          src.advance(4); // Consume length prefix
+          Ok(Some(src.split_to(length)))
+      }
+  }
 
-     impl<T: AsRef<[u8]>> Encoder<T> for LengthPrefixedCodec {
-         type Error = io::Error;
+  impl<T: AsRef<[u8]>> Encoder<T> for LengthPrefixedCodec {
+      type Error = io::Error;
 
-         fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
-             let data = item.as_ref();
-             dst.reserve(4 + data.len());
-             dst.put_u32(data.len() as u32);
-             dst.put_slice(data);
-             Ok(())
-         }
-     }
-     ```
+      fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+          let data = item.as_ref();
+          dst.reserve(4 + data.len());
+          dst.put_u32(data.len() as u32);
+          dst.put_slice(data);
+          Ok(())
+      }
+  }
+  ```
 
-     (Note: "wireframe" would abstract the direct use of `Encoder`/`Decoder`
-     behind its own `FrameProcessor` trait or provide helpers.)
+  (Note: "wireframe" would abstract the direct use of `Encoder`/`Decoder` behind
+  its own `FrameProcessor` trait or provide helpers.)
 
 1. **Server Setup and Handler**:
 

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -57,6 +57,7 @@ pub(crate) fn bytes_to_u64(bytes: &[u8], size: usize, endianness: Endianness) ->
         (4, Endianness::Little) => cur.read_u32::<LittleEndian>().map(u64::from),
         (8, Endianness::Big) => cur.read_u64::<BigEndian>(),
         (8, Endianness::Little) => cur.read_u64::<LittleEndian>(),
+        // size is validated above so this branch is unreachable
         _ => unreachable!(),
     }?;
     Ok(val)

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -104,6 +104,7 @@ pub(crate) fn bytes_to_u64(bytes: &[u8], size: usize, endianness: Endianness) ->
 /// let written = u64_to_bytes(0x1234, 2, Endianness::Big, &mut buf).unwrap();
 /// assert_eq!(&buf[..written], [0x12, 0x34]);
 /// ```
+#[must_use = "length prefix byte count must be used"]
 pub(crate) fn u64_to_bytes(
     len: usize,
     size: usize,

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -393,7 +393,7 @@ mod tests {
         #[case] endianness: Endianness,
     ) {
         let err = bytes_to_u64(&bytes, size, endianness)
-            .expect_err("bytes_to_u64 should fail for short slice");
+            .expect_err("bytes_to_u64 must error for truncated prefix slice");
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 
@@ -401,7 +401,7 @@ mod tests {
     fn u64_to_bytes_large() {
         let mut buf = [0u8; 8];
         let err = u64_to_bytes(300, 1, Endianness::Big, &mut buf)
-            .expect_err("u64_to_bytes should fail if value exceeds prefix size");
+            .expect_err("u64_to_bytes must fail if value exceeds 1-byte prefix");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -31,23 +31,35 @@ pub(crate) fn bytes_to_u64(bytes: &[u8], size: usize, endianness: Endianness) ->
     Ok(match (size, endianness) {
         (1, _) => u64::from(u8::from_ne_bytes([slice[0]])),
         (2, Endianness::Big) => u64::from(u16::from_be_bytes(
-            slice.try_into().expect("slice length validated"),
+            slice
+                .try_into()
+                .expect("expected 2 bytes for u16::from_be_bytes"),
         )),
         (2, Endianness::Little) => u64::from(u16::from_le_bytes(
-            slice.try_into().expect("slice length validated"),
+            slice
+                .try_into()
+                .expect("expected 2 bytes for u16::from_le_bytes"),
         )),
         (4, Endianness::Big) => u64::from(u32::from_be_bytes(
-            slice.try_into().expect("slice length validated"),
+            slice
+                .try_into()
+                .expect("expected 4 bytes for u32::from_be_bytes"),
         )),
         (4, Endianness::Little) => u64::from(u32::from_le_bytes(
-            slice.try_into().expect("slice length validated"),
+            slice
+                .try_into()
+                .expect("expected 4 bytes for u32::from_le_bytes"),
         )),
-        (8, Endianness::Big) => {
-            u64::from_be_bytes(slice.try_into().expect("slice length validated"))
-        }
-        (8, Endianness::Little) => {
-            u64::from_le_bytes(slice.try_into().expect("slice length validated"))
-        }
+        (8, Endianness::Big) => u64::from_be_bytes(
+            slice
+                .try_into()
+                .expect("expected 8 bytes for u64::from_be_bytes"),
+        ),
+        (8, Endianness::Little) => u64::from_le_bytes(
+            slice
+                .try_into()
+                .expect("expected 8 bytes for u64::from_le_bytes"),
+        ),
         _ => {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -380,14 +392,16 @@ mod tests {
         #[case] size: usize,
         #[case] endianness: Endianness,
     ) {
-        let err = bytes_to_u64(&bytes, size, endianness).expect_err("expected error");
+        let err = bytes_to_u64(&bytes, size, endianness)
+            .expect_err("bytes_to_u64 should fail for short slice");
         assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
     }
 
     #[rstest]
     fn u64_to_bytes_large() {
         let mut buf = [0u8; 8];
-        let err = u64_to_bytes(300, 1, Endianness::Big, &mut buf).expect_err("expected error");
+        let err = u64_to_bytes(300, 1, Endianness::Big, &mut buf)
+            .expect_err("u64_to_bytes should fail if value exceeds prefix size");
         assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
     }
 }

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -131,7 +131,7 @@ async fn send_response_propagates_write_error() {
     let err = app
         .send_response(&mut writer, &TestResp(3))
         .await
-        .expect_err("expected error");
+        .expect_err("send_response should propagate write error");
     assert!(matches!(err, wireframe::app::SendError::Io(_)));
 }
 
@@ -142,7 +142,7 @@ fn encode_fails_for_unsupported_prefix_size() {
     let mut buf = BytesMut::new();
     let err = processor
         .encode(&vec![1, 2], &mut buf)
-        .expect_err("expected error");
+        .expect_err("encode must fail for unsupported prefix size");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 }
 
@@ -151,7 +151,9 @@ fn decode_fails_for_unsupported_prefix_size() {
     let fmt = LengthFormat::new(3, Endianness::Little);
     let processor = LengthPrefixedProcessor::new(fmt);
     let mut buf = BytesMut::from(&[0x00, 0x01, 0x02][..]);
-    let err = processor.decode(&mut buf).expect_err("expected error");
+    let err = processor
+        .decode(&mut buf)
+        .expect_err("decode must fail for unsupported prefix size");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 }
 
@@ -165,6 +167,6 @@ async fn send_response_returns_encode_error() {
     let err = app
         .send_response(&mut Vec::new(), &FailingResp)
         .await
-        .expect_err("expected error");
+        .expect_err("send_response should fail when encode errors");
     assert!(matches!(err, wireframe::app::SendError::Serialize(_)));
 }


### PR DESCRIPTION
## Summary
- centralise prefix conversions in helper functions
- use helper functions in `read_len` and `write_len`

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686720af025883228d307b8f7a9b61bd

## Summary by Sourcery

Extract length prefix conversion into reusable helpers and refactor framing code to use them, adding comprehensive unit tests and refining test error messages.

Enhancements:
- Centralize length prefix encoding and decoding by introducing bytes_to_u64 and u64_to_bytes helper functions
- Refactor LengthFormat’s read_len and write_len methods to use the new helper functions and remove duplicated match logic

Tests:
- Add unit tests for bytes_to_u64 and u64_to_bytes covering various sizes, endianness, and error cases
- Update response tests to improve error expectation messages for send_response, encode, and decode failures