### PR TITLE
Refine length prefix utilities

### DIFF
--- a/src/frame/conversion.rs
+++ b/src/frame/conversion.rs
@@ -7,35 +7,11 @@ pub(crate) const ERR_UNSUPPORTED_PREFIX: &str = "unsupported length prefix size"
 pub(crate) const ERR_FRAME_TOO_LARGE: &str = "frame too large";
 pub(crate) const ERR_INCOMPLETE_PREFIX: &str = "incomplete length prefix";
 
-#[derive(Copy, Clone)]
-enum PrefixErr {
-    UnsupportedSize,
-    Incomplete,
-}
-
-fn prefix_err(kind: PrefixErr) -> io::Error {
-    match kind {
-        PrefixErr::UnsupportedSize => {
-            io::Error::new(io::ErrorKind::InvalidInput, ERR_UNSUPPORTED_PREFIX)
-        }
-        PrefixErr::Incomplete => {
-            io::Error::new(io::ErrorKind::UnexpectedEof, ERR_INCOMPLETE_PREFIX)
-        }
-    }
-}
-
 /// Checked conversion from `usize` to a specific prefix integer type.
 ///
 /// Returns `ERR_FRAME_TOO_LARGE` if the value does not fit in `T`.
 fn checked_prefix_cast<T: TryFrom<usize>>(len: usize) -> io::Result<T> {
     T::try_from(len).map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, ERR_FRAME_TOO_LARGE))
-}
-
-fn parse_bytes<const N: usize, F>(slice: &[u8], f: F) -> u64
-where
-    F: FnOnce([u8; N]) -> u64,
-{
-    f(slice[..N].try_into().expect("slice length checked"))
 }
 
 /// Converts a byte slice into a `u64` according to `size` and `endianness`.
@@ -48,21 +24,27 @@ where
 /// [`io::ErrorKind::UnexpectedEof`] if `bytes` is too short.
 pub fn bytes_to_u64(bytes: &[u8], size: usize, endianness: Endianness) -> io::Result<u64> {
     if !matches!(size, 1 | 2 | 4 | 8) {
-        return Err(prefix_err(PrefixErr::UnsupportedSize));
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            ERR_UNSUPPORTED_PREFIX,
+        ));
     }
     if bytes.len() < size {
-        return Err(prefix_err(PrefixErr::Incomplete));
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            ERR_INCOMPLETE_PREFIX,
+        ));
     }
 
-    let val = match (size, endianness) {
-        (1, _) => u64::from(bytes[0]),
-        (2, Endianness::Big) => parse_bytes::<2, _>(bytes, |b| u16::from_be_bytes(b).into()),
-        (2, Endianness::Little) => parse_bytes::<2, _>(bytes, |b| u16::from_le_bytes(b).into()),
-        (4, Endianness::Big) => parse_bytes::<4, _>(bytes, |b| u32::from_be_bytes(b).into()),
-        (4, Endianness::Little) => parse_bytes::<4, _>(bytes, |b| u32::from_le_bytes(b).into()),
-        (8, Endianness::Big) => parse_bytes::<8, _>(bytes, u64::from_be_bytes),
-        (8, Endianness::Little) => parse_bytes::<8, _>(bytes, u64::from_le_bytes),
-        _ => unreachable!(),
+    let mut buf = [0u8; 8];
+    match endianness {
+        Endianness::Big => buf[8 - size..].copy_from_slice(&bytes[..size]),
+        Endianness::Little => buf[..size].copy_from_slice(&bytes[..size]),
+    }
+
+    let val = match endianness {
+        Endianness::Big => u64::from_be_bytes(buf),
+        Endianness::Little => u64::from_le_bytes(buf),
     };
     Ok(val)
 }
@@ -81,34 +63,25 @@ pub fn u64_to_bytes(
     endianness: Endianness,
     out: &mut [u8; 8],
 ) -> io::Result<usize> {
-    match (size, endianness) {
-        (1, _) => {
-            out[0] = checked_prefix_cast::<u8>(len)?;
-        }
-        (2, Endianness::Big) => {
-            out[..2].copy_from_slice(&checked_prefix_cast::<u16>(len)?.to_be_bytes());
-        }
-        (2, Endianness::Little) => {
-            out[..2].copy_from_slice(&checked_prefix_cast::<u16>(len)?.to_le_bytes());
-        }
-        (4, Endianness::Big) => {
-            out[..4].copy_from_slice(&checked_prefix_cast::<u32>(len)?.to_be_bytes());
-        }
-        (4, Endianness::Little) => {
-            out[..4].copy_from_slice(&checked_prefix_cast::<u32>(len)?.to_le_bytes());
-        }
-        (8, Endianness::Big) => {
-            out[..8].copy_from_slice(&checked_prefix_cast::<u64>(len)?.to_be_bytes());
-        }
-        (8, Endianness::Little) => {
-            out[..8].copy_from_slice(&checked_prefix_cast::<u64>(len)?.to_le_bytes());
-        }
-        _ => {
-            return Err(prefix_err(PrefixErr::UnsupportedSize));
-        }
+    if !matches!(size, 1 | 2 | 4 | 8) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            ERR_UNSUPPORTED_PREFIX,
+        ));
     }
 
-    out[size..].fill(0);
+    let prefix_bytes = match (size, endianness) {
+        (1, _) => checked_prefix_cast::<u8>(len)?.to_ne_bytes().to_vec(),
+        (2, Endianness::Big) => checked_prefix_cast::<u16>(len)?.to_be_bytes().to_vec(),
+        (2, Endianness::Little) => checked_prefix_cast::<u16>(len)?.to_le_bytes().to_vec(),
+        (4, Endianness::Big) => checked_prefix_cast::<u32>(len)?.to_be_bytes().to_vec(),
+        (4, Endianness::Little) => checked_prefix_cast::<u32>(len)?.to_le_bytes().to_vec(),
+        (8, Endianness::Big) => checked_prefix_cast::<u64>(len)?.to_be_bytes().to_vec(),
+        (8, Endianness::Little) => checked_prefix_cast::<u64>(len)?.to_le_bytes().to_vec(),
+        _ => unreachable!(),
+    };
+
+    out[..size].copy_from_slice(&prefix_bytes);
 
     Ok(size)
 }

--- a/src/frame/conversion.rs
+++ b/src/frame/conversion.rs
@@ -58,8 +58,9 @@ pub fn bytes_to_u64(bytes: &[u8], size: usize, endianness: Endianness) -> io::Re
 /// `len` does not fit into the prefix.
 ///
 /// # Panics
-/// Panics if shifting `value` leaves bits outside the `u8` range. This cannot
-/// occur for valid prefix sizes and checked values.
+/// Panics if the bit-shifting within the `write_bytes` closure leaves bits of
+/// `value` outside the `u8` range. This cannot occur for valid prefix sizes and
+/// checked values.
 #[must_use = "length prefix byte count must be used"]
 pub fn u64_to_bytes(
     len: usize,

--- a/src/frame/conversion.rs
+++ b/src/frame/conversion.rs
@@ -70,18 +70,32 @@ pub fn u64_to_bytes(
         ));
     }
 
-    let prefix_bytes = match (size, endianness) {
-        (1, _) => checked_prefix_cast::<u8>(len)?.to_ne_bytes().to_vec(),
-        (2, Endianness::Big) => checked_prefix_cast::<u16>(len)?.to_be_bytes().to_vec(),
-        (2, Endianness::Little) => checked_prefix_cast::<u16>(len)?.to_le_bytes().to_vec(),
-        (4, Endianness::Big) => checked_prefix_cast::<u32>(len)?.to_be_bytes().to_vec(),
-        (4, Endianness::Little) => checked_prefix_cast::<u32>(len)?.to_le_bytes().to_vec(),
-        (8, Endianness::Big) => checked_prefix_cast::<u64>(len)?.to_be_bytes().to_vec(),
-        (8, Endianness::Little) => checked_prefix_cast::<u64>(len)?.to_le_bytes().to_vec(),
+    match (size, endianness) {
+        (1, _) => {
+            out[..1].copy_from_slice(&checked_prefix_cast::<u8>(len)?.to_ne_bytes());
+        }
+        (2, Endianness::Big) => {
+            out[..2].copy_from_slice(&checked_prefix_cast::<u16>(len)?.to_be_bytes());
+        }
+        (2, Endianness::Little) => {
+            out[..2].copy_from_slice(&checked_prefix_cast::<u16>(len)?.to_le_bytes());
+        }
+        (4, Endianness::Big) => {
+            out[..4].copy_from_slice(&checked_prefix_cast::<u32>(len)?.to_be_bytes());
+        }
+        (4, Endianness::Little) => {
+            out[..4].copy_from_slice(&checked_prefix_cast::<u32>(len)?.to_le_bytes());
+        }
+        (8, Endianness::Big) => {
+            out[..8].copy_from_slice(&checked_prefix_cast::<u64>(len)?.to_be_bytes());
+        }
+        (8, Endianness::Little) => {
+            out[..8].copy_from_slice(&checked_prefix_cast::<u64>(len)?.to_le_bytes());
+        }
         _ => unreachable!(),
-    };
+    }
 
-    out[..size].copy_from_slice(&prefix_bytes);
+    out[size..].fill(0);
 
     Ok(size)
 }

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -14,6 +14,10 @@ use super::{conversion::*, format::*};
 #[case(vec![1, 0, 0, 0], 4, Endianness::Little, 1)]
 #[case(vec![0, 0, 0, 0, 0, 0, 0, 1], 8, Endianness::Big, 1)]
 #[case(vec![1, 0, 0, 0, 0, 0, 0, 0], 8, Endianness::Little, 1)]
+#[case(vec![0xFF], 1, Endianness::Big, 0xFF)]
+#[case(vec![0xFF, 0xFF], 2, Endianness::Big, 0xFFFF)]
+#[case(vec![0xFF, 0xFF, 0xFF, 0xFF], 4, Endianness::Big, 0xFFFF_FFFF)]
+#[case(vec![0xFF; 8], 8, Endianness::Big, 0xFFFF_FFFF_FFFF_FFFF)]
 fn bytes_to_u64_ok(
     #[case] bytes: Vec<u8>,
     #[case] size: usize,
@@ -67,6 +71,14 @@ fn bytes_to_u64_unsupported(
 fn u64_to_bytes_large() {
     let mut buf = [0u8; 8];
     let err = u64_to_bytes(300, 1, Endianness::Big, &mut buf).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+}
+
+#[test]
+fn u64_to_bytes_zero_length() {
+    let mut buf = [0u8; 8];
+    let err = u64_to_bytes(0, 0, Endianness::Big, &mut buf)
+        .expect_err("u64_to_bytes must fail if length is zero");
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 }
 

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -94,3 +94,16 @@ fn u64_to_bytes_unsupported(
     let err = u64_to_bytes(value, size, endianness, &mut buf).unwrap_err();
     assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
 }
+
+#[rstest]
+#[case(0x1234usize, 4, Endianness::Big)]
+#[case(0x1234usize, 4, Endianness::Little)]
+fn u64_to_bytes_zeroes_remainder(
+    #[case] value: usize,
+    #[case] size: usize,
+    #[case] endianness: Endianness,
+) {
+    let mut buf = [0xaau8; 8];
+    u64_to_bytes(value, size, endianness, &mut buf).unwrap();
+    assert!(buf[size..].iter().all(|&b| b == 0));
+}


### PR DESCRIPTION
## Summary
- simplify `bytes_to_u64` and `u64_to_bytes`
- cover max and zero-length cases in frame tests

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688bc1a7a4e0832289453fc8d44c9c7e

## Summary by Sourcery

Simplify length prefix conversion utilities and enhance their test coverage

Enhancements:
- Remove the custom PrefixErr enum and parse_bytes helper in favor of inline error creation
- Refactor bytes_to_u64 to use a fixed 8-byte buffer and inline endianness handling
- Refactor u64_to_bytes to construct prefix bytes directly and inline size validation

Tests:
- Add tests for maximum prefix values (all-0xFF cases) for bytes_to_u64
- Add a test to ensure u64_to_bytes fails on zero-length prefixes