### PR TITLE
Fix overflow in doc encoder example

### DIFF
--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1162,19 +1162,19 @@ examples are invaluable. They make the abstract design tangible and showcase how
   impl<T: AsRef<[u8]>> Encoder<T> for LengthPrefixedCodec {
       type Error = io::Error;
 
-      fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
-          let data = item.as_ref();
-          if data.len() > u32::MAX as usize {
-              return Err(io::Error::new(
-                  io::ErrorKind::InvalidInput,
-                  "payload exceeds 4 GiB limit",
-              ));
-          }
-          dst.reserve(4 + data.len());
-          dst.put_u32(data.len() as u32);
-          dst.put_slice(data);
-          Ok(())
-      }
+        fn encode(&mut self, item: T, dst: &mut BytesMut) -> Result<(), Self::Error> {
+            let data = item.as_ref();
+            let length = u32::try_from(data.len()).map_err(|_| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "payload exceeds 4 GiB limit",
+                )
+            })?;
+            dst.reserve(4 + data.len());
+            dst.put_u32(length);
+            dst.put_slice(data);
+            Ok(())
+        }
   }
   ```
 


### PR DESCRIPTION
## Summary
- update `LengthPrefixedCodec` example in `rust-binary-router-library-design.md` to check payload size before casting

## Testing
- `make fmt`
- `make lint`
- `make test`
- `markdownlint docs/rust-binary-router-library-design.md`
- `nixie docs/rust-binary-router-library-design.md`


------
https://chatgpt.com/codex/tasks/task_e_686a86844a5c832289e0ee7a8d8fa245

## Summary by Sourcery

Validate payload size before casting in the LengthPrefixedCodec example to prevent u32 overflow

Bug Fixes:
- Prevent potential overflow when casting payload length to u32 in the documentation example

Documentation:
- Update LengthPrefixedCodec example to return an error if payload exceeds 4 GiB before encoding