### PR TITLE
Fix fairness comment

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -37,10 +37,10 @@ enum Event<F, E> {
 #[derive(Clone, Copy)]
 pub struct FairnessConfig {
     /// Number of consecutive high-priority frames to process before
-    /// checking the low-priority queue.
+    /// checking the low-priority queue. A zero value disables the
+    /// counter and relies solely on `time_slice` for fairness,
+    /// preserving strict high-priority ordering otherwise.
     pub max_high_before_low: usize,
-    /// A zero value disables the counter and relies solely on `time_slice` for
-    /// fairness, preserving strict high-priority ordering otherwise.
     /// Optional time slice after which the low-priority queue is checked
     /// if high-priority traffic has been continuous.
     pub time_slice: Option<Duration>,


### PR DESCRIPTION
## Summary
- clarify the `FairnessConfig::max_high_before_low` docs

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68684b92646883228c98962600545d77

## Summary by Sourcery

Documentation:
- Expand the `max_high_before_low` doc comment to state that setting it to zero disables the counter and relies solely on `time_slice`, preserving strict high-priority ordering