### PR TITLE
Add queue_frames edge case tests

### DIFF
--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -130,47 +130,6 @@ async fn queue_frames_empty_input(queues: (PushQueues<u8>, wireframe::push::Push
 }
 
 #[rstest]
-#[tokio::test]
-async fn queue_frames_single_high(queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>)) {
-    let (_, handle) = queues;
-    let order = [Priority::High];
-    let result = queue_frames(&order, &handle, 1).await;
-    assert_eq!(
-        result,
-        vec![1u8],
-        "Expected output to contain only the high-priority frame"
-    );
-}
-
-#[rstest]
-#[tokio::test]
-async fn queue_frames_single_low(queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>)) {
-    let (_, handle) = queues;
-    let order = [Priority::Low];
-    let result = queue_frames(&order, &handle, 0).await;
-    assert_eq!(
-        result,
-        vec![1u8],
-        "Expected output to contain only the low-priority frame"
-    );
-}
-
-#[rstest]
-#[tokio::test]
-async fn queue_frames_mixed_single_elements(
-    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
-) {
-    let (_, handle) = queues;
-    let order = [Priority::High, Priority::Low];
-    let result = queue_frames(&order, &handle, 1).await;
-    assert_eq!(
-        result,
-        vec![1u8, 2u8],
-        "Expected output to contain high then low frame"
-    );
-}
-
-#[rstest]
 #[case(vec![Priority::High, Priority::High, Priority::High, Priority::Low, Priority::Low])]
 #[case(vec![Priority::Low, Priority::Low, Priority::High, Priority::High, Priority::High])]
 #[case(vec![Priority::High; 3])]

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -119,11 +119,66 @@ async fn queue_frames(
     highs.into_iter().chain(lows.into_iter()).collect()
 }
 
+// Ensure the helper correctly handles edge cases without queued frames.
+#[rstest]
+#[tokio::test]
+async fn queue_frames_empty_input(queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>)) {
+    let (_, handle) = queues;
+    let priorities: &[Priority] = &[];
+    let result = queue_frames(priorities, &handle, 0).await;
+    assert!(result.is_empty(), "Expected empty output for empty input");
+}
+
+#[rstest]
+#[tokio::test]
+async fn queue_frames_single_high(queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>)) {
+    let (_, handle) = queues;
+    let order = [Priority::High];
+    let result = queue_frames(&order, &handle, 1).await;
+    assert_eq!(
+        result,
+        vec![1u8],
+        "Expected output to contain only the high-priority frame"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn queue_frames_single_low(queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>)) {
+    let (_, handle) = queues;
+    let order = [Priority::Low];
+    let result = queue_frames(&order, &handle, 0).await;
+    assert_eq!(
+        result,
+        vec![1u8],
+        "Expected output to contain only the low-priority frame"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn queue_frames_mixed_single_elements(
+    queues: (PushQueues<u8>, wireframe::push::PushHandle<u8>),
+) {
+    let (_, handle) = queues;
+    let order = [Priority::High, Priority::Low];
+    let result = queue_frames(&order, &handle, 1).await;
+    assert_eq!(
+        result,
+        vec![1u8, 2u8],
+        "Expected output to contain high then low frame"
+    );
+}
+
 #[rstest]
 #[case(vec![Priority::High, Priority::High, Priority::High, Priority::Low, Priority::Low])]
 #[case(vec![Priority::Low, Priority::Low, Priority::High, Priority::High, Priority::High])]
 #[case(vec![Priority::High; 3])]
 #[case(vec![Priority::Low; 3])]
+#[case(Vec::new())]
+#[case(vec![Priority::High])]
+#[case(vec![Priority::Low])]
+#[case(vec![Priority::High, Priority::Low])]
 #[tokio::test]
 async fn processes_all_priorities_in_order(
     #[case] order: Vec<Priority>,


### PR DESCRIPTION
## Summary
- extend `queue_frames` coverage with empty and single-element tests
- verify actor ordering for new single-element cases

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686c3d4166448322b5fe5bf528f4fe47

## Summary by Sourcery

Add edge-case tests for queue_frames to ensure correct behavior with empty, single-element, and minimal mixed inputs.

Tests:
- Add standalone test for empty input to verify queue_frames returns an empty sequence
- Extend parameterized test to include empty, single High, single Low, and one-of-each priority cases