### PR TITLE
Clarify bincode encoding in testing docs

### DIFF
--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -3,9 +3,11 @@
 //!
 //! These helpers spawn the application on a `tokio::io::duplex` stream and
 //! return all bytes written by the app for easy assertions. They work with any
-//! message implementing [`serde::Serialize`], but the payload is encoded using
-//! the `bincode` encoder before framing. The example uses a simple `u8` value so
-//! no generics are required.
+//! message implementing [`serde::Serialize`]. The payload is encoded with
+//! [`bincode::encode_to_vec`] using [`bincode::config::standard()`], which means
+//! little-endian byte order, variable-length integer encoding and no byte limit
+//! are applied. The example uses a simple `u8` value so no generics are
+//! required.
 //!
 //! ```rust
 //! use wireframe::app::WireframeApp;


### PR DESCRIPTION
## Summary
- document that the test helpers encode payloads with the `bincode` encoder

## Testing
- `make fmt` *(fails: reference links missing in docs)*
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687567e7026083228a17ed95f5bd3c56

## Summary by Sourcery

Documentation:
- Update documentation to specify that test helper payloads are encoded with the bincode encoder prior to framing