### PR TITLE
Add time slice fairness test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ logtest = "^2.0"
 proptest = "^1.0"
 loom = "^0.7"
 async-stream = "0.3"
+tokio = { version = "1", default-features = false, features = ["test-util"] }
 
 [features]
 advanced-tests = []

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -119,6 +119,16 @@ libraries. This convention prevents testing utilities from being included in
 production binaries, which helps keep them small and reduces compile times for
 non-test builds.
 
+When leveraging Tokio's test utilities—for example `tokio::time::pause` or the
+I/O helpers in `tokio-test`—enable the `test-util` feature via a dev-only
+dependency:
+
+```toml
+[dev-dependencies]
+tokio = { version = "1", default-features = false, features = ["test-util"] }
+rstest = "0.18"
+```
+
 ### B. Your First Fixture: Defining with `#[fixture]`
 
 A fixture in `rstest` is essentially a Rust function that provides some data or


### PR DESCRIPTION
## Summary
- add test to cover time-based queue fairness when `max_high_before_low` is zero
- add missing test for disabled fairness and annotate it properly
- clean up duplicate imports in test module
- use Tokio's virtual time to avoid flakiness in time slice fairness test
- move Tokio's test utilities to dev dependencies
- document enabling `tokio`'s `test-util` feature for deterministic tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `cargo test --test connection_actor fairness_yields_low_with_time_slice -- --exact --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68684cd037548322a494feb0d1e8476d

## Summary by Sourcery

Add comprehensive fairness tests for connection queues, use Tokio virtual time for deterministic scheduling, reorganize dependencies, and update documentation for test utilities

Build:
- Move Tokio's `test-util` feature into dev-dependencies in Cargo.toml

Documentation:
- Document enabling Tokio's `test-util` feature for deterministic tests

Tests:
- Add disabled-fairness test when `max_high_before_low` is zero
- Add time-slice fairness test using Tokio's virtual time to avoid flakiness
- Clean up duplicate imports in the test module