### PR TITLE
Add time slice fairness test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 bincode = "2"
-tokio = { version = "1", default-features = false, features = ["net", "signal", "rt-multi-thread", "macros", "sync", "time", "io-util"] }
+tokio = { version = "1", default-features = false, features = ["net", "signal", "rt-multi-thread", "macros", "sync", "time", "io-util", "test-util"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 async-trait = "0.1"

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -5,7 +5,10 @@
 
 use futures::stream;
 use rstest::{fixture, rstest};
-use tokio::time::{Duration, sleep, timeout};
+use tokio::{
+    sync::oneshot,
+    time::{Duration, sleep, timeout},
+};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use wireframe::{
     connection::{ConnectionActor, FairnessConfig},
@@ -66,6 +69,48 @@ async fn fairness_yields_low_after_burst(
     let mut out = Vec::new();
     actor.run(&mut out).await.unwrap();
     assert_eq!(out, vec![1, 2, 99, 3, 4, 5]);
+}
+
+#[rstest]
+#[tokio::test]
+async fn fairness_yields_low_with_time_slice(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, handle) = queues;
+    let fairness = FairnessConfig {
+        max_high_before_low: 0,
+        time_slice: Some(Duration::from_millis(10)),
+    };
+
+    let mut actor: ConnectionActor<_, ()> =
+        ConnectionActor::new(queues, handle.clone(), None, shutdown_token);
+    actor.set_fairness(fairness);
+
+    let (tx, rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut out = Vec::new();
+        let _ = actor.run(&mut out).await;
+        let _ = tx.send(out);
+    });
+
+    handle.push_high_priority(1).await.unwrap();
+    sleep(Duration::from_millis(5)).await;
+    handle.push_high_priority(2).await.unwrap();
+    sleep(Duration::from_millis(15)).await;
+    handle.push_low_priority(42).await.unwrap();
+    for n in 3..=5 {
+        handle.push_high_priority(n).await.unwrap();
+    }
+    drop(handle);
+
+    let out = rx.await.unwrap();
+    assert!(out.contains(&42), "Low-priority item was not yielded");
+    let pos = out.iter().position(|x| *x == 42).unwrap();
+    assert!(
+        pos > 0 && pos < out.len() - 1,
+        "Low-priority item should be yielded in the middle"
+    );
 }
 
 #[rstest]

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -73,6 +73,39 @@ async fn fairness_yields_low_after_burst(
 
 #[rstest]
 #[tokio::test]
+async fn fairness_disabled_processes_all_high_first(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+    shutdown_token: CancellationToken,
+) {
+    let (queues, handle) = queues;
+    let fairness = FairnessConfig {
+        max_high_before_low: 0,
+        time_slice: None,
+    };
+
+    for n in 1..=3 {
+        let message = format!("failed to push high-priority frame {n}");
+        handle.push_high_priority(n).await.expect(&message);
+    }
+    handle
+        .push_low_priority(4)
+        .await
+        .expect("failed to push low-priority frame 4");
+    handle
+        .push_low_priority(5)
+        .await
+        .expect("failed to push low-priority frame 5");
+
+    let mut actor: ConnectionActor<_, ()> =
+        ConnectionActor::new(queues, handle, None, shutdown_token);
+    actor.set_fairness(fairness);
+    let mut out = Vec::new();
+    actor.run(&mut out).await.expect("actor run failed");
+    assert_eq!(out, vec![1, 2, 3, 4, 5]);
+}
+
+#[rstest]
+#[tokio::test]
 async fn fairness_yields_low_with_time_slice(
     queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
     shutdown_token: CancellationToken,

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -110,6 +110,8 @@ async fn fairness_yields_low_with_time_slice(
     queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
     shutdown_token: CancellationToken,
 ) {
+    // Use Tokio's virtual clock so timing-dependent fairness is deterministic.
+    tokio::time::pause();
     let (queues, handle) = queues;
     let fairness = FairnessConfig {
         max_high_before_low: 0,
@@ -128,9 +130,9 @@ async fn fairness_yields_low_with_time_slice(
     });
 
     handle.push_high_priority(1).await.unwrap();
-    sleep(Duration::from_millis(5)).await;
+    tokio::time::advance(Duration::from_millis(5)).await;
     handle.push_high_priority(2).await.unwrap();
-    sleep(Duration::from_millis(15)).await;
+    tokio::time::advance(Duration::from_millis(15)).await;
     handle.push_low_priority(42).await.unwrap();
     for n in 3..=5 {
         handle.push_high_priority(n).await.unwrap();


### PR DESCRIPTION
## Summary
- add test to cover time-based queue fairness when `max_high_before_low` is zero
- clean up duplicate imports in test module

## Testing
- `make fmt`
- `make lint`
- `make test`
- `cargo test fairness_yields_low_with_time_slice -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68684cd037548322a494feb0d1e8476d

## Summary by Sourcery

Add a test to verify time-based queue fairness with a nonzero time slice when high-priority quotas are zero and remove redundant imports from the test module

Tests:
- Introduce `fairness_yields_low_with_time_slice` to ensure low-priority items are yielded based on time slices when `max_high_before_low` is zero

Chores:
- Clean up duplicate imports in the connection actor test module