### PR TITLE
Add Codecov upload to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,4 +57,8 @@ jobs:
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
         run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
+      - name: Upload coverage data to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
 

--- a/docs/multi-layered-testing-strategy.md
+++ b/docs/multi-layered-testing-strategy.md
@@ -15,6 +15,9 @@ reviewers. This approach ensures that we establish a baseline of correctness
 with simple tests before moving on to the more complex and subtle failure modes
 that can emerge in an asynchronous, high-concurrency system.
 
+Code coverage is measured with `cargo tarpaulin`. The CI workflow uploads the
+generated `lcov.info` report to Codecov for visibility across pull requests.
+
 ## 2. Layer 1: Foundational Correctness (Unit & Integration)
 
 **Objective:** To verify that each component behaves correctly in isolation and


### PR DESCRIPTION
## Summary
- add Codecov upload step to CI workflow
- document Codecov coverage reporting in the testing strategy

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686909ab77b8832291b706d85b9ef975