### PR TITLE
Replace allow attributes with expect

### DIFF
--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -60,7 +60,10 @@ impl FrameMetadata for HeaderSerializer {
 struct Ping;
 
 #[derive(bincode::Decode, bincode::Encode)]
-#[allow(dead_code)]
+#[expect(
+    dead_code,
+    reason = "placeholder for demonstration of metadata routing"
+)]
 struct Pong;
 
 #[tokio::main]

--- a/src/server.rs
+++ b/src/server.rs
@@ -558,7 +558,10 @@ mod tests {
 
     /// Test helper preamble carrying no data.
     #[derive(Debug, Clone, PartialEq, Encode, Decode)]
-    #[allow(dead_code)]
+    #[expect(
+        dead_code,
+        reason = "used only in doctest to illustrate an empty preamble"
+    )]
     struct EmptyPreamble;
 
     #[fixture]


### PR DESCRIPTION
## Summary
- remove allow(dead_code) from `EmptyPreamble` test helper
- remove allow(dead_code) from metadata routing example

## Testing
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make fmt`
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make lint`
- `RUSTUP_TOOLCHAIN=nightly-2025-07-22 make test`


------
https://chatgpt.com/codex/tasks/task_e_688d53c16fa48322a6078931d3eac25a