### PR TITLE
Replace unwraps with expect

### DIFF
--- a/docs/wireframe-testing-crate.md
+++ b/docs/wireframe-testing-crate.md
@@ -120,6 +120,17 @@ let bytes = drive_with_bincode(app, Ping(1)).await.unwrap();
 assert_eq!(bytes, [0, 1]);
 ```
 
+### Helper macros
+
+Two small macros, `push_expect!` and `recv_expect!`, reduce boilerplate in test
+code. They await a future and panic with a message including the call site when
+the future resolves to an error.
+
+```rust
+push_expect!(handle.push_high_priority(42));
+let (_, frame) = recv_expect!(queues.recv());
+```
+
 ## Example Usage
 
 ```rust

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -59,10 +59,6 @@ impl FrameMetadata for HeaderSerializer {
 #[derive(bincode::Decode, bincode::Encode)]
 struct Ping;
 
-#[derive(bincode::Decode, bincode::Encode)]
-// Placeholder for demonstration of metadata routing; not used directly.
-struct Pong;
-
 #[tokio::main]
 async fn main() -> io::Result<()> {
     let app = WireframeApp::new()

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -60,10 +60,7 @@ impl FrameMetadata for HeaderSerializer {
 struct Ping;
 
 #[derive(bincode::Decode, bincode::Encode)]
-#[expect(
-    dead_code,
-    reason = "placeholder for demonstration of metadata routing"
-)]
+// Placeholder for demonstration of metadata routing; not used directly.
 struct Pong;
 
 #[tokio::main]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,7 +40,9 @@ impl Drop for ActiveConnection {
 
 /// Return the current number of active connections.
 #[must_use]
-pub fn active_connection_count() -> u64 { ACTIVE_CONNECTIONS.load(Ordering::Relaxed) }
+pub fn active_connection_count() -> u64 {
+    ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
+}
 
 use crate::{
     fairness::Fairness,
@@ -185,11 +187,15 @@ where
     pub fn set_fairness(&mut self, fairness: FairnessConfig) { self.fairness.set_config(fairness); }
 
     /// Set or replace the current streaming response.
-    pub fn set_response(&mut self, stream: Option<FrameStream<F, E>>) { self.response = stream; }
+    pub fn set_response(&mut self, stream: Option<FrameStream<F, E>>) {
+        self.response = stream;
+    }
 
     /// Get a clone of the shutdown token used by the actor.
     #[must_use]
-    pub fn shutdown_token(&self) -> CancellationToken { self.shutdown.clone() }
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
 
     /// Drive the actor until all sources are exhausted or shutdown is triggered.
     ///
@@ -402,11 +408,6 @@ where
                     out.push(frame);
                     self.after_low();
                 }
-                Err(mpsc::error::TryRecvError::Empty) => {}
-                Err(mpsc::error::TryRecvError::Disconnected) => {
-                    self.low_rx = None;
-                    state.mark_closed();
-                }
             }
         }
     }
@@ -449,11 +450,15 @@ where
 
     /// Await cancellation on the provided shutdown token.
     #[inline]
-    async fn wait_shutdown(token: CancellationToken) { token.cancelled_owned().await; }
+    async fn wait_shutdown(token: CancellationToken) {
+        token.cancelled_owned().await;
+    }
 
     /// Receive the next frame from a push queue.
     #[inline]
-    async fn recv_push(rx: &mut mpsc::Receiver<F>) -> Option<F> { rx.recv().await }
+    async fn recv_push(rx: &mut mpsc::Receiver<F>) -> Option<F> {
+        rx.recv().await
+    }
 
     /// Poll `f` if `opt` is `Some`, returning `None` otherwise.
     #[expect(
@@ -536,11 +541,17 @@ impl ActorState {
     }
 
     /// Returns `true` while the actor is actively processing sources.
-    fn is_active(&self) -> bool { matches!(self.run_state, RunState::Active) }
+    fn is_active(&self) -> bool {
+        matches!(self.run_state, RunState::Active)
+    }
 
     /// Returns `true` once shutdown has begun.
-    fn is_shutting_down(&self) -> bool { matches!(self.run_state, RunState::ShuttingDown) }
+    fn is_shutting_down(&self) -> bool {
+        matches!(self.run_state, RunState::ShuttingDown)
+    }
 
     /// Returns `true` when all sources have finished.
-    fn is_done(&self) -> bool { matches!(self.run_state, RunState::Finished) }
+    fn is_done(&self) -> bool {
+        matches!(self.run_state, RunState::Finished)
+    }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -12,7 +12,10 @@ use std::{
 };
 
 use futures::StreamExt;
-use tokio::{sync::mpsc, time::Duration};
+use tokio::{
+    sync::mpsc::{self, error::TryRecvError},
+    time::Duration,
+};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, info_span, warn};
 
@@ -393,14 +396,19 @@ where
     fn after_high(&mut self, out: &mut Vec<F>, state: &mut ActorState) {
         self.fairness.after_high();
 
-        if self.fairness.should_yield()
-            && let Some(rx) = &mut self.low_rx
-        {
-            match rx.try_recv() {
-                Ok(mut frame) => {
-                    self.hooks.before_send(&mut frame, &mut self.ctx);
-                    out.push(frame);
-                    self.after_low();
+        if self.fairness.should_yield() {
+            let res = self.low_rx.as_mut().map(mpsc::Receiver::try_recv);
+            if let Some(res) = res {
+                match res {
+                    Ok(mut frame) => {
+                        self.hooks.before_send(&mut frame, &mut self.ctx);
+                        out.push(frame);
+                        self.after_low();
+                    }
+                    Err(TryRecvError::Empty) => {}
+                    Err(TryRecvError::Disconnected) => {
+                        Self::handle_closed_receiver(&mut self.low_rx, state);
+                    }
                 }
             }
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -40,9 +40,7 @@ impl Drop for ActiveConnection {
 
 /// Return the current number of active connections.
 #[must_use]
-pub fn active_connection_count() -> u64 {
-    ACTIVE_CONNECTIONS.load(Ordering::Relaxed)
-}
+pub fn active_connection_count() -> u64 { ACTIVE_CONNECTIONS.load(Ordering::Relaxed) }
 
 use crate::{
     fairness::Fairness,
@@ -187,15 +185,11 @@ where
     pub fn set_fairness(&mut self, fairness: FairnessConfig) { self.fairness.set_config(fairness); }
 
     /// Set or replace the current streaming response.
-    pub fn set_response(&mut self, stream: Option<FrameStream<F, E>>) {
-        self.response = stream;
-    }
+    pub fn set_response(&mut self, stream: Option<FrameStream<F, E>>) { self.response = stream; }
 
     /// Get a clone of the shutdown token used by the actor.
     #[must_use]
-    pub fn shutdown_token(&self) -> CancellationToken {
-        self.shutdown.clone()
-    }
+    pub fn shutdown_token(&self) -> CancellationToken { self.shutdown.clone() }
 
     /// Drive the actor until all sources are exhausted or shutdown is triggered.
     ///
@@ -450,15 +444,11 @@ where
 
     /// Await cancellation on the provided shutdown token.
     #[inline]
-    async fn wait_shutdown(token: CancellationToken) {
-        token.cancelled_owned().await;
-    }
+    async fn wait_shutdown(token: CancellationToken) { token.cancelled_owned().await; }
 
     /// Receive the next frame from a push queue.
     #[inline]
-    async fn recv_push(rx: &mut mpsc::Receiver<F>) -> Option<F> {
-        rx.recv().await
-    }
+    async fn recv_push(rx: &mut mpsc::Receiver<F>) -> Option<F> { rx.recv().await }
 
     /// Poll `f` if `opt` is `Some`, returning `None` otherwise.
     #[expect(
@@ -541,17 +531,11 @@ impl ActorState {
     }
 
     /// Returns `true` while the actor is actively processing sources.
-    fn is_active(&self) -> bool {
-        matches!(self.run_state, RunState::Active)
-    }
+    fn is_active(&self) -> bool { matches!(self.run_state, RunState::Active) }
 
     /// Returns `true` once shutdown has begun.
-    fn is_shutting_down(&self) -> bool {
-        matches!(self.run_state, RunState::ShuttingDown)
-    }
+    fn is_shutting_down(&self) -> bool { matches!(self.run_state, RunState::ShuttingDown) }
 
     /// Returns `true` when all sources have finished.
-    fn is_done(&self) -> bool {
-        matches!(self.run_state, RunState::Finished)
-    }
+    fn is_done(&self) -> bool { matches!(self.run_state, RunState::Finished) }
 }

--- a/src/frame/tests.rs
+++ b/src/frame/tests.rs
@@ -24,7 +24,10 @@ fn bytes_to_u64_ok(
     #[case] endianness: Endianness,
     #[case] expected: u64,
 ) {
-    assert_eq!(bytes_to_u64(&bytes, size, endianness).unwrap(), expected);
+    assert_eq!(
+        bytes_to_u64(&bytes, size, endianness).expect("failed to convert"),
+        expected
+    );
 }
 
 #[rstest]
@@ -42,7 +45,7 @@ fn u64_to_bytes_ok(
     #[case] expected: Vec<u8>,
 ) {
     let mut buf = [0u8; 8];
-    let written = u64_to_bytes(value, size, endianness, &mut buf).unwrap();
+    let written = u64_to_bytes(value, size, endianness, &mut buf).expect("failed to encode u64");
     assert_eq!(written, size);
     assert_eq!(&buf[..written], expected.as_slice());
 }

--- a/src/push.rs
+++ b/src/push.rs
@@ -97,7 +97,9 @@ pub(crate) struct PushHandleInner<F> {
 pub struct PushHandle<F>(Arc<PushHandleInner<F>>);
 
 impl<F: FrameLike> PushHandle<F> {
-    pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self { Self(arc) }
+    pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self {
+        Self(arc)
+    }
 
     /// Internal helper to push a frame with the requested priority.
     ///
@@ -253,7 +255,9 @@ impl<F: FrameLike> PushHandle<F> {
     }
 
     /// Downgrade to a `Weak` reference for storage in a registry.
-    pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> { Arc::downgrade(&self.0) }
+    pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> {
+        Arc::downgrade(&self.0)
+    }
 }
 
 /// Receiver ends of the push queues stored by the connection actor.
@@ -387,10 +391,10 @@ impl<F: FrameLike> PushQueues<F> {
         rate: Option<usize>,
         dlq: Option<mpsc::Sender<F>>,
     ) -> Result<(Self, PushHandle<F>), PushConfigError> {
-        if let Some(r) = rate {
-            if r == 0 || r > MAX_PUSH_RATE {
-                return Err(PushConfigError::InvalidRate(r));
-            }
+        if let Some(r) = rate.filter(|r| *r == 0 || *r > MAX_PUSH_RATE) {
+            // Reject unsupported rates early to avoid building queues that cannot
+            // be used. The bounds prevent runaway resource consumption.
+            return Err(PushConfigError::InvalidRate(r));
         }
         let (high_tx, high_rx) = mpsc::channel(high_capacity);
         let (low_tx, low_rx) = mpsc::channel(low_capacity);

--- a/src/push.rs
+++ b/src/push.rs
@@ -309,7 +309,8 @@ impl<F: FrameLike> PushQueues<F> {
         high_capacity: usize,
         low_capacity: usize,
     ) -> (Self, PushHandle<F>) {
-        Self::bounded_with_rate_dlq(high_capacity, low_capacity, None, None).unwrap()
+        Self::bounded_with_rate_dlq(high_capacity, low_capacity, None, None)
+            .expect("bounded_no_rate_limit should not fail")
     }
 
     /// Create queues with a custom rate limit in pushes per second.

--- a/src/push.rs
+++ b/src/push.rs
@@ -309,8 +309,12 @@ impl<F: FrameLike> PushQueues<F> {
         high_capacity: usize,
         low_capacity: usize,
     ) -> (Self, PushHandle<F>) {
-        Self::bounded_with_rate_dlq(high_capacity, low_capacity, None, None)
-            .expect("bounded_no_rate_limit should not fail")
+        // `bounded_with_rate_dlq` only fails when given an invalid rate. Passing
+        // `None` disables rate limiting entirely so the call is infallible. The
+        // debug assertion guards against future regressions.
+        let result = Self::bounded_with_rate_dlq(high_capacity, low_capacity, None, None);
+        debug_assert!(result.is_ok(), "bounded_no_rate_limit should not fail");
+        result.expect("bounded_no_rate_limit should not fail")
     }
 
     /// Create queues with a custom rate limit in pushes per second.

--- a/src/push.rs
+++ b/src/push.rs
@@ -97,9 +97,7 @@ pub(crate) struct PushHandleInner<F> {
 pub struct PushHandle<F>(Arc<PushHandleInner<F>>);
 
 impl<F: FrameLike> PushHandle<F> {
-    pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self {
-        Self(arc)
-    }
+    pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self { Self(arc) }
 
     /// Internal helper to push a frame with the requested priority.
     ///
@@ -255,9 +253,7 @@ impl<F: FrameLike> PushHandle<F> {
     }
 
     /// Downgrade to a `Weak` reference for storage in a registry.
-    pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> {
-        Arc::downgrade(&self.0)
-    }
+    pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> { Arc::downgrade(&self.0) }
 }
 
 /// Receiver ends of the push queues stored by the connection actor.

--- a/src/push.rs
+++ b/src/push.rs
@@ -97,7 +97,9 @@ pub(crate) struct PushHandleInner<F> {
 pub struct PushHandle<F>(Arc<PushHandleInner<F>>);
 
 impl<F: FrameLike> PushHandle<F> {
-    pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self { Self(arc) }
+    pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self {
+        Self(arc)
+    }
 
     /// Internal helper to push a frame with the requested priority.
     ///
@@ -253,7 +255,9 @@ impl<F: FrameLike> PushHandle<F> {
     }
 
     /// Downgrade to a `Weak` reference for storage in a registry.
-    pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> { Arc::downgrade(&self.0) }
+    pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> {
+        Arc::downgrade(&self.0)
+    }
 }
 
 /// Receiver ends of the push queues stored by the connection actor.
@@ -387,10 +391,10 @@ impl<F: FrameLike> PushQueues<F> {
         rate: Option<usize>,
         dlq: Option<mpsc::Sender<F>>,
     ) -> Result<(Self, PushHandle<F>), PushConfigError> {
-        if let Some(r) = rate
-            && (r == 0 || r > MAX_PUSH_RATE)
-        {
-            return Err(PushConfigError::InvalidRate(r));
+        if let Some(r) = rate {
+            if r == 0 || r > MAX_PUSH_RATE {
+                return Err(PushConfigError::InvalidRate(r));
+            }
         }
         let (high_tx, high_rx) = mpsc::channel(high_capacity);
         let (low_tx, low_rx) = mpsc::channel(low_capacity);

--- a/src/server.rs
+++ b/src/server.rs
@@ -229,7 +229,9 @@ where
     /// ```
     #[inline]
     #[must_use]
-    pub const fn worker_count(&self) -> usize { self.workers }
+    pub const fn worker_count(&self) -> usize {
+        self.workers
+    }
 
     /// Get the socket address the server is bound to, if available.
     #[must_use]

--- a/src/server.rs
+++ b/src/server.rs
@@ -229,9 +229,7 @@ where
     /// ```
     #[inline]
     #[must_use]
-    pub const fn worker_count(&self) -> usize {
-        self.workers
-    }
+    pub const fn worker_count(&self) -> usize { self.workers }
 
     /// Get the socket address the server is bound to, if available.
     #[must_use]

--- a/src/server.rs
+++ b/src/server.rs
@@ -507,10 +507,10 @@ async fn process_stream<F, T>(
     let peer_addr = stream.peer_addr().ok();
     match read_preamble::<_, T>(&mut stream).await {
         Ok((preamble, leftover)) => {
-            if let Some(handler) = on_success.as_ref()
-                && let Err(e) = handler(&preamble, &mut stream).await
-            {
-                tracing::error!(error = ?e, ?peer_addr, "preamble callback error");
+            if let Some(handler) = on_success.as_ref() {
+                if let Err(e) = handler(&preamble, &mut stream).await {
+                    tracing::error!(error = ?e, ?peer_addr, "preamble callback error");
+                }
             }
             let stream = RewindStream::new(leftover, stream);
             // Hand the connection to the application for processing.
@@ -558,10 +558,7 @@ mod tests {
 
     /// Test helper preamble carrying no data.
     #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-    #[expect(
-        dead_code,
-        reason = "used only in doctest to illustrate an empty preamble"
-    )]
+    // Used only in doctest to illustrate an empty preamble.
     struct EmptyPreamble;
 
     #[fixture]

--- a/src/server.rs
+++ b/src/server.rs
@@ -561,11 +561,6 @@ mod tests {
         message: String,
     }
 
-    /// Test helper preamble carrying no data.
-    #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-    // Used only in doctest to illustrate an empty preamble.
-    struct EmptyPreamble;
-
     #[fixture]
     fn factory() -> impl Fn() -> WireframeApp + Send + Sync + Clone + 'static {
         || WireframeApp::default()

--- a/tests/app_data.rs
+++ b/tests/app_data.rs
@@ -31,7 +31,8 @@ fn shared_state_extractor_returns_data(
     mut empty_payload: Payload<'static>,
 ) {
     request.insert_state(5u32);
-    let extracted = SharedState::<u32>::from_message_request(&request, &mut empty_payload).unwrap();
+    let extracted = SharedState::<u32>::from_message_request(&request, &mut empty_payload)
+        .expect("failed to extract shared state");
     assert_eq!(*extracted, 5);
 }
 
@@ -42,6 +43,6 @@ fn missing_shared_state_returns_error(
 ) {
     let err = SharedState::<u32>::from_message_request(&request, &mut empty_payload)
         .err()
-        .unwrap();
+        .expect("missing state error expected");
     assert!(matches!(err, ExtractError::MissingState(_)));
 }

--- a/tests/async_stream.rs
+++ b/tests/async_stream.rs
@@ -29,6 +29,6 @@ async fn async_stream_frames_processed_in_order() {
 
     let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(out, vec![0, 1, 2]);
 }

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -45,14 +45,20 @@ async fn strict_priority_order(
     shutdown_token: CancellationToken,
 ) {
     let (queues, handle) = queues;
-    handle.push_low_priority(2).await.unwrap();
-    handle.push_high_priority(1).await.unwrap();
+    handle
+        .push_low_priority(2)
+        .await
+        .expect("push low priority failed");
+    handle
+        .push_high_priority(1)
+        .await
+        .expect("push high priority failed");
 
     let stream = stream::iter(vec![Ok(3u8)]);
     let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(out, vec![1, 2, 3]);
 }
 
@@ -70,15 +76,21 @@ async fn fairness_yields_low_after_burst(
     };
 
     for n in 1..=5 {
-        handle.push_high_priority(n).await.unwrap();
+        handle
+            .push_high_priority(n)
+            .await
+            .expect("push high priority failed");
     }
-    handle.push_low_priority(99).await.unwrap();
+    handle
+        .push_low_priority(99)
+        .await
+        .expect("push low priority failed");
 
     let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, None, shutdown_token);
     actor.set_fairness(fairness);
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(out, vec![1, 2, 99, 3, 4, 5]);
 }
 
@@ -198,19 +210,34 @@ async fn fairness_yields_low_with_time_slice(
         let _ = tx.send(out);
     });
 
-    handle.push_high_priority(1).await.unwrap();
+    handle
+        .push_high_priority(1)
+        .await
+        .expect("push high priority failed");
     tokio::time::advance(Duration::from_millis(5)).await;
-    handle.push_high_priority(2).await.unwrap();
+    handle
+        .push_high_priority(2)
+        .await
+        .expect("push high priority failed");
     tokio::time::advance(Duration::from_millis(15)).await;
-    handle.push_low_priority(42).await.unwrap();
+    handle
+        .push_low_priority(42)
+        .await
+        .expect("push low priority failed");
     for n in 3..=5 {
-        handle.push_high_priority(n).await.unwrap();
+        handle
+            .push_high_priority(n)
+            .await
+            .expect("push high priority failed");
     }
     drop(handle);
 
-    let out = rx.await.unwrap();
+    let out = rx.await.expect("actor output missing");
     assert!(out.contains(&42), "Low-priority item was not yielded");
-    let pos = out.iter().position(|x| *x == 42).unwrap();
+    let pos = out
+        .iter()
+        .position(|x| *x == 42)
+        .expect("value 42 should be present");
     assert!(
         pos > 0 && pos < out.len() - 1,
         "Low-priority item should be yielded in the middle"
@@ -230,7 +257,7 @@ async fn shutdown_signal_precedence(
         ConnectionActor::new(queues, handle, None, shutdown_token);
     // drop the handle after actor creation to mimic early disconnection
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert!(out.is_empty());
 }
 
@@ -242,14 +269,17 @@ async fn complete_draining_of_sources(
     shutdown_token: CancellationToken,
 ) {
     let (queues, handle) = queues;
-    handle.push_high_priority(1).await.unwrap();
+    handle
+        .push_high_priority(1)
+        .await
+        .expect("push high priority failed");
 
     let stream = stream::iter(vec![Ok(2u8), Ok(3u8)]);
     let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     // drop handle after actor setup
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(out, vec![1, 2, 3]);
 }
 
@@ -289,7 +319,7 @@ async fn error_propagation_from_stream(
         hooks,
     );
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(called.load(Ordering::SeqCst), 1);
     assert_eq!(out, vec![1, 2]);
 }
@@ -307,7 +337,7 @@ async fn protocol_error_logs_warning(
     let mut actor: ConnectionActor<_, TestError> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert!(out.is_empty());
     let mut found = false;
     while let Some(record) = logger.pop() {
@@ -364,7 +394,7 @@ async fn interleaved_shutdown_during_stream(
     let mut actor: ConnectionActor<_, ()> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert!(!out.is_empty() && out.len() < 5);
 }
 
@@ -373,7 +403,10 @@ async fn interleaved_shutdown_during_stream(
 #[serial]
 async fn push_queue_exhaustion_backpressure() {
     let (mut queues, handle) = PushQueues::bounded(1, 1);
-    handle.push_high_priority(1).await.unwrap();
+    handle
+        .push_high_priority(1)
+        .await
+        .expect("push high priority failed");
 
     let blocked = timeout(Duration::from_millis(50), handle.push_high_priority(2)).await;
     assert!(blocked.is_err());
@@ -399,7 +432,10 @@ async fn before_send_hook_modifies_frames(
     shutdown_token: CancellationToken,
 ) {
     let (queues, handle) = queues;
-    handle.push_high_priority(1).await.unwrap();
+    handle
+        .push_high_priority(1)
+        .await
+        .expect("push high priority failed");
 
     let stream = stream::iter(vec![Ok(2u8)]);
     let hooks = ProtocolHooks {
@@ -415,7 +451,7 @@ async fn before_send_hook_modifies_frames(
         hooks,
     );
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(out, vec![2, 3]);
 }
 
@@ -446,7 +482,7 @@ async fn on_command_end_hook_runs(
         hooks,
     );
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     assert_eq!(counter.load(Ordering::SeqCst), 1);
 }
 
@@ -495,7 +531,7 @@ async fn connection_count_decrements_on_abort(
     assert_eq!(during, before + 1);
 
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     let after = wireframe::connection::active_connection_count();
     assert_eq!(during - after, 1);
 }
@@ -516,7 +552,7 @@ async fn connection_count_decrements_on_close(
     assert_eq!(during, before + 1);
 
     let mut out = Vec::new();
-    actor.run(&mut out).await.unwrap();
+    actor.run(&mut out).await.expect("actor run failed");
     let after = wireframe::connection::active_connection_count();
     assert_eq!(during - after, 1);
 }

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -22,27 +22,21 @@ use wireframe_testing::push_expect;
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
-fn queues() -> (PushQueues<u8>, wireframe::push::PushHandle<u8>) {
-    PushQueues::bounded(8, 8)
-}
+fn queues() -> (PushQueues<u8>, wireframe::push::PushHandle<u8>) { PushQueues::bounded(8, 8) }
 
 #[fixture]
 #[allow(
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
-fn shutdown_token() -> CancellationToken {
-    CancellationToken::new()
-}
+fn shutdown_token() -> CancellationToken { CancellationToken::new() }
 
 #[fixture]
 #[allow(
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
-fn empty_stream() -> Option<FrameStream<u8, ()>> {
-    None
-}
+fn empty_stream() -> Option<FrameStream<u8, ()>> { None }
 
 #[rstest]
 #[tokio::test]

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -35,10 +35,11 @@ struct TestMsg(u8);
 #[rstest]
 fn message_extractor_parses_and_advances(request: MessageRequest) {
     let msg = TestMsg(42);
-    let bytes = msg.to_bytes().unwrap();
+    let bytes = msg.to_bytes().expect("failed to serialise message");
     let mut payload = Payload::new(bytes.as_slice());
 
-    let extracted = Message::<TestMsg>::from_message_request(&request, &mut payload).unwrap();
+    let extracted = Message::<TestMsg>::from_message_request(&request, &mut payload)
+        .expect("failed to extract TestMsg from payload");
     assert_eq!(*extracted, msg);
     assert_eq!(payload.remaining(), 0);
 }
@@ -51,7 +52,8 @@ fn connection_info_reports_peer(mut request: MessageRequest, mut empty_payload: 
         .parse()
         .expect("hard-coded socket address must be valid");
     request.peer_addr = Some(addr);
-    let info = ConnectionInfo::from_message_request(&request, &mut empty_payload).unwrap();
+    let info = ConnectionInfo::from_message_request(&request, &mut empty_payload)
+        .expect("failed to build ConnectionInfo");
     assert_eq!(info.peer_addr(), Some(addr));
 }
 
@@ -66,7 +68,7 @@ fn shared_state_extractor(mut request: MessageRequest, mut empty_payload: Payloa
 
     let state =
         wireframe::extractor::SharedState::<u8>::from_message_request(&request, &mut empty_payload)
-            .unwrap();
+            .expect("failed to extract shared state");
     assert_eq!(*state, 42);
 }
 

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -19,11 +19,11 @@ where
     S: TestSerializer,
 {
     WireframeApp::new()
-        .unwrap()
+        .expect("failed to create app")
         .frame_processor(LengthPrefixedProcessor::default())
         .serializer(serializer)
         .route(1, Arc::new(|_| Box::pin(async {})))
-        .unwrap()
+        .expect("route registration failed")
 }
 
 struct CountingSerializer(Arc<AtomicUsize>);

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -55,6 +55,6 @@ async fn middleware_modifies_request_and_response() {
     let wrapped = mw.transform(service).await;
 
     let request = ServiceRequest::new(vec![1, 2, 3]);
-    let response = wrapped.call(request).await.unwrap();
+    let response = wrapped.call(request).await.expect("middleware call failed");
     assert_eq!(response.frame(), &[1, 2, 3, b'!', b'?']);
 }

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -54,35 +54,40 @@ impl Transform<HandlerService<Envelope>> for TagMiddleware {
 async fn middleware_applied_in_reverse_order() {
     let handler: Handler<Envelope> = std::sync::Arc::new(|_env: &Envelope| Box::pin(async {}));
     let app = WireframeApp::new()
-        .unwrap()
+        .expect("failed to create app")
         .route(1, handler)
-        .unwrap()
+        .expect("route registration failed")
         .wrap(TagMiddleware(b'A'))
-        .unwrap()
+        .expect("wrap failed")
         .wrap(TagMiddleware(b'B'))
-        .unwrap();
+        .expect("wrap failed");
 
     let (mut client, server) = duplex(256);
 
     let env = Envelope::new(1, vec![b'X']);
     let serializer = BincodeSerializer;
-    let bytes = serializer.serialize(&env).unwrap();
+    let bytes = serializer.serialize(&env).expect("serialization failed");
     // Use the default 4-byte big-endian length prefix for framing
     let processor = LengthPrefixedProcessor::default();
     let mut buf = BytesMut::new();
-    processor.encode(&bytes, &mut buf).unwrap();
-    client.write_all(&buf).await.unwrap();
-    client.shutdown().await.unwrap();
+    processor.encode(&bytes, &mut buf).expect("encoding failed");
+    client.write_all(&buf).await.expect("write failed");
+    client.shutdown().await.expect("shutdown failed");
 
     let handle = tokio::spawn(async move { app.handle_connection(server).await });
 
     let mut out = Vec::new();
-    client.read_to_end(&mut out).await.unwrap();
-    handle.await.unwrap();
+    client.read_to_end(&mut out).await.expect("read failed");
+    handle.await.expect("join failed");
 
     let mut buf = BytesMut::from(&out[..]);
-    let frame = processor.decode(&mut buf).unwrap().unwrap();
-    let (resp, _) = serializer.deserialize::<Envelope>(&frame).unwrap();
+    let frame = processor
+        .decode(&mut buf)
+        .expect("decode failed")
+        .expect("frame missing");
+    let (resp, _) = serializer
+        .deserialize::<Envelope>(&frame)
+        .expect("deserialize failed");
     let (_, bytes) = resp.into_parts();
     assert_eq!(bytes, vec![b'X', b'A', b'B', b'B', b'A']);
 }

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -11,11 +11,17 @@ use wireframe::push::{PushError, PushPolicy, PushPriority, PushQueues};
 async fn frames_routed_to_correct_priority_queues() {
     let (mut queues, handle) = PushQueues::bounded(1, 1);
 
-    handle.push_low_priority(1u8).await.unwrap();
-    handle.push_high_priority(2u8).await.unwrap();
+    handle
+        .push_low_priority(1u8)
+        .await
+        .expect("push low priority failed");
+    handle
+        .push_high_priority(2u8)
+        .await
+        .expect("push high priority failed");
 
-    let (prio1, frame1) = queues.recv().await.unwrap();
-    let (prio2, frame2) = queues.recv().await.unwrap();
+    let (prio1, frame1) = queues.recv().await.expect("recv failed");
+    let (prio2, frame2) = queues.recv().await.expect("recv failed");
 
     assert_eq!(prio1, PushPriority::High);
     assert_eq!(frame1, 2);
@@ -31,14 +37,20 @@ async fn frames_routed_to_correct_priority_queues() {
 async fn try_push_respects_policy() {
     let (mut queues, handle) = PushQueues::bounded(1, 1);
 
-    handle.push_high_priority(1u8).await.unwrap();
+    handle
+        .push_high_priority(1u8)
+        .await
+        .expect("push high priority failed");
     let result = handle.try_push(2u8, PushPriority::High, PushPolicy::ReturnErrorIfFull);
     assert!(result.is_err());
 
     // drain queue to allow new push
     let _ = queues.recv().await;
-    handle.push_high_priority(3u8).await.unwrap();
-    let (_, last) = queues.recv().await.unwrap();
+    handle
+        .push_high_priority(3u8)
+        .await
+        .expect("push high priority failed");
+    let (_, last) = queues.recv().await.expect("recv failed");
     assert_eq!(last, 3);
 }
 
@@ -65,11 +77,18 @@ async fn push_queues_error_on_closed() {
 #[tokio::test]
 async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
     time::pause();
-    let (mut queues, handle) = PushQueues::bounded_with_rate(2, 2, Some(1)).unwrap();
+    let (mut queues, handle) =
+        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
 
     match priority {
-        PushPriority::High => handle.push_high_priority(1u8).await.unwrap(),
-        PushPriority::Low => handle.push_low_priority(1u8).await.unwrap(),
+        PushPriority::High => handle
+            .push_high_priority(1u8)
+            .await
+            .expect("push high priority failed"),
+        PushPriority::Low => handle
+            .push_low_priority(1u8)
+            .await
+            .expect("push low priority failed"),
     }
 
     let attempt = match priority {
@@ -85,12 +104,18 @@ async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
 
     time::advance(Duration::from_secs(1)).await;
     match priority {
-        PushPriority::High => handle.push_high_priority(3u8).await.unwrap(),
-        PushPriority::Low => handle.push_low_priority(3u8).await.unwrap(),
+        PushPriority::High => handle
+            .push_high_priority(3u8)
+            .await
+            .expect("push high priority failed"),
+        PushPriority::Low => handle
+            .push_low_priority(3u8)
+            .await
+            .expect("push low priority failed"),
     }
 
-    let (_, first) = queues.recv().await.unwrap();
-    let (_, second) = queues.recv().await.unwrap();
+    let (_, first) = queues.recv().await.expect("recv failed");
+    let (_, second) = queues.recv().await.expect("recv failed");
     assert_eq!((first, second), (1, 3));
 }
 
@@ -98,13 +123,20 @@ async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
 #[tokio::test]
 async fn rate_limiter_allows_after_wait() {
     time::pause();
-    let (mut queues, handle) = PushQueues::bounded_with_rate(2, 2, Some(1)).unwrap();
-    handle.push_high_priority(1u8).await.unwrap();
+    let (mut queues, handle) =
+        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    handle
+        .push_high_priority(1u8)
+        .await
+        .expect("push high priority failed");
     time::advance(Duration::from_secs(1)).await;
-    handle.push_high_priority(2u8).await.unwrap();
+    handle
+        .push_high_priority(2u8)
+        .await
+        .expect("push high priority failed");
 
-    let (_, a) = queues.recv().await.unwrap();
-    let (_, b) = queues.recv().await.unwrap();
+    let (_, a) = queues.recv().await.expect("recv failed");
+    let (_, b) = queues.recv().await.expect("recv failed");
     assert_eq!((a, b), (1, 2));
 }
 
@@ -114,17 +146,24 @@ async fn rate_limiter_allows_after_wait() {
 #[tokio::test]
 async fn rate_limiter_shared_across_priorities() {
     time::pause();
-    let (mut queues, handle) = PushQueues::bounded_with_rate(2, 2, Some(1)).unwrap();
-    handle.push_high_priority(1u8).await.unwrap();
+    let (mut queues, handle) =
+        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    handle
+        .push_high_priority(1u8)
+        .await
+        .expect("push high priority failed");
 
     let attempt = time::timeout(Duration::from_millis(10), handle.push_low_priority(2u8)).await;
     assert!(attempt.is_err(), "second push should block across queues");
 
     time::advance(Duration::from_secs(1)).await;
-    handle.push_low_priority(2u8).await.unwrap();
+    handle
+        .push_low_priority(2u8)
+        .await
+        .expect("push low priority failed");
 
-    let (prio1, frame1) = queues.recv().await.unwrap();
-    let (prio2, frame2) = queues.recv().await.unwrap();
+    let (prio1, frame1) = queues.recv().await.expect("recv failed");
+    let (prio2, frame2) = queues.recv().await.expect("recv failed");
     assert_eq!(prio1, PushPriority::High);
     assert_eq!(frame1, 1);
     assert_eq!(prio2, PushPriority::Low);
@@ -136,12 +175,15 @@ async fn rate_limiter_shared_across_priorities() {
 async fn unlimited_queues_do_not_block() {
     time::pause();
     let (mut queues, handle) = PushQueues::bounded_no_rate_limit(1, 1);
-    handle.push_high_priority(1u8).await.unwrap();
+    handle
+        .push_high_priority(1u8)
+        .await
+        .expect("push high priority failed");
     let res = time::timeout(Duration::from_millis(10), handle.push_low_priority(2u8)).await;
     assert!(res.is_ok(), "pushes should not block when unlimited");
 
-    let (_, a) = queues.recv().await.unwrap();
-    let (_, b) = queues.recv().await.unwrap();
+    let (_, a) = queues.recv().await.expect("recv failed");
+    let (_, b) = queues.recv().await.expect("recv failed");
     assert_eq!((a, b), (1, 2));
 }
 
@@ -150,10 +192,14 @@ async fn unlimited_queues_do_not_block() {
 #[tokio::test]
 async fn rate_limiter_allows_burst_within_capacity_and_blocks_excess() {
     time::pause();
-    let (mut queues, handle) = PushQueues::bounded_with_rate(4, 4, Some(3)).unwrap();
+    let (mut queues, handle) =
+        PushQueues::bounded_with_rate(4, 4, Some(3)).expect("queue creation failed");
 
     for i in 0u8..3 {
-        handle.push_high_priority(i).await.unwrap();
+        handle
+            .push_high_priority(i)
+            .await
+            .expect("push high priority failed");
     }
 
     let res = time::timeout(Duration::from_millis(10), handle.push_high_priority(99)).await;
@@ -163,10 +209,13 @@ async fn rate_limiter_allows_burst_within_capacity_and_blocks_excess() {
     );
 
     time::advance(Duration::from_secs(1)).await;
-    handle.push_high_priority(100).await.unwrap();
+    handle
+        .push_high_priority(100)
+        .await
+        .expect("push high priority failed");
 
     for expected in [0u8, 1u8, 2u8, 100u8] {
-        let (_, frame) = queues.recv().await.unwrap();
+        let (_, frame) = queues.recv().await.expect("recv failed");
         assert_eq!(frame, expected);
     }
 }

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -132,7 +132,7 @@ fn custom_length_roundtrip(
 #[tokio::test]
 async fn send_response_propagates_write_error() {
     let app = WireframeApp::new()
-        .expect("route registration failed")
+        .expect("app creation failed")
         .frame_processor(LengthPrefixedProcessor::default());
 
     let mut writer = FailingWriter;

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -42,10 +42,14 @@ async fn readiness_receiver_dropped() {
     let factory = || WireframeApp::new().expect("WireframeApp::new failed");
     let server = WireframeServer::new(factory)
         .workers(1)
-        .bind("127.0.0.1:0".parse().unwrap())
-        .unwrap();
+        .bind(
+            "127.0.0.1:0"
+                .parse()
+                .expect("hard-coded socket address must be valid"),
+        )
+        .expect("bind failed");
 
-    let addr = server.local_addr().unwrap();
+    let addr = server.local_addr().expect("local addr missing");
     // Create channel and immediately drop receiver to force send failure
     let (tx_ready, rx_ready) = oneshot::channel();
     drop(rx_ready);
@@ -55,7 +59,7 @@ async fn readiness_receiver_dropped() {
             .ready_signal(tx_ready)
             .run_with_shutdown(tokio::time::sleep(Duration::from_millis(200)))
             .await
-            .unwrap();
+            .expect("server run failed");
     });
 
     // Wait briefly to ensure server attempted to send readiness signal

--- a/tests/session_registry.rs
+++ b/tests/session_registry.rs
@@ -31,8 +31,8 @@ async fn handle_retrieved_while_alive(
     registry.insert(id, &handle);
 
     let retrieved = registry.get(&id).expect("handle should be present");
-    retrieved.push_high_priority(7).await.unwrap();
-    let (_, val) = queues.recv().await.unwrap();
+    retrieved.push_high_priority(7).await.expect("push failed");
+    let (_, val) = queues.recv().await.expect("recv failed");
     assert_eq!(val, 7);
 }
 

--- a/wireframe_testing/src/helpers.rs
+++ b/wireframe_testing/src/helpers.rs
@@ -454,7 +454,7 @@ where
     let mut buf = Vec::new();
     client.read_to_end(&mut buf).await?;
 
-    server_task.await.unwrap();
+    server_task.await.expect("server task panicked");
     Ok(buf)
 }
 

--- a/wireframe_testing/src/helpers.rs
+++ b/wireframe_testing/src/helpers.rs
@@ -486,3 +486,35 @@ where
     let (_client, server) = duplex(64);
     app.handle_connection(server).await;
 }
+
+/// Await the provided future and panic with context on failure.
+///
+/// In debug builds, the generated message includes the call site for easier
+/// troubleshooting.
+#[macro_export]
+macro_rules! push_expect {
+    ($fut:expr) => {{
+        $fut.await
+            .expect(concat!("push failed at ", file!(), ":", line!()))
+    }};
+    ($fut:expr, $msg:expr) => {{
+        let m = ::std::format!("{msg} at {}:{}", file!(), line!(), msg = $msg);
+        $fut.await.expect(&m)
+    }};
+}
+
+/// Await the provided future and panic with context on failure.
+///
+/// In debug builds, the generated message includes the call site for easier
+/// troubleshooting.
+#[macro_export]
+macro_rules! recv_expect {
+    ($fut:expr) => {{
+        $fut.await
+            .expect(concat!("recv failed at ", file!(), ":", line!()))
+    }};
+    ($fut:expr, $msg:expr) => {{
+        let m = ::std::format!("{msg} at {}:{}", file!(), line!(), msg = $msg);
+        $fut.await.expect(&m)
+    }};
+}


### PR DESCRIPTION
## Summary
- replace `.unwrap()` calls with `.expect()` across tests and code
- add meaningful error messages for each `.expect()`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bc793d3588322b35989f097ecab1c

## Summary by Sourcery

Replace .unwrap() calls with .expect() throughout the codebase and tests, adding descriptive error messages for improved debugging

Enhancements:
- Replace unwrap calls in production code (e.g., queue creation and unbounded rate limit) with expect and custom error messages

Tests:
- Update tests to use expect with meaningful messages instead of unwrap for operations like push, recv, socket binding, encoding/decoding, actor execution, and middleware calls