### PR TITLE
Add test for strict priority when fairness disabled

### DIFF
--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -71,9 +71,18 @@ async fn fairness_yields_low_after_burst(
     assert_eq!(out, vec![1, 2, 99, 3, 4, 5]);
 }
 
+#[derive(Debug, Clone, Copy)]
+enum Priority {
+    High,
+    Low,
+}
+
 #[rstest]
+#[case(vec![Priority::High, Priority::High, Priority::High, Priority::Low, Priority::Low])]
+#[case(vec![Priority::Low, Priority::Low, Priority::High, Priority::High, Priority::High])]
 #[tokio::test]
 async fn fairness_disabled_processes_all_high_first(
+    #[case] order: Vec<Priority>,
     queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
     shutdown_token: CancellationToken,
 ) {
@@ -83,18 +92,22 @@ async fn fairness_disabled_processes_all_high_first(
         time_slice: None,
     };
 
-    for n in 1..=3 {
-        let message = format!("failed to push high-priority frame {n}");
-        handle.push_high_priority(n).await.expect(&message);
+    let mut highs = 1..=3;
+    let mut lows = 4..=5;
+    for priority in order {
+        match priority {
+            Priority::High => {
+                let n = highs.next().expect("ran out of high-priority frames");
+                let msg = format!("failed to push high-priority frame {n}");
+                handle.push_high_priority(n).await.expect(&msg);
+            }
+            Priority::Low => {
+                let n = lows.next().expect("ran out of low-priority frames");
+                let msg = format!("failed to push low-priority frame {n}");
+                handle.push_low_priority(n).await.expect(&msg);
+            }
+        }
     }
-    handle
-        .push_low_priority(4)
-        .await
-        .expect("failed to push low-priority frame 4");
-    handle
-        .push_low_priority(5)
-        .await
-        .expect("failed to push low-priority frame 5");
 
     let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, None, shutdown_token);


### PR DESCRIPTION
## Summary
- verify scheduler consumes all high priority frames first even if queued after low priority frames
- replace unwraps with expects in fairness_disabled_ignores_arrival_order test for clarity

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6869d1ea1a508322a090b3daba60809c

## Summary by Sourcery

Refactor and extend the fairness-disabled scheduler test to verify that high-priority frames are always processed before low-priority frames regardless of arrival order, using a new Priority enum and rstest parameterization.

Tests:
- Introduce a Priority enum and rstest cases to parameterize arrival sequences in the fairness_disabled_processes_all_high_first test
- Refactor the test to push frames in a loop based on priority cases with descriptive expect messages