### PR TITLE
Implement panic handling for connection tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +240,12 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -481,6 +543,23 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "gherkin"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b79820c0df536d1f3a089a2fa958f61cb96ce9e0f3f8f507f5a31179567755"
+dependencies = [
+ "heck 0.4.1",
+ "peg",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+ "textwrap",
+ "thiserror",
+ "typed-builder",
 ]
 
 [[package]]
@@ -988,6 +1067,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "peg"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f76678828272f177ac33b7e2ac2e3e73cc6c1cd1e3e387928aa69562fa51367"
+dependencies = [
+ "peg-macros",
+ "peg-runtime",
+]
+
+[[package]]
+name = "peg-macros"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636d60acf97633e48d266d7415a9355d4389cea327a193f87df395d88cd2b14d"
+dependencies = [
+ "peg-runtime",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "peg-runtime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555b1514d2d99d78150d3c799d4c357a3e2c2a8062cd108e93a06d9057629c5"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1041,7 +1167,7 @@ checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
  "rand",
@@ -1161,7 +1287,7 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1201,6 +1327,12 @@ name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -1284,7 +1416,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1367,6 +1499,21 @@ dependencies = [
  "quick-error",
  "tempfile",
  "wait-timeout",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -1455,6 +1602,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1681,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1546,6 +1722,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synthez"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d2c2202510a1e186e63e596d9318c91a8cbe85cd1a56a7be0c333e5f59ec8d"
+dependencies = [
+ "syn",
+ "synthez-codegen",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-codegen"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f724aa6d44b7162f3158a57bccd871a77b39a4aef737e01bcdff41f4772c7746"
+dependencies = [
+ "syn",
+ "synthez-core",
+]
+
+[[package]]
+name = "synthez-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bfa6ec52465e2425fd43ce5bbbe0f0b623964f7c63feb6b10980e816c654ea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn",
 ]
 
 [[package]]
@@ -1744,6 +1953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +2109,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2175,6 +2399,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bytes",
+ "cucumber",
  "dashmap",
  "futures",
  "leaky-bucket",
@@ -2214,7 +2439,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2116,7 +2116,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ loom = "^0.7"
 async-stream = "0.3"
 tokio = { version = "1", default-features = false, features = ["test-util"] }
 serial_test = "3.1"
-cucumber = "0.20"
+# Permit compatible bug fixes but block breaking updates
+cucumber = ">=0.20, <0.21"
 metrics-util = "0.20"
 metrics-exporter-prometheus = "0.17"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ loom = "^0.7"
 async-stream = "0.3"
 tokio = { version = "1", default-features = false, features = ["test-util"] }
 serial_test = "3.1"
+cucumber = "0.20"
 metrics-util = "0.20"
 metrics-exporter-prometheus = "0.17"
 
@@ -37,4 +38,8 @@ advanced-tests = []
 
 [lints.clippy]
 pedantic = "warn"
+
+[[test]]
+name = "cucumber"
+harness = false
 

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -162,6 +162,9 @@ This ensures that resources are cleaned up correctly even in the case of panics
 or early returns from user code, relying on the RAII (Resource Acquisition Is
 Initialization) pattern for safety.
 
+Connection tasks are wrapped with `catch_unwind` to log and discard panics.
+This prevents a single faulty connection from terminating the entire server.
+
 ### 3.2 Leak-Proof Registries with `Weak`/`Arc`
 
 A global `SessionRegistry` that stores `PushHandle`s to active connections is a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -160,7 +160,7 @@ production environments.
 
 - [ ] **Advanced Error Handling:**
 
-  - [ ] Implement panic handlers in connection tasks to prevent a single
+  - [x] Implement panic handlers in connection tasks to prevent a single
     connection from crashing the server.
 
 - [ ] **Testing:**

--- a/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
+++ b/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
@@ -238,6 +238,9 @@ expressive error-handling strategy.
   push fails due to a full queue, the frame can be routed to a separate "dead
   letter" channel for later inspection, logging, or reprocessing, enhancing the
   system's overall resilience.
+- **Panic Handling:** Connection tasks are wrapped in a panic handler using
+  `catch_unwind`. A misbehaving connection can no longer terminate the entire
+  server.
 
 ### B. First-Class Developer Ergonomics
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -369,6 +369,8 @@ async fn worker_task<F, T>(
                     let failure = on_failure.clone();
                     let factory = factory.clone();
                     let t = tracker.clone();
+                    // Capture peer address for better error context
+                    let peer_addr = stream.peer_addr().ok();
                     t.spawn(async move {
                         use futures::FutureExt as _;
                         if let Err(panic) = std::panic::AssertUnwindSafe(
@@ -377,7 +379,11 @@ async fn worker_task<F, T>(
                         .catch_unwind()
                         .await
                         {
-                            tracing::error!(?panic, "connection task panicked");
+                            tracing::error!(
+                                ?panic,
+                                ?peer_addr,
+                                "connection task panicked"
+                            );
                         }
                     });
                     delay = Duration::from_millis(10);

--- a/src/server.rs
+++ b/src/server.rs
@@ -369,7 +369,17 @@ async fn worker_task<F, T>(
                     let failure = on_failure.clone();
                     let factory = factory.clone();
                     let t = tracker.clone();
-                    t.spawn(process_stream(stream, factory, success, failure));
+                    t.spawn(async move {
+                        use futures::FutureExt as _;
+                        if let Err(panic) = std::panic::AssertUnwindSafe(
+                            process_stream(stream, factory, success, failure),
+                        )
+                        .catch_unwind()
+                        .await
+                        {
+                            tracing::error!(?panic, "connection task panicked");
+                        }
+                    });
                     delay = Duration::from_millis(10);
                 }
                 Err(e) => {
@@ -453,7 +463,8 @@ mod tests {
     use bincode::{Decode, Encode};
     use rstest::{fixture, rstest};
     use tokio::{
-        net::TcpListener,
+        net::{TcpListener, TcpStream},
+        sync::oneshot,
         time::{Duration, timeout},
     };
     use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -868,5 +879,38 @@ mod tests {
     #[test]
     fn test_server_debug_compilation_guard() {
         assert!(cfg!(debug_assertions));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn connection_panic_is_caught(
+        factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    ) {
+        let factory = move || {
+            factory()
+                .on_connection_setup(|| async { panic!("boom") })
+                .unwrap()
+        };
+        let server = WireframeServer::new(factory)
+            .workers(1)
+            .bind("127.0.0.1:0".parse().unwrap())
+            .expect("bind");
+        let addr = server.local_addr().unwrap();
+
+        let (tx, rx) = oneshot::channel();
+        let handle = tokio::spawn(async move {
+            server
+                .run_with_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        TcpStream::connect(addr).await.unwrap();
+        TcpStream::connect(addr).await.unwrap();
+
+        let _ = tx.send(());
+        handle.await.unwrap();
     }
 }

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,0 +1,8 @@
+mod steps;
+mod world;
+
+use cucumber::World;
+use world::PanicWorld;
+
+#[tokio::main]
+async fn main() { PanicWorld::run("tests/features").await; }

--- a/tests/features/connection_panic.feature
+++ b/tests/features/connection_panic.feature
@@ -1,0 +1,6 @@
+Feature: Connection panic resilience
+  Scenario: connection panic does not crash server
+    Given a running wireframe server with a panic in connection setup
+    When I connect to the server
+    And I connect to the server again
+    Then both connections succeed

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -1,0 +1,1 @@
+pub mod panic_steps;

--- a/tests/steps/panic_steps.rs
+++ b/tests/steps/panic_steps.rs
@@ -1,46 +1,17 @@
+//! Cucumber step implementations for panic resilience testing.
+//!
+//! Defines Given-When-Then steps that verify server stability
+//! when connection tasks panic during setup.
+
 use cucumber::{given, then, when};
-use tokio::{net::TcpStream, sync::oneshot};
-use wireframe::{app::WireframeApp, server::WireframeServer};
 
 use crate::world::PanicWorld;
 
 #[given("a running wireframe server with a panic in connection setup")]
-async fn start_server(world: &mut PanicWorld) {
-    let factory = || {
-        WireframeApp::new()
-            .unwrap()
-            .on_connection_setup(|| async { panic!("boom") })
-            .unwrap()
-    };
-    let server = WireframeServer::new(factory)
-        .workers(1)
-        .bind("127.0.0.1:0".parse().unwrap())
-        .expect("bind");
-    world.addr = Some(server.local_addr().unwrap());
-    let (tx, rx) = oneshot::channel();
-    world.shutdown = Some(tx);
-    tokio::spawn(async move {
-        server
-            .run_with_shutdown(async {
-                let _ = rx.await;
-            })
-            .await
-            .unwrap();
-    });
-    tokio::task::yield_now().await;
-}
+async fn start_server(world: &mut PanicWorld) { world.start_panic_server().await; }
 
 #[when("I connect to the server")]
-async fn connect(world: &mut PanicWorld) {
-    TcpStream::connect(world.addr.unwrap()).await.unwrap();
-    world.attempts += 1;
-}
+async fn connect(world: &mut PanicWorld) { world.connect_once().await; }
 
 #[then("both connections succeed")]
-async fn verify(world: &mut PanicWorld) {
-    assert_eq!(world.attempts, 2);
-    if let Some(tx) = world.shutdown.take() {
-        let _ = tx.send(());
-    }
-    tokio::task::yield_now().await;
-}
+async fn verify(world: &mut PanicWorld) { world.verify_and_shutdown().await; }

--- a/tests/steps/panic_steps.rs
+++ b/tests/steps/panic_steps.rs
@@ -1,0 +1,46 @@
+use cucumber::{given, then, when};
+use tokio::{net::TcpStream, sync::oneshot};
+use wireframe::{app::WireframeApp, server::WireframeServer};
+
+use crate::world::PanicWorld;
+
+#[given("a running wireframe server with a panic in connection setup")]
+async fn start_server(world: &mut PanicWorld) {
+    let factory = || {
+        WireframeApp::new()
+            .unwrap()
+            .on_connection_setup(|| async { panic!("boom") })
+            .unwrap()
+    };
+    let server = WireframeServer::new(factory)
+        .workers(1)
+        .bind("127.0.0.1:0".parse().unwrap())
+        .expect("bind");
+    world.addr = Some(server.local_addr().unwrap());
+    let (tx, rx) = oneshot::channel();
+    world.shutdown = Some(tx);
+    tokio::spawn(async move {
+        server
+            .run_with_shutdown(async {
+                let _ = rx.await;
+            })
+            .await
+            .unwrap();
+    });
+    tokio::task::yield_now().await;
+}
+
+#[when("I connect to the server")]
+async fn connect(world: &mut PanicWorld) {
+    TcpStream::connect(world.addr.unwrap()).await.unwrap();
+    world.attempts += 1;
+}
+
+#[then("both connections succeed")]
+async fn verify(world: &mut PanicWorld) {
+    assert_eq!(world.attempts, 2);
+    if let Some(tx) = world.shutdown.take() {
+        let _ = tx.send(());
+    }
+    tokio::task::yield_now().await;
+}

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -1,11 +1,77 @@
+//! Test world state for Cucumber panic resilience tests.
+//!
+//! Provides shared state management for behavioural tests verifying
+//! server resilience against connection task panics.
+
 use std::net::SocketAddr;
 
 use cucumber::World;
-use tokio::sync::oneshot::Sender;
+use tokio::{
+    net::TcpStream,
+    sync::oneshot::{self, Sender},
+};
+use wireframe::{app::WireframeApp, server::WireframeServer};
 
 #[derive(Debug, Default, World)]
 pub struct PanicWorld {
     pub addr: Option<SocketAddr>,
     pub attempts: usize,
     pub shutdown: Option<Sender<()>>,
+}
+
+impl PanicWorld {
+    /// Start a server that panics during connection setup.
+    ///
+    /// # Panics
+    /// Panics if binding the server fails or the server task fails.
+    pub async fn start_panic_server(&mut self) {
+        let factory = || {
+            WireframeApp::new()
+                .expect("Failed to create WireframeApp")
+                .on_connection_setup(|| async { panic!("boom") })
+                .unwrap()
+        };
+        let server = WireframeServer::new(factory)
+            .workers(1)
+            .bind("127.0.0.1:0".parse().expect("Failed to parse address"))
+            .expect("bind");
+
+        self.addr = Some(server.local_addr().expect("Failed to get server address"));
+        let (tx, rx) = oneshot::channel();
+        self.shutdown = Some(tx);
+
+        tokio::spawn(async move {
+            server
+                .run_with_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+
+        tokio::task::yield_now().await;
+    }
+
+    /// Connect to the running server once.
+    ///
+    /// # Panics
+    /// Panics if the server address is unknown or the connection fails.
+    pub async fn connect_once(&mut self) {
+        TcpStream::connect(self.addr.expect("Server address not set"))
+            .await
+            .expect("Failed to connect");
+        self.attempts += 1;
+    }
+
+    /// Verify both connections succeeded and shut down the server.
+    ///
+    /// # Panics
+    /// Panics if the connection attempts do not match the expected count.
+    pub async fn verify_and_shutdown(&mut self) {
+        assert_eq!(self.attempts, 2);
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        tokio::task::yield_now().await;
+    }
 }

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -1,0 +1,11 @@
+use std::net::SocketAddr;
+
+use cucumber::World;
+use tokio::sync::oneshot::Sender;
+
+#[derive(Debug, Default, World)]
+pub struct PanicWorld {
+    pub addr: Option<SocketAddr>,
+    pub attempts: usize,
+    pub shutdown: Option<Sender<()>>,
+}


### PR DESCRIPTION
## Summary
- add panic handling around connection tasks
- test connection panics are isolated via unit and behavioural tests
- document panic handler design and mark roadmap as complete

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_6881736067a4832299a85aacc59fd724

## Summary by Sourcery

Add panic handling to connection tasks to prevent a faulty connection from crashing the server, accompanied by new tests and documentation updates.

Enhancements:
- Wrap connection task execution in catch_unwind to log and swallow panics.

Build:
- Add cucumber dependency and configure a custom test harness in Cargo.toml.

Documentation:
- Document panic handling design in production-resilience and philosophy guides and mark the panic handler roadmap item as complete.

Tests:
- Add a unit test to verify connection panics are isolated.
- Add end-to-end Cucumber feature tests, world state, and step definitions for connection panic resilience.