### PR TITLE
Fix decoder example to propagate errors

### DIFF
--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1120,60 +1120,60 @@ examples are invaluable. They make the abstract design tangible and showcase how
      }
      ```
 
-  2. **Frame Processor Implementation** (Simple Length-Prefixed Framing using
-     `tokio-util`):
+1. **Frame Processor Implementation** (Simple length-prefixed framing using
+   `tokio-util`; demonstrates error propagation):
 
-  ```rust
-  // Crate: my_frame_processor.rs
-  use bytes::{BytesMut, Buf, BufMut};
-  use tokio_util::codec::{Decoder, Encoder};
-  use byteorder::{BigEndian, ReadBytesExt};
-  use std::io;
+```rust
+// Crate: my_frame_processor.rs
+use bytes::{BytesMut, Buf, BufMut};
+use tokio_util::codec::{Decoder, Encoder};
+use byteorder::{BigEndian, ReadBytesExt};
+use std::io;
 
-  const MAX_FRAME_LEN: usize = 16 * 1024 * 1024; // 16 MiB upper limit
+const MAX_FRAME_LEN: usize = 16 * 1024 * 1024; // 16 MiB upper limit
 
-  pub struct LengthPrefixedCodec;
+pub struct LengthPrefixedCodec;
 
-  impl Decoder for LengthPrefixedCodec {
-      type Item = BytesMut; // Raw frame payload
-      type Error = io::Error;
+impl Decoder for LengthPrefixedCodec {
+    type Item = BytesMut; // Raw frame payload
+    type Error = io::Error;
 
-      fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-          if src.len() < 4 { return Ok(None); } // Not enough data for length prefix
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        if src.len() < 4 { return Ok(None); } // Not enough data for length prefix
 
-          let length = (&src[..4])
-              .read_u32::<BigEndian>()
-              .expect("slice length checked") as usize;
+      let length = (&src[..4])
+          .read_u32::<BigEndian>()?
+          as usize;
 
-          if length > MAX_FRAME_LEN {
-              return Err(io::Error::new(io::ErrorKind::InvalidInput, "frame too large"));
-          }
+        if length > MAX_FRAME_LEN {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "frame too large"));
+        }
 
-          if src.len() < 4 + length {
-              src.reserve(4 + length - src.len());
-              return Ok(None); // Not enough data for full frame
-          }
+        if src.len() < 4 + length {
+            src.reserve(4 + length - src.len());
+            return Ok(None); // Not enough data for full frame
+        }
 
-          src.advance(4); // Consume length prefix
-          Ok(Some(src.split_to(length)))
-      }
-  }
+        src.advance(4); // Consume length prefix
+        Ok(Some(src.split_to(length)))
+    }
+}
 
-  impl<T: AsRef<[u8]>> Encoder<T> for LengthPrefixedCodec {
-      type Error = io::Error;
+impl<T: AsRef<[u8]>> Encoder<T> for LengthPrefixedCodec {
+    type Error = io::Error;
 
-      fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
-          let data = item.as_ref();
-          dst.reserve(4 + data.len());
-          dst.put_u32(data.len() as u32);
-          dst.put_slice(data);
-          Ok(())
-      }
-  }
-  ```
+    fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let data = item.as_ref();
+        dst.reserve(4 + data.len());
+        dst.put_u32(data.len() as u32);
+        dst.put_slice(data);
+        Ok(())
+    }
+}
+```
 
-  (Note: "wireframe" would abstract the direct use of `Encoder`/`Decoder` behind
-  its own `FrameProcessor` trait or provide helpers.)
+(Note: "wireframe" would abstract the direct use of `Encoder`/`Decoder` behind
+its own `FrameProcessor` trait or provide helpers.)
 
 1. **Server Setup and Handler**:
 


### PR DESCRIPTION
## Summary
- illustrate error propagation when reading the frame length
- document this behaviour in the decoder code example

## Testing
- `mdformat-all`
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686a864d8fc08322a56644be2c248414

## Summary by Sourcery

Revise the length-prefixed framing example to propagate IO errors on invalid or oversized frames in both decode and encode paths and document this behavior.

Enhancements:
- Add error handling for invalid input and oversized frames in both decode and encode implementations

Documentation:
- Update the decoder example in documentation to illustrate and document error propagation when reading the frame length