### PR TITLE
Fix docs referencing missing trait

### DIFF
--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! These helpers spawn the application on a `tokio::io::duplex` stream and
 //! return all bytes written by the app for easy assertions. They work with any
-//! message implementing [`bincode::Encode`] – the example uses a simple `u8`
+//! message implementing [`serde::Serialize`] – the example uses a simple `u8`
 //! value so no generics are required.
 //!
 //! ```rust


### PR DESCRIPTION
## Summary
- clarify example and docs to use `serde::Serialize`

## Testing
- `make lint`
- `make test`
- `mdformat-all` *(fails: MD052 in docs)*
- `nixie *.md **/*.md`

------
https://chatgpt.com/codex/tasks/task_e_6873bfa294a483228fbbaae3e5321f02

## Summary by Sourcery

Fix missing trait references by replacing bincode::Encode with serde::Serialize in documentation and helper code

Bug Fixes:
- Correct missing trait references in docs and code to use serde::Serialize

Enhancements:
- Switch helper function trait bounds from bincode::Encode to serde::Serialize

Documentation:
- Update documentation examples and descriptions to reflect use of serde::Serialize