### PR TITLE
Fix duplicate dependency entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ serial_test = "3.2.0"
 cucumber = "0.20.2"
 metrics-util = "0.20.0"
 tracing-test = "0.2.5"
-metrics-exporter-prometheus = "0.17.2"
 
 [features]
 default = ["metrics"]


### PR DESCRIPTION
## Summary
- remove `metrics-exporter-prometheus` from `dev-dependencies` to avoid duplication

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`

------
https://chatgpt.com/codex/tasks/task_e_688d44d2ab38832292442c9c3c78e50b