### PR TITLE
Update CI coverage actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,23 +40,18 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
         run: cargo test
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
       - name: Run coverage
-        run: cargo tarpaulin --out lcov
-      - name: Install CodeScene coverage tool
-        if: env.CS_ACCESS_TOKEN
-        run: |
-          set -euo pipefail
-          curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-          bash install-cs-coverage-tool.sh -y
-          rm install-cs-coverage-tool.sh
+        id: coverage
+        uses: leynos/shared-actions/.github/actions/ratchet-coverage@v1.2.0
+        with:
+          args: --workspace --lcov --output-path lcov.info
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
-        run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.0
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}
       - name: Upload coverage data to Codecov
         # v5.4.3
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,12 @@ jobs:
         run: cargo test
       - name: Run coverage
         id: coverage
-        uses: leynos/shared-actions/.github/actions/ratchet-coverage@v1.2.0
+        uses: leynos/shared-actions/.github/actions/ratchet-coverage@v1.2.1
         with:
           args: --workspace --lcov --output-path lcov.info
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.0
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
         with:
           format: lcov
           access-token: ${{ env.CS_ACCESS_TOKEN }}

--- a/docs/multi-layered-testing-strategy.md
+++ b/docs/multi-layered-testing-strategy.md
@@ -15,10 +15,12 @@ reviewers. This approach ensures that we establish a baseline of correctness
 with simple tests before moving on to the more complex and subtle failure modes
 that can emerge in an asynchronous, high-concurrency system.
 
-Code coverage is measured with `cargo tarpaulin`.  The CI workflow uploads the
-generated `lcov.info` report to Codecov using a pinned version of the Codecov
-GitHub Action (`18283e04ce6e62d37312384ff67231eb8fd56d24`, corresponding to
-v5.4.3) to make coverage visible across pull requests.
+Code coverage is measured with `cargo llvm-cov`. The workflow uses the
+`ratchet-coverage` action to fail if coverage drops, and uploads the resulting
+`lcov.info` to Codecov using a pinned version of the Codecov GitHub Action
+(`18283e04ce6e62d37312384ff67231eb8fd56d24`, corresponding to v5.4.3). The same
+report is also sent to CodeScene via the `upload-codescene-coverage@v1.2.0`
+action.
 
 ## 2. Layer 1: Foundational Correctness (Unit & Integration)
 

--- a/docs/multi-layered-testing-strategy.md
+++ b/docs/multi-layered-testing-strategy.md
@@ -15,12 +15,12 @@ reviewers. This approach ensures that we establish a baseline of correctness
 with simple tests before moving on to the more complex and subtle failure modes
 that can emerge in an asynchronous, high-concurrency system.
 
-Code coverage is measured with `cargo llvm-cov`. The workflow uses the
-`ratchet-coverage` action to fail if coverage drops, and uploads the resulting
-`lcov.info` to Codecov using a pinned version of the Codecov GitHub Action
-(`18283e04ce6e62d37312384ff67231eb8fd56d24`, corresponding to v5.4.3). The same
-report is also sent to CodeScene via the `upload-codescene-coverage@v1.2.0`
-action.
+Code coverage is measured with `cargo llvm-cov`. The `ratchet-coverage` action
+builds on this tool—not `cargo-tarpaulin`—and fails if coverage drops. The
+resulting `lcov.info` is uploaded to Codecov using a pinned version of the
+Codecov GitHub Action (`18283e04ce6e62d37312384ff67231eb8fd56d24`, corresponding
+to v5.4.3). The same report is also sent to CodeScene via the
+`upload-codescene-coverage@v1.2.0` action.
 
 ## 2. Layer 1: Foundational Correctness (Unit & Integration)
 


### PR DESCRIPTION
## Summary
- switch to the shared `ratchet-coverage` action for coverage
- upload CodeScene coverage using the new `upload-codescene-coverage` action
- document the new coverage workflow

## Testing
- `make fmt`
- `make lint`
- `make test`
- `markdownlint *.md **/*.md`
- `mdformat-all`
- `nixie *.md **/*.md` *(fails: RuntimeError: Event loop is closed)*

------
https://chatgpt.com/codex/tasks/task_e_6869243cbb0483229d3ae9c1dae7deb7

## Summary by Sourcery

Consolidate CI coverage steps by adopting shared GitHub Actions for coverage measurement and CodeScene uploads, and update project docs to reflect the new coverage pipeline.

CI:
- Switch CI coverage job to use shared `ratchet-coverage` action with lcov output
- Replace manual CodeScene CLI installation with shared `upload-codescene-coverage` action

Documentation:
- Update documentation to reference `cargo llvm-cov`, `ratchet-coverage`, and `upload-codescene-coverage` workflows