### PR TITLE
Add fairness disabled test

### DIFF
--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -81,16 +81,23 @@ async fn fairness_disabled_processes_all_high_first(
     };
 
     for n in 1..=3 {
-        handle.push_high_priority(n).await.unwrap();
+        let message = format!("failed to push high-priority frame {n}");
+        handle.push_high_priority(n).await.expect(&message);
     }
-    handle.push_low_priority(4).await.unwrap();
-    handle.push_low_priority(5).await.unwrap();
+    handle
+        .push_low_priority(4)
+        .await
+        .expect("failed to push low-priority frame 4");
+    handle
+        .push_low_priority(5)
+        .await
+        .expect("failed to push low-priority frame 5");
 
     let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, None, shutdown_token);
     actor.set_fairness(fairness);
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(out, vec![1, 2, 3, 4, 5]);
 }
 

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -70,6 +70,32 @@ async fn fairness_yields_low_after_burst(
 
 #[rstest]
 #[tokio::test]
+async fn fairness_disabled_processes_all_high_first(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, handle) = queues;
+    let fairness = FairnessConfig {
+        max_high_before_low: 0,
+        time_slice: None,
+    };
+
+    for n in 1..=3 {
+        handle.push_high_priority(n).await.unwrap();
+    }
+    handle.push_low_priority(4).await.unwrap();
+    handle.push_low_priority(5).await.unwrap();
+
+    let mut actor: ConnectionActor<_, ()> =
+        ConnectionActor::new(queues, handle, None, shutdown_token);
+    actor.set_fairness(fairness);
+    let mut out = Vec::new();
+    actor.run(&mut out).await.unwrap();
+    assert_eq!(out, vec![1, 2, 3, 4, 5]);
+}
+
+#[rstest]
+#[tokio::test]
 async fn shutdown_signal_precedence(
     queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
     shutdown_token: CancellationToken,


### PR DESCRIPTION
## Summary
- ensure fairness logic allows strict high-priority ordering when disabled

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68684b415d30832295e9e8e5017abdc5

## Summary by Sourcery

Tests:
- Add a `fairness_disabled_processes_all_high_first` test to ensure all high-priority items are processed before any low-priority ones when fairness is disabled