### PR TITLE
Remove unused_port fixture

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,8 @@
 //! Shared utilities for integration tests.
 //!
-//! Provides fixtures for a basic [`WireframeApp`] factory and an unused
-//! local port. These helpers reduce duplication across test modules.
+//! Provides fixtures for a basic [`WireframeApp`] factory and a helper to
+//! create a TCP listener bound to an unused local port. These helpers reduce
+//! duplication across test modules.
 
 use std::net::{Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
 
@@ -21,15 +22,4 @@ use wireframe::app::WireframeApp;
 )]
 pub fn factory() -> impl Fn() -> WireframeApp + Send + Sync + Clone + 'static {
     || WireframeApp::new().expect("WireframeApp::new failed")
-}
-
-#[fixture]
-#[allow(
-    unused_braces,
-    reason = "rustc false positive for single line rstest fixtures"
-)]
-pub fn unused_port() -> SocketAddr {
-    unused_listener()
-        .local_addr()
-        .expect("failed to obtain local addr")
 }

--- a/tests/preamble.rs
+++ b/tests/preamble.rs
@@ -66,7 +66,6 @@ where
     B: FnOnce(std::net::SocketAddr) -> Fut,
 {
     let listener = unused_listener();
-    let _addr = listener.local_addr().expect("addr");
     let server = server.bind_listener(listener).expect("bind");
     let addr = server.local_addr().expect("addr");
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -40,7 +40,6 @@ async fn readiness_receiver_dropped() {
     };
 
     let listener = unused_listener();
-    let _addr = listener.local_addr().unwrap();
     let server = WireframeServer::new(factory())
         .workers(1)
         .bind_listener(listener)


### PR DESCRIPTION
## Summary
- remove race-prone `unused_port` fixture and document listener helper
- bind tests to an `unused_listener` and drop unused address lookups

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688fd25cd0088322a9a7411407f6d136