### PR TITLE
Unify app constructors with generic new

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ details.
 
 `WireframeApp` defaults to a simple `Envelope` containing a message ID and raw
 payload bytes. Applications can supply their own envelope type by calling
-`WireframeApp::<_, _, MyEnv>::new_with_envelope()`. The custom type must
-implement the `Packet` trait:
+`WireframeApp::<_, _, MyEnv>::new()`. The custom type must implement the
+`Packet` trait:
 
 ```rust
 use wireframe::app::{Packet, WireframeApp};
@@ -107,7 +107,7 @@ impl Packet for MyEnv {
     fn from_parts(id: u32, data: Vec<u8>) -> Self { Self { id, data } }
 }
 
-let app = WireframeApp::<_, _, MyEnv>::new_with_envelope()
+let app = WireframeApp::<_, _, MyEnv>::new()
     .unwrap()
     .route(1, std::sync::Arc::new(|env: &MyEnv| Box::pin(async move { /* ... */ })))
     .unwrap();

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,7 +5,10 @@
 
 use std::io;
 
-use wireframe::{app::WireframeApp, server::WireframeServer};
+use wireframe::{
+    app::{Envelope, WireframeApp},
+    server::WireframeServer,
+};
 
 #[tokio::main]
 async fn main() -> io::Result<()> {
@@ -14,7 +17,7 @@ async fn main() -> io::Result<()> {
             .unwrap()
             .route(
                 1,
-                std::sync::Arc::new(|_| {
+                std::sync::Arc::new(|_: &Envelope| {
                     Box::pin(async move {
                         println!("echo request received");
                         // `WireframeApp` automatically echoes the envelope back.

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -67,7 +67,7 @@ async fn main() -> io::Result<()> {
         .serializer(HeaderSerializer)
         .route(
             1,
-            Arc::new(|_env| {
+            Arc::new(|_env: &Envelope| {
                 Box::pin(async move {
                     println!("received ping message");
                 })
@@ -76,7 +76,7 @@ async fn main() -> io::Result<()> {
         .unwrap()
         .route(
             2,
-            Arc::new(|_env| {
+            Arc::new(|_env: &Envelope| {
                 Box::pin(async move {
                     println!("received pong message");
                 })

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -130,7 +130,7 @@ impl<E: Packet> Transform<HandlerService<E>> for Logging {
 fn build_app() -> AppResult<WireframeApp> {
     WireframeApp::new()?
         .serializer(BincodeSerializer)
-        .route(PING_ID, Arc::new(|_| Box::pin(ping_handler())))?
+        .route(PING_ID, Arc::new(|_: &Envelope| Box::pin(ping_handler())))?
         .wrap(PongMiddleware)?
         .wrap(Logging)
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -140,7 +140,9 @@ impl std::error::Error for SendError {
 }
 
 impl From<io::Error> for SendError {
-    fn from(e: io::Error) -> Self { SendError::Io(e) }
+    fn from(e: io::Error) -> Self {
+        SendError::Io(e)
+    }
 }
 
 /// Envelope-like type used to wrap incoming and outgoing messages.
@@ -198,19 +200,29 @@ pub struct Envelope {
 impl Envelope {
     /// Create a new [`Envelope`] with the provided id and payload.
     #[must_use]
-    pub fn new(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    pub fn new(id: u32, msg: Vec<u8>) -> Self {
+        Self { id, msg }
+    }
 
     /// Consume the envelope, returning its id and payload bytes.
     #[must_use]
-    pub fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    pub fn into_parts(self) -> (u32, Vec<u8>) {
+        (self.id, self.msg)
+    }
 }
 
 impl Packet for Envelope {
-    fn id(&self) -> u32 { self.id }
+    fn id(&self) -> u32 {
+        self.id
+    }
 
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    fn into_parts(self) -> (u32, Vec<u8>) {
+        (self.id, self.msg)
+    }
 
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    fn from_parts(id: u32, msg: Vec<u8>) -> Self {
+        Self { id, msg }
+    }
 }
 
 /// Number of idle polls before terminating a connection.
@@ -247,27 +259,51 @@ where
     }
 }
 
-impl WireframeApp<BincodeSerializer, (), Envelope> {
-    /// Construct a new empty application builder.
-    ///
-    /// # Errors
-    ///
-    /// This function currently never returns an error but uses the
-    /// [`Result`] type for forward compatibility.
-    pub fn new() -> Result<Self> { Ok(Self::default()) }
-}
-
 impl<E> WireframeApp<BincodeSerializer, (), E>
 where
     E: Packet,
 {
-    /// Construct a new application builder using a custom envelope type.
+    /// Construct a new empty application builder.
     ///
     /// # Errors
     ///
     /// This function currently never returns an error but uses [`Result`] for
     /// forward compatibility.
-    pub fn new_with_envelope() -> Result<Self> { Ok(Self::default()) }
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::app::{Packet, WireframeApp};
+    ///
+    /// #[derive(bincode::Encode, bincode::BorrowDecode)]
+    /// struct MyEnv { id: u32, data: Vec<u8> }
+    ///
+    /// impl Packet for MyEnv {
+    ///     fn id(&self) -> u32 { self.id }
+    ///     fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.data) }
+    ///     fn from_parts(id: u32, data: Vec<u8>) -> Self { Self { id, data } }
+    /// }
+    ///
+    /// let app = WireframeApp::<_, _, MyEnv>::new()
+    ///     .expect("failed to create app");
+    /// ```
+    pub fn new() -> Result<Self> {
+        Ok(Self::default())
+    }
+
+    /// Construct a new application builder using a custom envelope type.
+    ///
+    /// Deprecated: call [`WireframeApp::new`] with explicit envelope type
+    /// parameters.
+    ///
+    /// # Errors
+    ///
+    /// This function currently never returns an error but uses [`Result`] for
+    /// forward compatibility.
+    #[deprecated(note = "use `WireframeApp::<_, _, E>::new()` instead")]
+    pub fn new_with_envelope() -> Result<Self> {
+        Self::new()
+    }
 }
 
 impl<S, C, E> WireframeApp<S, C, E>

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -49,7 +49,7 @@ where
     let setup_cb = call_counting_callback(setup, state);
     let teardown_cb = call_counting_callback(teardown, ());
 
-    WireframeApp::<_, _, E>::new_with_envelope()
+    WireframeApp::<_, _, E>::new()
         .expect("failed to create app")
         .on_connection_setup(move || setup_cb(()))
         .expect("setup callback")
@@ -74,7 +74,7 @@ async fn setup_without_teardown_runs() {
     let setup_count = Arc::new(AtomicUsize::new(0));
     let cb = call_counting_callback(&setup_count, ());
 
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .expect("failed to create app")
         .on_connection_setup(move || cb(()))
         .expect("setup callback");
@@ -89,7 +89,7 @@ async fn teardown_without_setup_does_not_run() {
     let teardown_count = Arc::new(AtomicUsize::new(0));
     let cb = call_counting_callback(&teardown_count, ());
 
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .expect("failed to create app")
         .on_connection_teardown(cb)
         .expect("teardown callback");
@@ -106,11 +106,17 @@ struct StateEnvelope {
 }
 
 impl wireframe::app::Packet for StateEnvelope {
-    fn id(&self) -> u32 { self.id }
+    fn id(&self) -> u32 {
+        self.id
+    }
 
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    fn into_parts(self) -> (u32, Vec<u8>) {
+        (self.id, self.msg)
+    }
 
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    fn from_parts(id: u32, msg: Vec<u8>) -> Self {
+        Self { id, msg }
+    }
 }
 
 #[tokio::test]

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -6,7 +6,7 @@
 use bytes::BytesMut;
 use rstest::rstest;
 use wireframe::{
-    app::WireframeApp,
+    app::{Envelope, WireframeApp},
     frame::{Endianness, FrameProcessor, LengthFormat, LengthPrefixedProcessor},
     message::Message,
     serializer::BincodeSerializer,
@@ -39,7 +39,7 @@ impl<'de> bincode::BorrowDecode<'de, ()> for FailingResp {
 /// Tests that sending a response serialises and frames the data correctly,
 /// and that the response can be decoded and deserialised back to its original value asynchronously.
 async fn send_response_encodes_and_frames() {
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .expect("failed to create app")
         .frame_processor(LengthPrefixedProcessor::default())
         .serializer(BincodeSerializer);
@@ -131,7 +131,7 @@ fn custom_length_roundtrip(
 
 #[tokio::test]
 async fn send_response_propagates_write_error() {
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .expect("app creation failed")
         .frame_processor(LengthPrefixedProcessor::default());
 
@@ -190,7 +190,7 @@ fn encode_fails_for_length_too_large(#[case] fmt: LengthFormat, #[case] len: usi
 /// This test sends a `FailingResp` using `send_response` and asserts that the resulting
 /// error is of the `Serialize` variant, indicating a failure during response encoding.
 async fn send_response_returns_encode_error() {
-    let app = WireframeApp::new().expect("failed to create app");
+    let app = WireframeApp::<_, _, Envelope>::new().expect("failed to create app");
     let err = app
         .send_response(&mut Vec::new(), &FailingResp)
         .await

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -25,11 +25,17 @@ struct TestEnvelope {
 }
 
 impl wireframe::app::Packet for TestEnvelope {
-    fn id(&self) -> u32 { self.id }
+    fn id(&self) -> u32 {
+        self.id
+    }
 
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    fn into_parts(self) -> (u32, Vec<u8>) {
+        (self.id, self.msg)
+    }
 
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    fn from_parts(id: u32, msg: Vec<u8>) -> Self {
+        Self { id, msg }
+    }
 }
 
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
@@ -40,7 +46,7 @@ struct Echo(u8);
 async fn handler_receives_message_and_echoes_response() {
     let called = Arc::new(AtomicUsize::new(0));
     let called_clone = called.clone();
-    let app = WireframeApp::<_, _, TestEnvelope>::new_with_envelope()
+    let app = WireframeApp::<_, _, TestEnvelope>::new()
         .expect("failed to create app")
         .frame_processor(LengthPrefixedProcessor::default())
         .route(
@@ -79,7 +85,7 @@ async fn handler_receives_message_and_echoes_response() {
 
 #[tokio::test]
 async fn multiple_frames_processed_in_sequence() {
-    let app = WireframeApp::<_, _, TestEnvelope>::new_with_envelope()
+    let app = WireframeApp::<_, _, TestEnvelope>::new()
         .expect("failed to create app")
         .frame_processor(LengthPrefixedProcessor::default())
         .route(

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -14,11 +14,8 @@ use futures::stream;
 use rstest::rstest;
 use tokio_util::sync::CancellationToken;
 use wireframe::{
-    ConnectionContext,
-    WireframeProtocol,
-    app::WireframeApp,
-    connection::ConnectionActor,
-    push::PushQueues,
+    ConnectionContext, WireframeProtocol,
+    app::{Envelope, WireframeApp}, connection::ConnectionActor, push::PushQueues,
 };
 
 struct TestProtocol {
@@ -37,7 +34,9 @@ impl WireframeProtocol for TestProtocol {
         self.counter.fetch_add(1, Ordering::SeqCst);
     }
 
-    fn before_send(&self, frame: &mut Self::Frame, _ctx: &mut ConnectionContext) { frame.push(1); }
+    fn before_send(&self, frame: &mut Self::Frame, _ctx: &mut ConnectionContext) {
+        frame.push(1);
+    }
 
     fn on_command_end(&self, _ctx: &mut ConnectionContext) {
         self.counter.fetch_add(1, Ordering::SeqCst);
@@ -51,7 +50,7 @@ async fn builder_produces_protocol_hooks() {
     let protocol = TestProtocol {
         counter: counter.clone(),
     };
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .expect("failed to create app")
         .with_protocol(protocol);
     let mut hooks = app.protocol_hooks();
@@ -75,7 +74,7 @@ async fn connection_actor_uses_protocol_from_builder() {
     let protocol = TestProtocol {
         counter: counter.clone(),
     };
-    let app = WireframeApp::new()
+    let app = WireframeApp::<_, _, Envelope>::new()
         .expect("failed to create app")
         .with_protocol(protocol);
 


### PR DESCRIPTION
## Summary
- merge `WireframeApp::new` and `new_with_envelope` into one generic `new`
- deprecate `new_with_envelope` as a wrapper around `new`
- update docs, examples, and tests to use the generic constructor

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make nixie` *(fails: error: too many arguments. Expected 0 arguments but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_688fd388dc08832299c95dd15ab3a723