### PR TITLE
Clean up middleware transform attributes

### DIFF
--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -156,8 +156,6 @@ where
     type Output: Service;
 
     /// Create a new middleware service wrapping `service`.
-    #[inline]
-    #[allow(clippy::inline_fn_without_body, unused_attributes)]
     #[must_use = "use the returned middleware service"]
     async fn transform(&self, service: S) -> Self::Output;
 }


### PR DESCRIPTION
## Summary
- remove unused inline attribute from `Transform::transform`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bc791151483228c94278bf134c453

## Summary by Sourcery

Enhancements:
- Remove unused #[inline] and #[allow(clippy::inline_fn_without_body, unused_attributes)] from the Transform::transform method