### PR TITLE
Fix preamble error docs

### DIFF
--- a/src/preamble.rs
+++ b/src/preamble.rs
@@ -52,31 +52,26 @@ where
     Ok(())
 }
 
-/// Read and decode a connection preamble using bincode.
+/// Asynchronously read and decode a connection preamble using bincode.
 ///
 /// This helper reads the exact number of bytes required by `T`, as
 /// indicated by [`DecodeError::UnexpectedEnd`]. Additional bytes are
-/// requested from the reader until decoding succeeds or fails for some
+/// requested from `reader` until decoding succeeds or fails for some
 /// other reason.
 ///
-/// # Errors
-///
-/// Returns a [`DecodeError`] if decoding the preamble fails or an
-/// Asynchronously reads and decodes a preamble of type `T` from an async reader using bincode.
-///
-/// Attempts to decode a value of type `T` from the beginning of the byte stream, reading more bytes
-/// as needed until decoding succeeds or an error occurs. Any bytes remaining after the decoded
-/// value are returned as leftovers.
+/// Attempts to decode a value of type `T` from the beginning of the
+/// byte stream, reading more bytes as needed until decoding succeeds or
+/// an error occurs. Any bytes remaining after the decoded value are
+/// returned as leftovers.
 ///
 /// # Returns
 ///
-/// A tuple containing the decoded value and a vector of leftover bytes following the decoded
-/// preamble.
+/// A tuple containing the decoded value and any leftover bytes.
 ///
 /// # Errors
 ///
-/// Returns a `DecodeError` if decoding fails or if an I/O error occurs while reading from the
-/// reader.
+/// Returns a [`DecodeError`] if decoding fails or if an I/O error occurs
+/// while reading from `reader`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
## Summary
- clarify the `read_preamble` documentation
- improve explanation of decoding failures and I/O errors

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686720f0c200832281c90a97c52fb0af

## Summary by Sourcery

Update read_preamble documentation to clarify its asynchronous behavior and error conditions

Documentation:
- Clarify that read_preamble reads asynchronously from the provided reader using bincode
- Improve explanations of decoding failures, I/O errors, and how leftover bytes are returned