### PR TITLE
Improve server readiness signaling

### DIFF
--- a/tests/world.rs
+++ b/tests/world.rs
@@ -6,26 +6,18 @@
 use std::net::SocketAddr;
 
 use cucumber::World;
-use tokio::{
-    net::TcpStream,
-    sync::oneshot::{self, Sender},
-};
+use tokio::{net::TcpStream, sync::oneshot};
 use wireframe::{app::WireframeApp, server::WireframeServer};
 
-#[derive(Debug, Default, World)]
-pub struct PanicWorld {
-    pub addr: Option<SocketAddr>,
-    pub attempts: usize,
-    pub shutdown: Option<Sender<()>>,
-    pub handle: Option<tokio::task::JoinHandle<()>>,
+#[derive(Debug)]
+struct PanicServer {
+    addr: SocketAddr,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: tokio::task::JoinHandle<()>,
 }
 
-impl PanicWorld {
-    /// Start a server that panics during connection setup.
-    ///
-    /// # Panics
-    /// Panics if binding the server fails or the server task fails.
-    pub async fn start_panic_server(&mut self) {
+impl PanicServer {
+    async fn spawn() -> Self {
         let factory = || {
             WireframeApp::new()
                 .expect("Failed to create WireframeApp")
@@ -37,32 +29,58 @@ impl PanicWorld {
             .bind("127.0.0.1:0".parse().expect("Failed to parse address"))
             .expect("bind");
 
-        self.addr = Some(server.local_addr().expect("Failed to get server address"));
-        let (tx, rx) = oneshot::channel();
-        let (ready_tx, ready_rx) = oneshot::channel();
-        self.shutdown = Some(tx);
+        let addr = server.local_addr().expect("Failed to get server address");
+        let (tx_shutdown, rx_shutdown) = oneshot::channel();
+        let (tx_ready, rx_ready) = oneshot::channel();
 
-        self.handle = Some(tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             server
-                .ready_signal(ready_tx)
+                .ready_signal(tx_ready)
                 .run_with_shutdown(async {
-                    let _ = rx.await;
+                    let _ = rx_shutdown.await;
                 })
                 .await
                 .expect("Server task failed");
-        }));
+        });
+        rx_ready.await.expect("Server did not signal ready");
 
-        ready_rx.await.expect("Server did not signal ready");
+        Self {
+            addr,
+            shutdown: Some(tx_shutdown),
+            handle,
+        }
     }
+}
+
+impl Drop for PanicServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        let _ = futures::executor::block_on(&mut self.handle);
+    }
+}
+
+#[derive(Debug, Default, World)]
+pub struct PanicWorld {
+    server: Option<PanicServer>,
+    attempts: usize,
+}
+
+impl PanicWorld {
+    /// Start a server that panics during connection setup.
+    ///
+    /// # Panics
+    /// Panics if binding the server fails or the server task fails.
+    pub async fn start_panic_server(&mut self) { self.server.replace(PanicServer::spawn().await); }
 
     /// Connect to the running server once.
     ///
     /// # Panics
     /// Panics if the server address is unknown or the connection fails.
     pub async fn connect_once(&mut self) {
-        TcpStream::connect(self.addr.expect("Server address not set"))
-            .await
-            .expect("Failed to connect");
+        let addr = self.server.as_ref().expect("Server not started").addr;
+        TcpStream::connect(addr).await.expect("Failed to connect");
         self.attempts += 1;
     }
 
@@ -72,11 +90,8 @@ impl PanicWorld {
     /// Panics if the connection attempts do not match the expected count.
     pub async fn verify_and_shutdown(&mut self) {
         assert_eq!(self.attempts, 2);
-        if let Some(tx) = self.shutdown.take() {
-            let _ = tx.send(());
-        }
-        if let Some(handle) = self.handle.take() {
-            handle.await.expect("Server task join failed");
-        }
+        // dropping PanicServer will shut it down
+        self.server.take();
+        tokio::task::yield_now().await;
     }
 }


### PR DESCRIPTION
## Summary
- document thread safety and single-use semantics for `ready_tx`
- warn if readiness signal can't be sent
- add `catch_and_log_unwind` helper and use it in `worker_task`
- simplify `PanicWorld` using a `PanicServer` helper

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_688567eb84e0832281113f65dfff5132