### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,19 @@ updates:
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
     schedule:
       interval: "weekly"
 
   # Enable version updates for Cargo
   - package-ecosystem: "cargo"
     directory: "/"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "cargo"
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Summary
- configure Dependabot to check GitHub Actions weekly and Cargo dependencies daily

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ff3597ce083228d75a34aec47b424

## Summary by Sourcery

Build:
- Add .github/dependabot.yml to configure Dependabot for GitHub Actions weekly updates and Cargo daily updates