### PR TITLE
Refactor run_app helpers

### DIFF
--- a/docs/wireframe-testing-crate.md
+++ b/docs/wireframe-testing-crate.md
@@ -6,12 +6,11 @@ frames, enabling fast tests without opening real network connections.
 
 ## Motivation
 
-The existing tests in [`tests/`](../tests) use helper functions such as
-`run_app_with_frame` and `run_app_with_frames` to feed length-prefixed frames
-through an in-memory duplex stream. These helpers simplify testing handlers by
-allowing assertions on encoded responses without spinning up a full server.
-Encapsulating this logic in a dedicated crate keeps test code concise and
-reusable across projects.
+The existing tests in [`tests/`](../tests) use a helper function called
+`run_app` to feed length-prefixed frames through an in-memory duplex stream.
+This helper simplifies testing handlers by allowing assertions on encoded
+responses without spinning up a full server. Encapsulating this logic in a
+dedicated crate keeps test code concise and reusable across projects.
 
 ## Crate Layout
 
@@ -63,12 +62,11 @@ where
     M: Serialize;
 ```
 
-These functions mirror the behaviour of `run_app_with_frame` and
-`run_app_with_frames` found in the repository’s test utilities. They create a
-`tokio::io::duplex` stream, spawn the application as a background task, and
-write the provided frame(s) to the client side of the stream. After the
-application finishes processing, the helpers collect the bytes written back and
-return them for inspection.
+These functions mirror the behaviour of the `run_app` helper found in the
+repository’s test utilities. They create a `tokio::io::duplex` stream, spawn
+the application as a background task, and write the provided frame(s) to the
+client side of the stream. After the application finishes processing, the
+helpers collect the bytes written back and return them for inspection.
 
 Any I/O errors surfaced by the duplex stream or failures while decoding a
 length prefix propagate through the returned `IoResult`. Malformed or truncated
@@ -78,8 +76,9 @@ assert on these failure conditions directly.
 ### Custom Buffer Capacity
 
 A variant accepting a buffer `capacity` allows fine-tuning the size of the
-in-memory duplex channel, matching the existing
-`run_app_with_frame_with_capacity` and `run_app_with_frames_with_capacity`
+in-memory duplex channel. The legacy helpers `run_app_with_frame_with_capacity`
+and `run_app_with_frames_with_capacity` are replaced by `run_app`, which
+accepts `Option<usize>` for the buffer size.
 
 ```helpers.
 pub async fn drive_with_frame_with_capacity(

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -17,7 +17,7 @@ use wireframe::{
     frame::{FrameProcessor, LengthPrefixedProcessor},
     serializer::{BincodeSerializer, Serializer},
 };
-use wireframe_testing::{processor, run_app_with_frame, run_with_duplex_server};
+use wireframe_testing::{processor, run_app, run_with_duplex_server};
 
 fn call_counting_callback<R, A>(
     counter: &Arc<AtomicUsize>,
@@ -133,7 +133,7 @@ async fn helpers_propagate_connection_state() {
         .encode(&bytes, &mut frame)
         .unwrap();
 
-    let out = run_app_with_frame(app, frame.to_vec()).await.unwrap();
+    let out = run_app(app, vec![frame.to_vec()], None).await.unwrap();
     assert!(!out.is_empty());
     assert_eq!(setup.load(Ordering::SeqCst), 1);
     assert_eq!(teardown.load(Ordering::SeqCst), 1);

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -31,10 +31,7 @@ pub use helpers::{
     drive_with_frames_mut,
     drive_with_frames_with_capacity,
     processor,
-    run_app_with_frame,
-    run_app_with_frame_with_capacity,
-    run_app_with_frames,
-    run_app_with_frames_with_capacity,
+    run_app,
     run_with_duplex_server,
 };
 pub use logging::{LoggerHandle, logger};


### PR DESCRIPTION
## Summary
- consolidate `run_app_with_*` helpers into a single `run_app` function
- adapt lifecycle tests to use the new helper
- document the new helper in `wireframe_testing` docs

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bf5a716088322842517a91ad75d33

## Summary by Sourcery

Consolidate the various test helpers into a single run_app function with optional buffer capacity, update error handling, and adapt the docs and lifecycle tests to use the new API.

Enhancements:
- Replace multiple run_app_with_* helper functions with a unified run_app that accepts a list of frames and an optional capacity
- Map server task failures to io::Error for clearer error propagation

Documentation:
- Revise wireframe-testing documentation to describe the new run_app helper and its optional capacity parameter, removing legacy helper references

Tests:
- Update lifecycle tests to call run_app instead of the old run_app_with_frame helpers

Chores:
- Remove deprecated run_app_with_frame(_with_capacity) and run_app_with_frames(_with_capacity) exports from the crate