### PR TITLE
Unify WireframeApp constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,18 @@ WireframeServer::new(|| {
 .await
 ```
 
-This example showcases how derive macros and the framing abstraction simplify a binary protocol server. See the [full example](docs/rust-binary-router-library-design.md#5-6-illustrative-api-usage-examples) <!-- markdownlint-disable-line MD013 --> in the design document for further details.
+This example showcases how derive macros and the framing abstraction simplify a
+binary protocol server. See the
+[full example](docs/rust-binary-router-library-design.md#5-6-illustrative-api-usage-examples)
+ <!-- markdownlint-disable-line MD013 --> in the design document for further
+details.
 
 ## Custom Envelopes
 
 `WireframeApp` defaults to a simple `Envelope` containing a message ID and raw
 payload bytes. Applications can supply their own envelope type by calling
-`WireframeApp::<_, _, MyEnv>::new_with_envelope()`. The custom type must
-implement the `Packet` trait:
+`WireframeApp::<_, _, MyEnv>::new()`. The custom type must implement the
+`Packet` trait:
 
 ```rust
 use wireframe::app::{Packet, WireframeApp};
@@ -103,7 +107,7 @@ impl Packet for MyEnv {
     fn from_parts(id: u32, data: Vec<u8>) -> Self { Self { id, data } }
 }
 
-let app = WireframeApp::<_, _, MyEnv>::new_with_envelope()
+let app = WireframeApp::<_, _, MyEnv>::new()
     .unwrap()
     .route(1, std::sync::Arc::new(|env: &MyEnv| Box::pin(async move { /* ... */ })))
     .unwrap();

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,12 +5,15 @@
 
 use std::io;
 
-use wireframe::{app::WireframeApp, server::WireframeServer};
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    server::WireframeServer,
+};
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
     let factory = || {
-        WireframeApp::new()
+        WireframeApp::<_, _, Envelope>::new()
             .unwrap()
             .route(
                 1,

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -65,7 +65,7 @@ struct Pong;
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())
         .serializer(HeaderSerializer)

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -78,7 +78,7 @@ fn handle_packet(_env: &Envelope) -> Pin<Box<dyn Future<Output = ()> + Send>> {
 #[tokio::main]
 async fn main() -> io::Result<()> {
     let factory = || {
-        WireframeApp::new()
+        WireframeApp::<_, _, Envelope>::new()
             .expect("Failed to create WireframeApp")
             .frame_processor(LengthPrefixedProcessor::new(LengthFormat::u16_le()))
             .wrap(DecodeMiddleware)

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -128,7 +128,7 @@ impl<E: Packet> Transform<HandlerService<E>> for Logging {
 }
 
 fn build_app() -> AppResult<WireframeApp> {
-    WireframeApp::new()?
+    WireframeApp::<_, _, Envelope>::new()?
         .serializer(BincodeSerializer)
         .route(PING_ID, Arc::new(|_| Box::pin(ping_handler())))?
         .wrap(PongMiddleware)?

--- a/src/app.rs
+++ b/src/app.rs
@@ -407,7 +407,7 @@ where
     ///
     /// ```rust,no_run
     /// use tokio::sync::mpsc;
-    /// use wireframe::app::WireframeApp;
+    /// use wireframe::app::{Envelope, WireframeApp};
     ///
     /// # fn build() -> WireframeApp { WireframeApp::<_, _, Envelope>::new().unwrap() }
     /// # fn main() {

--- a/src/app.rs
+++ b/src/app.rs
@@ -247,27 +247,32 @@ where
     }
 }
 
-impl WireframeApp<BincodeSerializer, (), Envelope> {
-    /// Construct a new empty application builder.
-    ///
-    /// # Errors
-    ///
-    /// This function currently never returns an error but uses the
-    /// [`Result`] type for forward compatibility.
-    pub fn new() -> Result<Self> { Ok(Self::default()) }
+fn builder_new<E>() -> WireframeApp<BincodeSerializer, (), E>
+where
+    E: Packet,
+{
+    WireframeApp::<BincodeSerializer, (), E>::default()
 }
 
 impl<E> WireframeApp<BincodeSerializer, (), E>
 where
     E: Packet,
 {
-    /// Construct a new application builder using a custom envelope type.
+    /// Construct a new empty application builder using the provided envelope type.
     ///
     /// # Errors
     ///
     /// This function currently never returns an error but uses [`Result`] for
     /// forward compatibility.
-    pub fn new_with_envelope() -> Result<Self> { Ok(Self::default()) }
+    pub fn new() -> Result<Self> { Ok(builder_new::<E>()) }
+
+    /// Deprecated alias for [`WireframeApp::new`].
+    ///
+    /// # Errors
+    ///
+    /// This function currently never returns an error but uses [`Result`] for
+    /// forward compatibility.
+    pub fn new_with_envelope() -> Result<Self> { Self::new() }
 }
 
 impl<S, C, E> WireframeApp<S, C, E>
@@ -404,7 +409,7 @@ where
     /// use tokio::sync::mpsc;
     /// use wireframe::app::WireframeApp;
     ///
-    /// # fn build() -> WireframeApp { WireframeApp::new().unwrap() }
+    /// # fn build() -> WireframeApp { WireframeApp::<_, _, Envelope>::new().unwrap() }
     /// # fn main() {
     /// let (tx, _rx) = mpsc::channel(16);
     /// let app = build().with_push_dlq(tx);

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -43,7 +43,9 @@ impl MessageRequest {
     ///     extractor::{MessageRequest, SharedState},
     /// };
     ///
-    /// let _app = WireframeApp::new().unwrap().app_data(5u32);
+    /// let _app = WireframeApp::<_, _, Envelope>::new()
+    ///     .unwrap()
+    ///     .app_data(5u32);
     /// // The framework populates the request with application data.
     /// # let mut req = MessageRequest::default();
     /// # req.insert_state(5u32);

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -39,7 +39,7 @@ impl MessageRequest {
     ///
     /// ```rust,no_run
     /// use wireframe::{
-    ///     app::WireframeApp,
+    ///     app::{Envelope, WireframeApp},
     ///     extractor::{MessageRequest, SharedState},
     /// };
     ///

--- a/src/server.rs
+++ b/src/server.rs
@@ -87,7 +87,10 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// use wireframe::{
+    ///     app::{Envelope, WireframeApp},
+    ///     server::WireframeServer,
+    /// };
     ///
     /// let server = WireframeServer::new(|| WireframeApp::default());
     /// assert!(server.worker_count() >= 1);
@@ -129,7 +132,7 @@ where
     ///
     /// ```no_run
     /// # use wireframe::server::WireframeServer;
-    /// # use wireframe::app::WireframeApp;
+    /// # use wireframe::app::{Envelope, WireframeApp};
     /// # let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// #[derive(bincode::Decode)]
     /// # struct MyPreamble;
@@ -167,7 +170,10 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// use wireframe::{
+    ///     app::{Envelope, WireframeApp},
+    ///     server::WireframeServer,
+    /// };
     ///
     /// let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory).workers(4);
@@ -221,7 +227,10 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// use wireframe::{
+    ///     app::{Envelope, WireframeApp},
+    ///     server::WireframeServer,
+    /// };
     ///
     /// let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory);
@@ -259,7 +268,10 @@ where
     /// ```no_run
     /// use std::net::SocketAddr;
     ///
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// use wireframe::{
+    ///     app::{Envelope, WireframeApp},
+    ///     server::WireframeServer,
+    /// };
     ///
     /// let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory);
@@ -307,7 +319,10 @@ where
     /// ```no_run
     /// use std::net::SocketAddr;
     ///
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    /// use wireframe::{
+    ///     app::{Envelope, WireframeApp},
+    ///     server::WireframeServer,
+    /// };
     /// async fn run_server() -> std::io::Result<()> {
     ///     let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     ///     let addr = "127.0.0.1:8080"
@@ -450,7 +465,7 @@ async fn worker_task<F, T>(
 /// ```no_run
 /// # use std::sync::Arc;
 /// # use tokio::net::TcpStream;
-/// # use wireframe::app::WireframeApp;
+/// # use wireframe::app::{Envelope, WireframeApp};
 /// # async fn example() {
 /// let stream: TcpStream = unimplemented!();
 /// let factory = || WireframeApp::<_, _, Envelope>::new();

--- a/src/server.rs
+++ b/src/server.rs
@@ -130,7 +130,7 @@ where
     /// ```no_run
     /// # use wireframe::server::WireframeServer;
     /// # use wireframe::app::WireframeApp;
-    /// # let factory = || WireframeApp::new().expect("Failed to initialise app");
+    /// # let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// #[derive(bincode::Decode)]
     /// # struct MyPreamble;
     /// let server = WireframeServer::new(factory).with_preamble::<MyPreamble>();
@@ -169,7 +169,7 @@ where
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().expect("Failed to initialise app");
+    /// let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory).workers(4);
     /// assert_eq!(server.worker_count(), 4);
     /// let server = server.workers(0);
@@ -223,7 +223,7 @@ where
     /// ```no_run
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().expect("Failed to initialise app");
+    /// let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory);
     /// assert!(server.worker_count() >= 1);
     /// ```
@@ -261,7 +261,7 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let factory = || WireframeApp::new().expect("Failed to initialise app");
+    /// let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     /// let server = WireframeServer::new(factory);
     /// let addr: SocketAddr = "127.0.0.1:8080".parse().expect("Failed to parse address");
     /// let server = server.bind(addr).expect("Failed to bind address");
@@ -309,7 +309,7 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     /// async fn run_server() -> std::io::Result<()> {
-    ///     let factory = || WireframeApp::new().expect("Failed to initialise app");
+    ///     let factory = || WireframeApp::<_, _, Envelope>::new().expect("Failed to initialise app");
     ///     let addr = "127.0.0.1:8080"
     ///         .parse::<SocketAddr>()
     ///         .expect("Failed to parse address");
@@ -453,7 +453,7 @@ async fn worker_task<F, T>(
 /// # use wireframe::app::WireframeApp;
 /// # async fn example() {
 /// let stream: TcpStream = unimplemented!();
-/// let factory = || WireframeApp::new();
+/// let factory = || WireframeApp::<_, _, Envelope>::new();
 /// // process_stream::<_, ()>(stream, factory, None, None).await;
 /// # }
 /// ```

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -49,7 +49,7 @@ where
     let setup_cb = call_counting_callback(setup, state);
     let teardown_cb = call_counting_callback(teardown, ());
 
-    WireframeApp::<_, _, E>::new_with_envelope()
+    WireframeApp::<_, _, E>::new()
         .unwrap()
         .on_connection_setup(move || setup_cb(()))
         .unwrap()
@@ -74,7 +74,7 @@ async fn setup_without_teardown_runs() {
     let setup_count = Arc::new(AtomicUsize::new(0));
     let cb = call_counting_callback(&setup_count, ());
 
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .on_connection_setup(move || cb(()))
         .unwrap();
@@ -89,7 +89,7 @@ async fn teardown_without_setup_does_not_run() {
     let teardown_count = Arc::new(AtomicUsize::new(0));
     let cb = call_counting_callback(&teardown_count, ());
 
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .on_connection_teardown(cb)
         .unwrap();

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -18,7 +18,7 @@ fn mock_wireframe_app_with_serializer<S>(serializer: S) -> WireframeApp<S>
 where
     S: TestSerializer,
 {
-    WireframeApp::new()
+    WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())
         .serializer(serializer)

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -53,7 +53,7 @@ impl Transform<HandlerService<Envelope>> for TagMiddleware {
 #[tokio::test]
 async fn middleware_applied_in_reverse_order() {
     let handler: Handler<Envelope> = std::sync::Arc::new(|_env: &Envelope| Box::pin(async {}));
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .route(1, handler)
         .unwrap()

--- a/tests/preamble.rs
+++ b/tests/preamble.rs
@@ -11,7 +11,11 @@ use tokio::{
     sync::oneshot,
     time::{Duration, timeout},
 };
-use wireframe::{app::WireframeApp, preamble::read_preamble, server::WireframeServer};
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    preamble::read_preamble,
+    server::WireframeServer,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
 struct HotlinePreamble {
@@ -36,7 +40,7 @@ impl HotlinePreamble {
 
 #[fixture]
 fn factory() -> impl Fn() -> WireframeApp + Send + Sync + Clone + 'static {
-    || WireframeApp::new().expect("WireframeApp::new failed")
+    || WireframeApp::<_, _, Envelope>::new().expect("WireframeApp::new failed")
 }
 
 /// Create a server configured with `HotlinePreamble` handlers.

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -6,7 +6,7 @@
 use bytes::BytesMut;
 use rstest::rstest;
 use wireframe::{
-    app::WireframeApp,
+    app::{Envelope, WireframeApp},
     frame::{Endianness, FrameProcessor, LengthFormat, LengthPrefixedProcessor},
     message::Message,
     serializer::BincodeSerializer,
@@ -39,7 +39,7 @@ impl<'de> bincode::BorrowDecode<'de, ()> for FailingResp {
 /// Tests that sending a response serialises and frames the data correctly,
 /// and that the response can be decoded and deserialised back to its original value asynchronously.
 async fn send_response_encodes_and_frames() {
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())
         .serializer(BincodeSerializer);
@@ -123,7 +123,7 @@ fn custom_length_roundtrip(
 
 #[tokio::test]
 async fn send_response_propagates_write_error() {
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default());
 
@@ -182,7 +182,7 @@ fn encode_fails_for_length_too_large(#[case] fmt: LengthFormat, #[case] len: usi
 /// This test sends a `FailingResp` using `send_response` and asserts that the resulting
 /// error is of the `Serialize` variant, indicating a failure during response encoding.
 async fn send_response_returns_encode_error() {
-    let app = WireframeApp::new().unwrap();
+    let app = WireframeApp::<_, _, Envelope>::new().unwrap();
     let err = app
         .send_response(&mut Vec::new(), &FailingResp)
         .await

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -40,7 +40,7 @@ struct Echo(u8);
 async fn handler_receives_message_and_echoes_response() {
     let called = Arc::new(AtomicUsize::new(0));
     let called_clone = called.clone();
-    let app = WireframeApp::<_, _, TestEnvelope>::new_with_envelope()
+    let app = WireframeApp::<_, _, TestEnvelope>::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())
         .route(
@@ -79,7 +79,7 @@ async fn handler_receives_message_and_echoes_response() {
 
 #[tokio::test]
 async fn multiple_frames_processed_in_sequence() {
-    let app = WireframeApp::<_, _, TestEnvelope>::new_with_envelope()
+    let app = WireframeApp::<_, _, TestEnvelope>::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())
         .route(

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,31 +1,42 @@
 //! Tests for [`WireframeServer`] configuration.
 
-use wireframe::{app::WireframeApp, server::WireframeServer};
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    server::WireframeServer,
+};
 
 #[test]
 fn default_worker_count_matches_cpu_count() {
-    let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"));
+    let server = WireframeServer::new(|| {
+        WireframeApp::<_, _, Envelope>::new().expect("WireframeApp::new failed")
+    });
     let expected = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
     assert_eq!(server.worker_count(), expected);
 }
 
 #[test]
 fn default_workers_at_least_one() {
-    let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"));
+    let server = WireframeServer::new(|| {
+        WireframeApp::<_, _, Envelope>::new().expect("WireframeApp::new failed")
+    });
     assert!(server.worker_count() >= 1);
 }
 
 #[test]
 fn workers_method_enforces_minimum() {
-    let server =
-        WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed")).workers(0);
+    let server = WireframeServer::new(|| {
+        WireframeApp::<_, _, Envelope>::new().expect("WireframeApp::new failed")
+    })
+    .workers(0);
     assert_eq!(server.worker_count(), 1);
 }
 
 #[test]
 fn workers_accepts_large_values() {
-    let server = WireframeServer::new(|| WireframeApp::new().expect("WireframeApp::new failed"))
-        .workers(128);
+    let server = WireframeServer::new(|| {
+        WireframeApp::<_, _, Envelope>::new().expect("WireframeApp::new failed")
+    })
+    .workers(128);
     assert_eq!(server.worker_count(), 128);
 }
 
@@ -39,7 +50,7 @@ async fn readiness_receiver_dropped() {
         time::{Duration, sleep},
     };
 
-    let factory = || WireframeApp::new().expect("WireframeApp::new failed");
+    let factory = || WireframeApp::<_, _, Envelope>::new().expect("WireframeApp::new failed");
     let server = WireframeServer::new(factory)
         .workers(1)
         .bind("127.0.0.1:0".parse().unwrap())

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 use wireframe::{
     ConnectionContext,
     WireframeProtocol,
-    app::WireframeApp,
+    app::{Envelope, WireframeApp},
     connection::ConnectionActor,
     push::PushQueues,
 };
@@ -51,7 +51,9 @@ async fn builder_produces_protocol_hooks() {
     let protocol = TestProtocol {
         counter: counter.clone(),
     };
-    let app = WireframeApp::new().unwrap().with_protocol(protocol);
+    let app = WireframeApp::<_, _, Envelope>::new()
+        .unwrap()
+        .with_protocol(protocol);
     let mut hooks = app.protocol_hooks();
 
     let (queues, handle) = PushQueues::bounded(1, 1);
@@ -73,7 +75,9 @@ async fn connection_actor_uses_protocol_from_builder() {
     let protocol = TestProtocol {
         counter: counter.clone(),
     };
-    let app = WireframeApp::new().unwrap().with_protocol(protocol);
+    let app = WireframeApp::<_, _, Envelope>::new()
+        .unwrap()
+        .with_protocol(protocol);
 
     let hooks = app.protocol_hooks();
     let (queues, handle) = PushQueues::bounded(8, 8);

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -7,7 +7,10 @@ use std::net::SocketAddr;
 
 use cucumber::World;
 use tokio::{net::TcpStream, sync::oneshot};
-use wireframe::{app::WireframeApp, server::WireframeServer};
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    server::WireframeServer,
+};
 
 #[derive(Debug)]
 struct PanicServer {
@@ -19,7 +22,7 @@ struct PanicServer {
 impl PanicServer {
     async fn spawn() -> Self {
         let factory = || {
-            WireframeApp::new()
+            WireframeApp::<_, _, Envelope>::new()
                 .expect("Failed to create WireframeApp")
                 .on_connection_setup(|| async { panic!("boom") })
                 .expect("Failed to set connection setup callback")


### PR DESCRIPTION
## Summary
- merge `new` and `new_with_envelope` APIs
- update docs and examples for the generic constructor
- adjust tests and examples to specify `Envelope`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688bf56161c0832296bc2f9bfaeda967

## Summary by Sourcery

Consolidate the application builder API by collapsing the old `new` and `new_with_envelope` methods into a single generic constructor, updating documentation, examples, and tests to use the new signature.

Enhancements:
- Unify `WireframeApp` constructors by merging `new` and `new_with_envelope` into a single generic `new()` method
- Deprecate the `new_with_envelope` alias in favor of the unified `new()` constructor
- Introduce a private `builder_new` helper to simplify default construction
- Require explicit envelope type parameters when calling `WireframeApp::new()`

Documentation:
- Update README and doc comments to reflect the new generic `new()` API and remove references to `new_with_envelope`
- Adjust code examples across the repository to specify the envelope type parameter on `WireframeApp::new()`

Tests:
- Modify all tests to instantiate `WireframeApp` with explicit envelope type (`Envelope`) via the new constructor