### PR TITLE
Implement typed protocol error handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -406,7 +406,7 @@ where
     ///
     /// If no protocol is installed, returns default (no-op) hooks.
     #[must_use]
-    pub fn protocol_hooks(&self) -> ProtocolHooks<Vec<u8>> {
+    pub fn protocol_hooks(&self) -> ProtocolHooks<Vec<u8>, ()> {
         self.protocol
             .as_ref()
             .map(|p| ProtocolHooks::from_protocol(&Arc::clone(p)))

--- a/src/response.rs
+++ b/src/response.rs
@@ -72,6 +72,22 @@ impl<F, E> From<Vec<F>> for Response<F, E> {
 }
 
 /// A generic error type for wireframe operations.
+///
+/// # Examples
+///
+/// ```no_run
+/// use wireframe::response::WireframeError;
+///
+/// #[derive(Debug)]
+/// enum MyError {
+///     BadRequest,
+/// }
+///
+/// let proto_err: WireframeError<MyError> = MyError::BadRequest.into();
+/// let io_err: WireframeError<MyError> = WireframeError::from_io(std::io::Error::other("boom"));
+/// # drop(proto_err);
+/// # drop(io_err);
+/// ```
 #[derive(Debug)]
 pub enum WireframeError<E = ()> {
     /// An error in the underlying transport (e.g., socket closed).

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -119,15 +119,46 @@ async fn error_propagation_from_stream(
         Ok(2u8),
         Err(WireframeError::Protocol(TestError::Kaboom)),
     ]);
-    let mut actor: ConnectionActor<_, TestError> =
+    let called = Arc::new(AtomicUsize::new(0));
+    let c = called.clone();
+    let hooks = ProtocolHooks {
+        handle_error: Some(Box::new(
+            move |_e: TestError, _ctx: &mut ConnectionContext| {
+                c.fetch_add(1, Ordering::SeqCst);
+            },
+        )),
+        ..ProtocolHooks::<u8, TestError>::default()
+    };
+    let mut actor: ConnectionActor<_, TestError> = ConnectionActor::with_hooks(
+        queues,
+        handle,
+        Some(Box::pin(stream)),
+        shutdown_token,
+        hooks,
+    );
+    let mut out = Vec::new();
+    actor.run(&mut out).await.unwrap();
+    assert_eq!(called.load(Ordering::SeqCst), 1);
+    assert_eq!(out, vec![1, 2]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn io_error_terminates_connection(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, handle) = queues;
+    let stream = stream::iter(vec![
+        Ok(1u8),
+        Err(WireframeError::Io(std::io::Error::other("fail"))),
+    ]);
+    let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
     let result = actor.run(&mut out).await;
-    assert!(matches!(
-        result,
-        Err(WireframeError::Protocol(TestError::Kaboom))
-    ));
-    assert_eq!(out, vec![1, 2]);
+    assert!(matches!(result, Err(WireframeError::Io(_))));
+    assert_eq!(out, vec![1]);
 }
 
 #[rstest]
@@ -190,7 +221,7 @@ async fn before_send_hook_modifies_frames(
     let stream = stream::iter(vec![Ok(2u8)]);
     let hooks = ProtocolHooks {
         before_send: Some(Box::new(|f: &mut u8, _ctx: &mut ConnectionContext| *f += 1)),
-        ..ProtocolHooks::default()
+        ..ProtocolHooks::<u8, ()>::default()
     };
 
     let mut actor: ConnectionActor<_, ()> = ConnectionActor::with_hooks(
@@ -220,7 +251,7 @@ async fn on_command_end_hook_runs(
         on_command_end: Some(Box::new(move |_ctx: &mut ConnectionContext| {
             c.fetch_add(1, Ordering::SeqCst);
         })),
-        ..ProtocolHooks::default()
+        ..ProtocolHooks::<u8, ()>::default()
     };
 
     let mut actor: ConnectionActor<_, ()> = ConnectionActor::with_hooks(


### PR DESCRIPTION
## Summary
- extend `WireframeProtocol` with `handle_error` for recoverable protocol errors
- support typed errors in `ProtocolHooks` and `ConnectionActor`
- document `WireframeError` usage and new trait method
- test protocol error handling and IO error propagation

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `markdownlint *.md docs/**/*.md`
- `mdformat-all README.md docs/**/*.md`

------
https://chatgpt.com/codex/tasks/task_e_68685a3ed63c8322959c5f1c33da81ac