### PR TITLE
Implement error displays

### DIFF
--- a/src/push.rs
+++ b/src/push.rs
@@ -45,6 +45,17 @@ pub enum PushError {
     Closed,
 }
 
+impl std::fmt::Display for PushError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::QueueFull => f.write_str("push queue full"),
+            Self::Closed => f.write_str("push queue closed"),
+        }
+    }
+}
+
+impl std::error::Error for PushError {}
+
 pub(crate) struct PushHandleInner<F> {
     high_prio_tx: mpsc::Sender<F>,
     low_prio_tx: mpsc::Sender<F>,

--- a/src/response.rs
+++ b/src/response.rs
@@ -89,3 +89,21 @@ impl<E> WireframeError<E> {
     #[must_use]
     pub fn from_io(e: std::io::Error) -> Self { WireframeError::Io(e) }
 }
+
+impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WireframeError::Io(e) => write!(f, "transport error: {e}"),
+            WireframeError::Protocol(e) => write!(f, "protocol error: {e:?}"),
+        }
+    }
+}
+
+impl<E: std::fmt::Debug> std::error::Error for WireframeError<E> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            WireframeError::Io(e) => Some(e),
+            WireframeError::Protocol(_e) => None,
+        }
+    }
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -99,11 +99,14 @@ impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
     }
 }
 
-impl<E: std::fmt::Debug> std::error::Error for WireframeError<E> {
+impl<E> std::error::Error for WireframeError<E>
+where
+    E: std::fmt::Debug + std::error::Error + 'static,
+{
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             WireframeError::Io(e) => Some(e),
-            WireframeError::Protocol(_e) => None,
+            WireframeError::Protocol(e) => Some(e),
         }
     }
 }

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -1,7 +1,7 @@
 //! Tests for Display and Error trait implementations on error types.
 //!
 //! Verifies that error types provide human-readable messages via Display
-//! and correctly expose underlying error sources via Error::source.
+//! and correctly expose underlying error sources via `Error::source`.
 
 use std::error::Error;
 

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -1,5 +1,7 @@
 //! Tests for Display implementations on error types.
 
+use std::error::Error;
+
 use wireframe::{push::PushError, response::WireframeError};
 
 #[test]
@@ -23,6 +25,12 @@ fn wireframe_error_messages() {
     let io = WireframeError::<ProtoErr>::Io(io_error);
     assert_eq!(io.to_string(), "transport error: socket closed");
 
+    let source = io.source().expect("io variant must have source");
+    assert_eq!(source.to_string(), "socket closed");
+
     let proto = WireframeError::Protocol(ProtoErr);
     assert_eq!(proto.to_string(), "protocol error: ProtoErr");
+
+    let source = proto.source().expect("protocol variant must have source");
+    assert_eq!(source.to_string(), "boom");
 }

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -1,4 +1,7 @@
-//! Tests for Display implementations on error types.
+//! Tests for Display and Error trait implementations on error types.
+//!
+//! Verifies that error types provide human-readable messages via Display
+//! and correctly expose underlying error sources via Error::source.
 
 use std::error::Error;
 

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -1,0 +1,28 @@
+//! Tests for Display implementations on error types.
+
+use wireframe::{push::PushError, response::WireframeError};
+
+#[test]
+fn push_error_messages() {
+    assert_eq!(PushError::QueueFull.to_string(), "push queue full");
+    assert_eq!(PushError::Closed.to_string(), "push queue closed");
+}
+
+#[derive(Debug)]
+struct ProtoErr;
+
+impl std::fmt::Display for ProtoErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { f.write_str("boom") }
+}
+
+impl std::error::Error for ProtoErr {}
+
+#[test]
+fn wireframe_error_messages() {
+    let io_error = std::io::Error::other("socket closed");
+    let io = WireframeError::<ProtoErr>::Io(io_error);
+    assert_eq!(io.to_string(), "transport error: socket closed");
+
+    let proto = WireframeError::Protocol(ProtoErr);
+    assert_eq!(proto.to_string(), "protocol error: ProtoErr");
+}

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -9,7 +9,7 @@ use wireframe::{push::PushError, response::WireframeError};
 
 #[rstest::rstest]
 #[case(PushError::QueueFull, "push queue full")]
-#[case(PushError::Closed,    "push queue closed")]
+#[case(PushError::Closed, "push queue closed")]
 fn push_error_messages(#[case] err: PushError, #[case] expected: &str) {
     assert_eq!(err.to_string(), expected);
 }

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -7,10 +7,11 @@ use std::error::Error;
 
 use wireframe::{push::PushError, response::WireframeError};
 
-#[test]
-fn push_error_messages() {
-    assert_eq!(PushError::QueueFull.to_string(), "push queue full");
-    assert_eq!(PushError::Closed.to_string(), "push queue closed");
+#[rstest::rstest]
+#[case(PushError::QueueFull, "push queue full")]
+#[case(PushError::Closed,    "push queue closed")]
+fn push_error_messages(#[case] err: PushError, #[case] expected: &str) {
+    assert_eq!(err.to_string(), expected);
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary
- implement `Display` and `Error` for `PushError` and `WireframeError`
- add unit tests for their messages

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68672877bd40832288a1ab59f7fe1cc6

## Summary by Sourcery

Implement user-friendly display messages and error trait support for PushError and WireframeError, and add unit tests to verify their formatting and error sources.

Enhancements:
- Provide Display implementations for PushError and WireframeError to produce readable error messages
- Implement std::error::Error for both error types to expose underlying sources

Tests:
- Add unit tests for PushError and WireframeError to verify display outputs and source propagation