### PR TITLE
Refactor worker task

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -449,11 +449,10 @@ async fn accept_loop<F, T>(
     }
 }
 
-/// Runs a worker task that accepts incoming TCP connections and processes them
-/// asynchronously.
+/// Worker task that delegates connection acceptance to `accept_loop`.
 ///
-/// Each accepted connection is handled in a separate task, with optional callbacks for preamble
-/// decode success or failure. The worker listens for shutdown signals to terminate gracefully.
+/// This function serves as an entry point for worker tasks, passing all parameters
+/// to `accept_loop` which handles the actual connection acceptance and processing.
 async fn worker_task<F, T>(
     listener: Arc<TcpListener>,
     factory: F,


### PR DESCRIPTION
## Summary
- separate panic handling into `spawn_connection_task`
- extract accept logic into `accept_loop`
- keep `worker_task` focused on coordination
- test new helper function

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688bf5ca37788322a5e98a3a4d0cab5c

## Summary by Sourcery

Refactor worker_task by splitting off connection spawning and panic handling into spawn_connection_task, moving the accept loop into accept_loop, and updating tests to cover shutdown behavior and panic logging

Bug Fixes:
- Catch and log panics in connection tasks to prevent worker crashes

Enhancements:
- Move connection spawning and panic handling into spawn_connection_task
- Extract accept logic into accept_loop and simplify worker_task to delegate to it

Tests:
- Rename shutdown signal test to use accept_loop
- Add test verifying spawn_connection_task logs panics without tearing down the worker