### PR TITLE
Refine fairness config documentation

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -37,9 +37,11 @@ enum Event<F, E> {
 #[derive(Clone, Copy)]
 pub struct FairnessConfig {
     /// Number of consecutive high-priority frames to process before
-    /// checking the low-priority queue. A zero value disables the
-    /// counter and relies solely on `time_slice` for fairness,
-    /// preserving strict high-priority ordering otherwise.
+    /// checking the low-priority queue.
+    ///
+    /// A zero value disables the counter and relies solely on
+    /// `time_slice` for fairness, preserving strict high-priority
+    /// ordering otherwise.
     pub max_high_before_low: usize,
     /// Optional time slice after which the low-priority queue is checked
     /// if high-priority traffic has been continuous.


### PR DESCRIPTION
## Summary
- restructure the `max_high_before_low` field documentation so the zero-value behaviour is included in the field's doc comment

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6869d21b30cc83228f30160295c1995e

## Summary by Sourcery

Documentation:
- Restructure the `max_high_before_low` doc comment to include an example of zero-value behavior and enhance formatting for clarity.