### PR TITLE
Improve SessionRegistry active handle pruning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,19 @@ project:
 - Prefer `.expect()` over `.unwrap()`.
 - Use `concat!()` to combine long string literals rather than escaping newlines
   with a backslash.
+- Prefer single line versions of functions where appropriate. I.e.,
+
+  ```
+  pub fn new(id: u64) -> Self { Self(id) }
+  ```
+
+  Instead of:
+
+  ```
+  pub fn new(id: u64) -> Self {
+      Self(id)
+  }
+  ```
 
 ### Dependency Management
 

--- a/README.md
+++ b/README.md
@@ -83,10 +83,9 @@ WireframeServer::new(|| {
 ```
 
 This example showcases how derive macros and the framing abstraction simplify a
-binary protocol server. See the
+binary protocol server. See the <!-- markdownlint-disable-next-line MD013 -->
 [full example](docs/rust-binary-router-library-design.md#5-6-illustrative-api-usage-examples)
- <!-- markdownlint-disable-line MD013 --> in the design document for further
-details.
+ in the design document for further details.
 
 ## Custom Envelopes
 

--- a/README.md
+++ b/README.md
@@ -193,9 +193,10 @@ let app = WireframeApp::new().with_protocol(MySqlProtocolImpl);
 The \[`SessionRegistry`\] stores weak references to \[`PushHandle`\]s for
 active connections. Background tasks can look up a handle by \[`ConnectionId`\]
 to send frames asynchronously without keeping the connection alive. Entries are
-pruned on lookup and when calling `active_handles()`. Invoke `prune()` from a
-maintenance task when only removal of dead entries is required, without
-collecting handles.
+pruned on lookup and when calling `active_handles()`. `DashMap::retain` holds
+per-bucket write locks while collecting, so heavy traffic may experience
+contention. Invoke `prune()` from a maintenance task when only removal of dead
+entries is required, without collecting handles.
 
 ```rust
 use wireframe::{

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ WireframeServer::new(|| {
 ```
 
 This example showcases how derive macros and the framing abstraction simplify a
-binary protocol server. See the <!-- markdownlint-disable-next-line MD013 -->
+binary protocol server. See the
+<!-- markdownlint-disable-next-line MD013 -->
 [full example](docs/rust-binary-router-library-design.md#5-6-illustrative-api-usage-examples)
  in the design document for further details.
 

--- a/README.md
+++ b/README.md
@@ -192,9 +192,10 @@ let app = WireframeApp::new().with_protocol(MySqlProtocolImpl);
 
 The \[`SessionRegistry`\] stores weak references to \[`PushHandle`\]s for
 active connections. Background tasks can look up a handle by \[`ConnectionId`\]
-to send frames asynchronously without keeping the connection alive. Stale
-entries are pruned on lookup and when calling `active_handles()`. Use `prune()`
-if you only need to remove dead entries without collecting handles.
+to send frames asynchronously without keeping the connection alive. Entries are
+pruned on lookup and when calling `active_handles()`. Invoke `prune()` from a
+maintenance task when only removal of dead entries is required, without
+collecting handles.
 
 ```rust
 use wireframe::{

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ let app = WireframeApp::new().with_protocol(MySqlProtocolImpl);
 The \[`SessionRegistry`\] stores weak references to \[`PushHandle`\]s for
 active connections. Background tasks can look up a handle by \[`ConnectionId`\]
 to send frames asynchronously without keeping the connection alive. Stale
-entries are removed automatically when looked up and found to be dead. Call
-`active_handles()` to iterate over live sessions for broadcast or diagnostics.
+entries are pruned on lookup and when calling `active_handles()`. Use `prune()`
+if you only need to remove dead entries without collecting handles.
 
 ```rust
 use wireframe::{

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -447,10 +447,10 @@ impl<F> SessionRegistry<F> {
 ```
 
 `active_handles()` prunes stale entries as it collects the remaining live
-handles. Invoke `prune()` from a maintenance task when only cleanup of dead
-sessions is required. `DashMap::retain` acquires per-bucket write locks, so
-collecting and pruning in one pass may increase contention under heavy
-concurrency compared with a dedicated `remove_if` cleanup.
+handles. Maintenance tasks may call `prune()` when only cleanup of dead sessions
+is required. `DashMap::retain` acquires per-bucket write locks, so collecting
+and pruning in one pass may increase contention under heavy concurrency
+compared with a dedicated `remove_if` cleanup.
 
 The diagram below summarises the data structures and how they interact when
 storing session handles. `SessionRegistry` maps `ConnectionId`s to weak

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -432,13 +432,16 @@ impl<F> SessionRegistry<F> {
 
     /// Returns all live session handles for broadcast or diagnostics.
     pub fn active_handles(&self) -> Vec<(ConnectionId, PushHandle<F>)> {
-        self.0
-            .iter()
-            .filter_map(|entry| {
-                let id = *entry.key();
-                entry.value().upgrade().map(|h| (id, PushHandle(h)))
-            })
-            .collect()
+        let mut handles = Vec::new();
+        self.0.retain(|id, weak| {
+            if let Some(inner) = weak.upgrade() {
+                handles.push((*id, PushHandle(inner)));
+                true
+            } else {
+                false
+            }
+        });
+        handles
     }
 }
 ```

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -212,9 +212,9 @@ The solution is to store non-owning `Weak` pointers in the registry.
    impl<F> SessionRegistry<F> {
        pub fn get(&self, id: &ConnectionId) -> Option<PushHandle<F>> {
            self.0.get(id)
-               .and_then(|weak_ref| weak_ref.upgrade()) // Attempt to get a strong reference.
-               .map(PushHandle) // If successful, wrap it in our public type.
-       }
+                .and_then(|weak_ref| weak_ref.upgrade()) // Attempt to get a strong reference.
+                .map(PushHandle::from_arc) // If successful, wrap it in our public type.
+        }
 
        // Optional: A method to periodically sweep for dead entries.
        pub fn prune(&self) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,23 +15,17 @@ use crate::push::{FrameLike, PushHandle, PushHandleInner};
 pub struct ConnectionId(u64);
 
 impl From<u64> for ConnectionId {
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
+    fn from(value: u64) -> Self { Self(value) }
 }
 
 impl ConnectionId {
     /// Create a new [`ConnectionId`] with the provided value.
     #[must_use]
-    pub fn new(id: u64) -> Self {
-        Self(id)
-    }
+    pub fn new(id: u64) -> Self { Self(id) }
 
     /// Return the inner `u64` representation.
     #[must_use]
-    pub fn as_u64(&self) -> u64 {
-        self.0
-    }
+    pub fn as_u64(&self) -> u64 { self.0 }
 }
 
 impl std::fmt::Display for ConnectionId {
@@ -78,17 +72,13 @@ impl<F: FrameLike> SessionRegistry<F> {
     }
 
     /// Remove a handle, typically on connection teardown.
-    pub fn remove(&self, id: &ConnectionId) {
-        self.0.remove(id);
-    }
+    pub fn remove(&self, id: &ConnectionId) { self.0.remove(id); }
 
     /// Remove all stale weak references without returning any handles.
     ///
     /// `DashMap::retain` acquires per-bucket write locks, so other operations
     /// may contend briefly while the registry is pruned.
-    pub fn prune(&self) {
-        self.0.retain(|_, weak| weak.strong_count() > 0);
-    }
+    pub fn prune(&self) { self.0.retain(|_, weak| weak.strong_count() > 0); }
 
     /// Prune stale weak references, then collect the remaining live handles.
     ///
@@ -106,7 +96,5 @@ impl<F: FrameLike> SessionRegistry<F> {
     /// to clean up without collecting handles. `DashMap::retain` holds
     /// per-bucket write locks while iterating.
     #[must_use]
-    pub fn active_ids(&self) -> Vec<ConnectionId> {
-        self.retain_and_collect(|id, _| id)
-    }
+    pub fn active_ids(&self) -> Vec<ConnectionId> { self.retain_and_collect(|id, _| id) }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -92,8 +92,9 @@ impl<F: FrameLike> SessionRegistry<F> {
 
     /// Prune stale weak references, then collect the remaining live handles.
     ///
-    /// This holds per-bucket write locks while iterating. Use [`prune`] from a
-    /// maintenance task when only cleanup is required.
+    /// This method mutates the registry. Use [`prune`] from a maintenance task
+    /// to clean up without collecting handles. `DashMap::retain` holds
+    /// per-bucket write locks while iterating.
     #[must_use]
     pub fn active_handles(&self) -> Vec<(ConnectionId, PushHandle<F>)> {
         self.retain_and_collect(|id, inner| (id, PushHandle::from_arc(inner)))
@@ -101,8 +102,9 @@ impl<F: FrameLike> SessionRegistry<F> {
 
     /// Prune stale weak references, then return the IDs of the live connections.
     ///
-    /// This holds per-bucket write locks while iterating. Use [`prune`] from a
-    /// maintenance task when only cleanup is required.
+    /// This method mutates the registry. Use [`prune`] from a maintenance task
+    /// to clean up without collecting handles. `DashMap::retain` holds
+    /// per-bucket write locks while iterating.
     #[must_use]
     pub fn active_ids(&self) -> Vec<ConnectionId> {
         self.retain_and_collect(|id, _| id)

--- a/src/session.rs
+++ b/src/session.rs
@@ -58,10 +58,10 @@ impl<F: FrameLike> SessionRegistry<F> {
     /// Remove a handle, typically on connection teardown.
     pub fn remove(&self, id: &ConnectionId) { self.0.remove(id); }
 
-    /// Drop entries whose connections have terminated.
+    /// Remove all stale weak references without returning any handles.
     pub fn prune(&self) { self.0.retain(|_, weak| weak.strong_count() > 0); }
 
-    /// Return a list of all live connection IDs and their handles.
+    /// Prune stale weak references, then collect the remaining live handles.
     #[must_use]
     pub fn active_handles(&self) -> Vec<(ConnectionId, PushHandle<F>)> {
         let mut handles = Vec::new();


### PR DESCRIPTION
## Summary
- simplify `active_handles` to prune and collect in a single `retain` pass
- update the outbound messaging design doc to reflect the new approach

## Testing
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_688bf5ee5c1883229baf94a4eec8b09d

## Summary by Sourcery

Streamline SessionRegistry.active_handles by consolidating pruning and handle collection into a single retain operation and align documentation with the new approach.

Enhancements:
- Simplify SessionRegistry active_handles to prune stale entries and collect handles in a single retain pass

Documentation:
- Update asynchronous outbound messaging design doc to reflect simplified active_handles implementation