### PR TITLE
Improve error Display test docs

### DIFF
--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -2,8 +2,8 @@
 //!
 //! Verifies that error types provide human-readable messages via Display
 //! and correctly expose underlying error sources via `Error::source`.
-//! Implementing these traits keeps logs clear for operators
-//! and surfaces cause chains so developers can diagnose issues.
+//! Implementing these traits keeps logs clear for operators,
+//! and surfaces causal chains so developers can diagnose issues.
 
 use std::error::Error;
 


### PR DESCRIPTION
## Summary
- clarify why Display and Error traits matter for users

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68684aa2d72083228cc40942031cb985

## Summary by Sourcery

Documentation:
- Clarify the rationale for implementing Display and Error traits in the error_display test file