### PR TITLE
Optimize bytes_to_u64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,12 +122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1257,6 @@ dependencies = [
  "async-stream",
  "async-trait",
  "bincode",
- "byteorder",
  "bytes",
  "dashmap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 async-trait = "0.1"
 bytes = "1"
-byteorder = "1"
 log = "0.4"
 dashmap = "5"
 

--- a/docs/multi-layered-testing-strategy.md
+++ b/docs/multi-layered-testing-strategy.md
@@ -15,7 +15,7 @@ reviewers. This approach ensures that we establish a baseline of correctness
 with simple tests before moving on to the more complex and subtle failure modes
 that can emerge in an asynchronous, high-concurrency system.
 
-Code coverage is measured with `cargo tarpaulin`.  The CI workflow uploads the
+Code coverage is measured with `cargo tarpaulin`. The CI workflow uploads the
 generated `lcov.info` report to Codecov using a pinned version of the Codecov
 GitHub Action (`18283e04ce6e62d37312384ff67231eb8fd56d24`, corresponding to
 v5.4.3) to make coverage visible across pull requests.

--- a/docs/rust-binary-router-library-design.md
+++ b/docs/rust-binary-router-library-design.md
@@ -1127,7 +1127,6 @@ examples are invaluable. They make the abstract design tangible and showcase how
   // Crate: my_frame_processor.rs
   use bytes::{BytesMut, Buf, BufMut};
   use tokio_util::codec::{Decoder, Encoder};
-  use byteorder::{BigEndian, ReadBytesExt};
   use std::io;
 
   const MAX_FRAME_LEN: usize = 16 * 1024 * 1024; // 16 MiB upper limit
@@ -1141,9 +1140,9 @@ examples are invaluable. They make the abstract design tangible and showcase how
       fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
           if src.len() < 4 { return Ok(None); } // Not enough data for length prefix
 
-          let length = (&src[..4])
-              .read_u32::<BigEndian>()
-              .expect("slice length checked") as usize;
+          let length = u32::from_be_bytes(
+              src[..4].try_into().expect("slice length checked"),
+          ) as usize;
 
           if length > MAX_FRAME_LEN {
               return Err(io::Error::new(io::ErrorKind::InvalidInput, "frame too large"));


### PR DESCRIPTION
## Summary
- remove byteorder dependency
- optimise bytes_to_u64 using direct slice parsing
- update docs example to show new approach
- fix formatting

## Testing
- `make fmt`
- `make lint`
- `make test`
- `nixie *.md **/*.md`


------
https://chatgpt.com/codex/tasks/task_e_686a872b0e648322b158f6130fc906d1