### PR TITLE
Use expect() in documentation examples

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -43,7 +43,7 @@ pub trait Message: Encode + for<'de> BorrowDecode<'de, ()> {
     /// #[derive(bincode::Encode, bincode::BorrowDecode)]
     /// struct MyMessageType(u8);
     /// let bytes = vec![]; // serialized message bytes
-    /// let (_msg, consumed) = MyMessageType::from_bytes(&bytes).unwrap();
+    /// let (_msg, consumed) = MyMessageType::from_bytes(&bytes).expect("valid message bytes");
     /// assert!(consumed <= bytes.len());
     /// ```
     fn from_bytes(bytes: &[u8]) -> Result<(Self, usize), DecodeError>

--- a/src/message.rs
+++ b/src/message.rs
@@ -43,7 +43,8 @@ pub trait Message: Encode + for<'de> BorrowDecode<'de, ()> {
     /// #[derive(bincode::Encode, bincode::BorrowDecode)]
     /// struct MyMessageType(u8);
     /// let bytes = vec![]; // serialized message bytes
-    /// let (_msg, consumed) = MyMessageType::from_bytes(&bytes).expect("valid message bytes");
+    /// let (_msg, consumed) =
+    ///     MyMessageType::from_bytes(&bytes).expect("Failed to decode message bytes");
     /// assert!(consumed <= bytes.len());
     /// ```
     fn from_bytes(bytes: &[u8]) -> Result<(Self, usize), DecodeError>

--- a/src/preamble.rs
+++ b/src/preamble.rs
@@ -95,9 +95,11 @@ where
 ///             .with_big_endian()
 ///             .with_fixed_int_encoding(),
 ///     )
-///     .unwrap();
+///     .expect("encoding example preamble");
 ///     let mut reader = BufReader::new(&data[..]);
-///     let (preamble, leftover) = read_preamble::<_, MyPreamble>(&mut reader).await.unwrap();
+///     let (preamble, leftover) = read_preamble::<_, MyPreamble>(&mut reader)
+///         .await
+///         .expect("valid preamble bytes");
 ///     assert_eq!(preamble.0, 42);
 ///     assert!(leftover.is_empty());
 /// }

--- a/src/preamble.rs
+++ b/src/preamble.rs
@@ -95,11 +95,11 @@ where
 ///             .with_big_endian()
 ///             .with_fixed_int_encoding(),
 ///     )
-///     .expect("encoding example preamble");
+///     .expect("Failed to encode example preamble");
 ///     let mut reader = BufReader::new(&data[..]);
 ///     let (preamble, leftover) = read_preamble::<_, MyPreamble>(&mut reader)
 ///         .await
-///         .expect("valid preamble bytes");
+///         .expect("Failed to decode preamble bytes");
 ///     assert_eq!(preamble.0, 42);
 ///     assert!(leftover.is_empty());
 /// }

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,7 +115,7 @@ where
     /// ```no_run
     /// # use wireframe::server::WireframeServer;
     /// # use wireframe::app::WireframeApp;
-    /// # let factory = || WireframeApp::new().unwrap();
+    /// # let factory = || WireframeApp::new().expect("app should initialise");
     /// #[derive(bincode::Decode)]
     /// # struct MyPreamble;
     /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
@@ -153,7 +153,7 @@ where
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().unwrap();
+    /// let factory = || WireframeApp::new().expect("app should initialise");
     /// let server = WireframeServer::new(factory).workers(4);
     /// assert_eq!(server.worker_count(), 4);
     /// let server = server.workers(0);
@@ -196,7 +196,7 @@ where
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().unwrap();
+    /// let factory = || WireframeApp::new().expect("app should initialise");
     /// let server = WireframeServer::new(factory);
     /// assert!(server.worker_count() >= 1);
     /// ```
@@ -234,9 +234,9 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().unwrap();
+    /// let factory = || WireframeApp::new().expect("app should initialise");
     /// let server = WireframeServer::new(factory);
-    /// let addr: SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    /// let addr: SocketAddr = "127.0.0.1:8080".parse().expect("valid address");
     /// let server = server.bind(addr).expect("Failed to bind address");
     /// ```
     pub fn bind(mut self, addr: SocketAddr) -> io::Result<Self> {
@@ -282,10 +282,12 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     /// async fn run_server() -> std::io::Result<()> {
-    ///     let factory = || WireframeApp::new().unwrap();
-    ///     let server = WireframeServer::new(factory)
-    ///         .workers(4)
-    ///         .bind("127.0.0.1:8080".parse::<SocketAddr>().unwrap())?;
+    ///     let factory = || WireframeApp::new().expect("app should initialise");
+    ///     let server = WireframeServer::new(factory).workers(4).bind(
+    ///         "127.0.0.1:8080"
+    ///             .parse::<SocketAddr>()
+    ///             .expect("valid address"),
+    ///     )?;
     ///     server.run().await
     /// }
     /// ```

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,7 +115,7 @@ where
     /// ```no_run
     /// # use wireframe::server::WireframeServer;
     /// # use wireframe::app::WireframeApp;
-    /// # let factory = || WireframeApp::new().expect("app should initialise");
+    /// # let factory = || WireframeApp::new().expect("Failed to initialise app");
     /// #[derive(bincode::Decode)]
     /// # struct MyPreamble;
     /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
@@ -153,7 +153,7 @@ where
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().expect("app should initialise");
+    /// let factory = || WireframeApp::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory).workers(4);
     /// assert_eq!(server.worker_count(), 4);
     /// let server = server.workers(0);
@@ -196,7 +196,7 @@ where
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().expect("app should initialise");
+    /// let factory = || WireframeApp::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory);
     /// assert!(server.worker_count() >= 1);
     /// ```
@@ -234,9 +234,9 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().expect("app should initialise");
+    /// let factory = || WireframeApp::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory);
-    /// let addr: SocketAddr = "127.0.0.1:8080".parse().expect("valid address");
+    /// let addr: SocketAddr = "127.0.0.1:8080".parse().expect("Failed to parse address");
     /// let server = server.bind(addr).expect("Failed to bind address");
     /// ```
     pub fn bind(mut self, addr: SocketAddr) -> io::Result<Self> {
@@ -282,12 +282,11 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     /// async fn run_server() -> std::io::Result<()> {
-    ///     let factory = || WireframeApp::new().expect("app should initialise");
-    ///     let server = WireframeServer::new(factory).workers(4).bind(
-    ///         "127.0.0.1:8080"
-    ///             .parse::<SocketAddr>()
-    ///             .expect("valid address"),
-    ///     )?;
+    ///     let factory = || WireframeApp::new().expect("Failed to initialise app");
+    ///     let addr = "127.0.0.1:8080"
+    ///         .parse::<SocketAddr>()
+    ///         .expect("Failed to parse address");
+    ///     let server = WireframeServer::new(factory).workers(4).bind(addr)?;
     ///     server.run().await
     /// }
     /// ```


### PR DESCRIPTION
## Summary
- replace `unwrap()` with `expect()` in doctest code examples
- keep documentation examples compiling

## Testing
- `make fmt`
- `make lint`
- `make test`
- `cargo test --doc`


------
https://chatgpt.com/codex/tasks/task_e_686720d9943c832284c4d886043b4fcc

## Summary by Sourcery

Replace unwrap() calls in documentation examples with expect() calls including descriptive error messages to improve clarity and ensure doctests compile successfully

Enhancements:
- Replace unwrap() with expect() in documentation code samples to provide clearer failure messages

Documentation:
- Update examples in server, preamble, and message modules to use expect() instead of unwrap()

Tests:
- Verify doctests continue to compile and pass after updates