### PR TITLE
Test LengthFormat error handling

### DIFF
--- a/tests/response.rs
+++ b/tests/response.rs
@@ -135,9 +135,12 @@ async fn send_response_propagates_write_error() {
     assert!(matches!(err, wireframe::app::SendError::Io(_)));
 }
 
-#[test]
-fn encode_fails_for_unsupported_prefix_size() {
-    let fmt = LengthFormat::new(3, Endianness::Big);
+#[rstest]
+#[case(0, Endianness::Big)]
+#[case(3, Endianness::Big)]
+#[case(5, Endianness::Little)]
+fn encode_fails_for_invalid_prefix_size(#[case] bytes: usize, #[case] endian: Endianness) {
+    let fmt = LengthFormat::new(bytes, endian);
     let processor = LengthPrefixedProcessor::new(fmt);
     let mut buf = BytesMut::new();
     let err = processor
@@ -146,12 +149,28 @@ fn encode_fails_for_unsupported_prefix_size() {
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 }
 
-#[test]
-fn decode_fails_for_unsupported_prefix_size() {
-    let fmt = LengthFormat::new(3, Endianness::Little);
+#[rstest]
+#[case(0, Endianness::Little)]
+#[case(3, Endianness::Little)]
+#[case(5, Endianness::Big)]
+fn decode_fails_for_invalid_prefix_size(#[case] bytes: usize, #[case] endian: Endianness) {
+    let fmt = LengthFormat::new(bytes, endian);
     let processor = LengthPrefixedProcessor::new(fmt);
-    let mut buf = BytesMut::from(&[0x00, 0x01, 0x02][..]);
+    let mut buf = BytesMut::from(vec![0u8; bytes].as_slice());
     let err = processor.decode(&mut buf).expect_err("expected error");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+}
+
+#[rstest]
+#[case(LengthFormat::new(1, Endianness::Big), 256)]
+#[case(LengthFormat::new(2, Endianness::Little), 65_536)]
+fn encode_fails_for_length_too_large(#[case] fmt: LengthFormat, #[case] len: usize) {
+    let processor = LengthPrefixedProcessor::new(fmt);
+    let frame = vec![0u8; len];
+    let mut buf = BytesMut::new();
+    let err = processor
+        .encode(&frame, &mut buf)
+        .expect_err("expected error");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
 }
 


### PR DESCRIPTION
## Summary
- add parameterised tests for invalid prefix sizes and lengths
- check that encode/decode return `InvalidInput`

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686720df302883228671891f828f577e

## Summary by Sourcery

Use rstest to consolidate and expand error handling tests for LengthFormat, parameterizing invalid prefix sizes and excessive lengths and asserting InvalidInput errors.

Enhancements:
- Replace individual invalid-prefix tests with parameterized rstest usage

Tests:
- Parameterize encode error tests for invalid prefix sizes (0, 3, 5 bytes) using rstest
- Parameterize decode error tests for invalid prefix sizes (0, 3, 5 bytes) using rstest
- Add rstest cases for encode failures when payload length exceeds prefix capacity