### PR TITLE
Fix docs for rate limiter tests

### DIFF
--- a/tests/push.rs
+++ b/tests/push.rs
@@ -57,6 +57,8 @@ async fn push_queues_error_on_closed() {
 }
 
 /// A push beyond the configured rate is blocked.
+/// Time is paused using [`tokio::time::pause`], so the test runs in a
+/// virtual-time context.
 #[rstest]
 #[case::high(PushPriority::High)]
 #[case::low(PushPriority::Low)]
@@ -107,6 +109,8 @@ async fn rate_limiter_allows_after_wait() {
 }
 
 /// The limiter counts pushes from all priority queues.
+/// The token bucket is shared, so pushes from one priority reduce
+/// the allowance for the other.
 #[tokio::test]
 async fn rate_limiter_shared_across_priorities() {
     time::pause();
@@ -142,6 +146,7 @@ async fn unlimited_queues_do_not_block() {
 }
 
 /// A burst up to capacity succeeds and further pushes are blocked.
+/// The maximum burst size equals the configured `capacity` parameter.
 #[tokio::test]
 async fn rate_limiter_allows_burst_within_capacity_and_blocks_excess() {
     time::pause();

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -18,7 +18,6 @@ use wireframe_testing::{LoggerHandle, logger};
 )]
 #[fixture]
 fn rt() -> Runtime {
-fn rt() -> Runtime {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -19,12 +19,11 @@ use wireframe_testing::{LoggerHandle, logger};
 )]
 #[fixture]
 fn rt() -> Runtime {
-    return {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build test runtime")
-    };
+fn rt() -> Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("failed to build test runtime")
 }
 
 /// Verifies how queue policies log and drop when the queue is full.

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -12,16 +12,19 @@ use wireframe::push::{PushPolicy, PushPriority, PushQueues};
 use wireframe_testing::{LoggerHandle, logger};
 
 /// Builds a single-thread [`Runtime`] for async tests.
-#[allow(
+#[allow(unfulfilled_lint_expectations)]
+#[expect(
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
 #[fixture]
 fn rt() -> Runtime {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("failed to build test runtime")
+    return {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build test runtime")
+    };
 }
 
 /// Verifies how queue policies log and drop when the queue is full.

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -12,8 +12,7 @@ use wireframe::push::{PushPolicy, PushPriority, PushQueues};
 use wireframe_testing::{LoggerHandle, logger};
 
 /// Builds a single-thread [`Runtime`] for async tests.
-#[allow(unfulfilled_lint_expectations)]
-#[expect(
+#[allow(
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -2,7 +2,9 @@
 //! with in-memory streams during tests.
 //!
 //! These helpers spawn the application on a `tokio::io::duplex` stream and
-//! return all bytes written by the app for easy assertions.
+//! return all bytes written by the app for easy assertions. They work with any
+//! message implementing [`bincode::Encode`] – the example uses a simple `u8`
+//! value so no generics are required.
 //!
 //! ```rust
 //! use wireframe::app::WireframeApp;

--- a/wireframe_testing/src/logging.rs
+++ b/wireframe_testing/src/logging.rs
@@ -43,10 +43,10 @@ impl LoggerHandle {
     ///
     /// ```no_run
     /// use wireframe_testing::LoggerHandle;
-    /// # use log::info;
+    /// # use log::warn;
     ///
     /// let mut log = LoggerHandle::new();
-    /// info!("init");
+    /// warn!("warned");
     /// assert!(log.pop().is_some());
     /// assert!(log.pop().is_none());
     /// ```


### PR DESCRIPTION
## Summary
- expand push queue rate limiter comments
- highlight shared token bucket across priorities
- document burst capacity for push limiter
- switch policy test fixture to expect unused_braces
- clarify generic usage in `wireframe_testing` docs
- show log assertion in `LoggerHandle` example

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6873af46cde88322838d3bc1ccfe0c33

## Summary by Sourcery

Improve documentation and linting in rate limiter tests and update testing utilities examples

Enhancements:
- Add doc comments to rate limiter tests explaining virtual-time usage, shared token bucket across priorities, and burst capacity behavior
- Replace rstest fixture lint attributes with expect(unused_braces) and wrap the test runtime fixture in an explicit return block

Documentation:
- Enhance wireframe_testing documentation to note generic bincode::Encode support and use of a simple u8 example
- Update LoggerHandle example to use warn! and demonstrate log assertion

Tests:
- Switch policy test fixture to use expect lint and adjust implementation style