### PR TITLE
Refactor connection actor event polling

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -251,9 +251,9 @@ where
 
             () = Self::await_shutdown(self.shutdown.clone()), if state.is_active() => Event::Shutdown,
 
-            res = Self::poll_high_priority(self.high_rx.as_mut()), if high_available => Event::High(res),
+            res = Self::poll_priority(self.high_rx.as_mut()), if high_available => Event::High(res),
 
-            res = Self::poll_low_priority(self.low_rx.as_mut()), if low_available => Event::Low(res),
+            res = Self::poll_priority(self.low_rx.as_mut()), if low_available => Event::Low(res),
 
             res = Self::poll_response(self.response.as_mut()), if resp_available => Event::Response(res),
 
@@ -494,13 +494,8 @@ where
     /// Await shutdown cancellation on the provided token.
     async fn await_shutdown(token: CancellationToken) { Self::wait_shutdown(token).await; }
 
-    /// Poll the high-priority queue.
-    async fn poll_high_priority(rx: Option<&mut mpsc::Receiver<F>>) -> Option<F> {
-        Self::poll_optional(rx, Self::recv_push).await
-    }
-
-    /// Poll the low-priority queue.
-    async fn poll_low_priority(rx: Option<&mut mpsc::Receiver<F>>) -> Option<F> {
+    /// Poll whichever priority queue is provided.
+    async fn poll_priority(rx: Option<&mut mpsc::Receiver<F>>) -> Option<F> {
         Self::poll_optional(rx, Self::recv_push).await
     }
 


### PR DESCRIPTION
## Summary
- simplify `next_event` by moving shutdown and queue polling to helpers
- dispatch events via a new `handle_event` function

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bf57d7b7883229d7adce6ad9c1693

## Summary by Sourcery

Refactor connection actor event polling to simplify next_event logic and centralize event dispatch

Enhancements:
- Extract shutdown waiting and queue polling into dedicated async helper methods (await_shutdown, poll_high_priority, poll_low_priority, poll_response)
- Replace inline tokio::select arms in next_event with calls to the new helper methods
- Introduce handle_event method to centralize event dispatching and delegate to existing process_* handlers