### PR TITLE
Add correlation IDs to frame headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,15 @@ implement the `Packet` trait:
 use wireframe::app::{Packet, WireframeApp};
 
 #[derive(bincode::Encode, bincode::BorrowDecode)]
-struct MyEnv { id: u32, data: Vec<u8> }
+struct MyEnv { id: u32, correlation_id: u32, data: Vec<u8> }
 
 impl Packet for MyEnv {
     fn id(&self) -> u32 { self.id }
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.data) }
-    fn from_parts(id: u32, data: Vec<u8>) -> Self { Self { id, data } }
+    fn correlation_id(&self) -> u32 { self.correlation_id }
+    fn into_parts(self) -> (u32, u32, Vec<u8>) { (self.id, self.correlation_id, self.data) }
+    fn from_parts(id: u32, correlation_id: u32, data: Vec<u8>) -> Self {
+        Self { id, correlation_id, data }
+    }
 }
 
 let app = WireframeApp::<_, _, MyEnv>::new_with_envelope()

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -290,9 +290,11 @@ fragmentation layer must be hardened.
 
 Each frame's header carries a `correlation_id` linking it to a request. Servers
 must verify that outbound frames echo the identifier from the triggering
-request. A mismatch is a protocol error and should terminate the stream. This
-check prevents malicious peers from injecting frames into unrelated
-conversations and simplifies debugging by providing a stable audit trail.
+request. A mismatch is a protocol error and must terminate the stream. The
+server ought to log the offending identifier and close the connection to
+prevent cross-stream confusion. This check prevents malicious peers from
+injecting frames into unrelated conversations and simplifies debugging by
+providing a stable audit trail.
 
 ## 5. Advanced Resilience Patterns
 

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -286,6 +286,14 @@ fragmentation layer must be hardened.
   assemblies, which are purged if they are not completed within the time limit
   (e.g., 30 seconds).
 
+### 4.3 Correlation ID Validation
+
+Each frame's header carries a `correlation_id` linking it to a request. Servers
+must verify that outbound frames echo the identifier from the triggering
+request. A mismatch is a protocol error and should terminate the stream. This
+check prevents malicious peers from injecting frames into unrelated
+conversations and simplifies debugging by providing a stable audit trail.
+
 ## 5. Advanced Resilience Patterns
 
 For applications requiring the highest levels of reliability, `wireframe` will

--- a/docs/message-versioning.md
+++ b/docs/message-versioning.md
@@ -45,6 +45,7 @@ Extend `Envelope` with an optional `version` field:
 ```rust
 pub struct Envelope {
     id: u32,
+    correlation_id: u32,
     version: Option<u16>,
     msg: Vec<u8>,
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -177,9 +177,9 @@ This is the next major feature set. It enables a handler to return multiple,
 distinct messages over time in response to a single request, forming a logical
 stream.
 
-- [ ] **Protocol Enhancement:**
+- [x] **Protocol Enhancement:**
 
-  - [ ] Add a `correlation_id` field to the `Frame` header. For a request, this
+  - [x] Add a `correlation_id` field to the `Frame` header. For a request, this
     is the unique request ID. For each message in a multi-packet response, this
     ID must match the original request's ID.
 
@@ -194,7 +194,7 @@ stream.
   - [ ] Modify the `Connection` actor: upon receiving `Response::MultiPacket`,
     it should consume messages from the receiver and send each one as a `Frame`.
 
-  - [ ] Each sent frame must carry the correct `correlation_id` from the
+  - [x] Each sent frame must carry the correct `correlation_id` from the
     initial request.
 
   - [ ] When the channel closes, send the end-of-stream marker frame.

--- a/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
+++ b/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
@@ -111,6 +111,14 @@ The polling order will be:
 4. **Handler Response Stream:** For frames belonging to the current
    request-response cycle.
 
+#### Correlation Identifiers
+
+Every frame header now carries a `correlation_id` that ties it to the
+originating request. Clients set a unique identifier on each request and the
+server mirrors this value on every frame in the response stream. This mechanism
+allows out-of-order or multi-part replies to be reassembled reliably without
+relying on transport sequencing.
+
 ### B. Transparent Message Fragmentation & Re-assembly
 
 Many real-world protocols split large logical messages into smaller physical

--- a/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
+++ b/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
@@ -117,7 +117,9 @@ Every frame header now carries a `correlation_id` that ties it to the
 originating request. Clients set a unique identifier on each request and the
 server mirrors this value on every frame in the response stream. This mechanism
 allows out-of-order or multi-part replies to be reassembled reliably without
-relying on transport sequencing.
+relying on transport sequencing. Implementations must reject any frame whose
+identifier diverges from the original request, logging the mismatch and closing
+the connection.
 
 ### B. Transparent Message Fragmentation & Re-assembly
 

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -52,6 +52,8 @@ impl FrameMetadata for HeaderSerializer {
         // `parse` receives the complete frame because `LengthPrefixedProcessor`
         // ensures `src` contains exactly one message. Returning `src.len()` is
         // therefore correct for this demo.
+        // Using 0 as the correlation_id here because there is no correlation
+        // tracking in this example. Update if correlation semantics change.
         Ok((Envelope::new(id, 0, payload), src.len()))
     }
 }

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -52,7 +52,7 @@ impl FrameMetadata for HeaderSerializer {
         // `parse` receives the complete frame because `LengthPrefixedProcessor`
         // ensures `src` contains exactly one message. Returning `src.len()` is
         // therefore correct for this demo.
-        Ok((Envelope::new(id, payload), src.len()))
+        Ok((Envelope::new(id, 0, payload), src.len()))
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -40,6 +40,30 @@ impl<F> FrameContainer<F> {
     }
 }
 
+macro_rules! forward_frame_methods {
+    ($t:ident) => {
+        impl $t {
+            /// Borrow the inner frame bytes.
+            #[must_use]
+            pub fn frame(&self) -> &[u8] {
+                self.inner.frame().as_slice()
+            }
+
+            /// Mutable access to the inner frame bytes.
+            #[must_use]
+            pub fn frame_mut(&mut self) -> &mut Vec<u8> {
+                self.inner.frame_mut()
+            }
+
+            /// Consume the container, returning the raw frame bytes.
+            #[must_use]
+            pub fn into_inner(self) -> Vec<u8> {
+                self.inner.into_inner()
+            }
+        }
+    };
+}
+
 /// Incoming request wrapper passed through middleware.
 #[derive(Debug)]
 pub struct ServiceRequest {
@@ -55,24 +79,6 @@ impl ServiceRequest {
             inner: FrameContainer::new(frame),
             correlation_id,
         }
-    }
-
-    /// Borrow the underlying frame bytes.
-    #[must_use]
-    pub fn frame(&self) -> &[u8] {
-        self.inner.frame().as_slice()
-    }
-
-    /// Mutable access to the inner frame bytes.
-    #[must_use]
-    pub fn frame_mut(&mut self) -> &mut Vec<u8> {
-        self.inner.frame_mut()
-    }
-
-    /// Consume the request, returning the inner frame bytes.
-    #[must_use]
-    pub fn into_inner(self) -> Vec<u8> {
-        self.inner.into_inner()
     }
 
     /// Return the correlation identifier associated with this request.
@@ -96,25 +102,10 @@ impl ServiceResponse {
             inner: FrameContainer::new(frame),
         }
     }
-
-    /// Borrow the inner frame bytes.
-    #[must_use]
-    pub fn frame(&self) -> &[u8] {
-        self.inner.frame().as_slice()
-    }
-
-    /// Mutable access to the response frame bytes.
-    #[must_use]
-    pub fn frame_mut(&mut self) -> &mut Vec<u8> {
-        self.inner.frame_mut()
-    }
-
-    /// Consume the response, yielding the raw frame bytes.
-    #[must_use]
-    pub fn into_inner(self) -> Vec<u8> {
-        self.inner.into_inner()
-    }
 }
+
+forward_frame_methods!(ServiceRequest);
+forward_frame_methods!(ServiceResponse);
 
 /// Continuation used by middleware to call the next service in the chain.
 pub struct Next<'a, S>

--- a/tests/correlation_cucumber.rs
+++ b/tests/correlation_cucumber.rs
@@ -1,0 +1,13 @@
+//! Cucumber test runner for correlation id behaviour.
+
+mod correlation_world;
+#[path = "steps/correlation_steps.rs"]
+mod steps;
+
+use correlation_world::CorrelationWorld;
+use cucumber::World;
+
+#[tokio::main]
+async fn main() {
+    CorrelationWorld::run("tests/features/correlation").await;
+}

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -1,0 +1,35 @@
+//! Tests for correlation id propagation.
+
+use bytes::BytesMut;
+use rstest::rstest;
+use wireframe::{
+    app::{Envelope, Packet, WireframeApp},
+    frame::{FrameProcessor, LengthPrefixedProcessor},
+    serializer::{BincodeSerializer, Serializer},
+};
+use wireframe_testing::drive_with_bincode;
+
+#[rstest]
+#[tokio::test]
+async fn response_echoes_correlation_id() {
+    let app = WireframeApp::new()
+        .expect("failed to create app")
+        .frame_processor(LengthPrefixedProcessor::default())
+        .route(1, std::sync::Arc::new(|_: &Envelope| Box::pin(async {})))
+        .expect("route registration failed");
+
+    let env = Envelope::new(1, 7, vec![1]);
+    let out = drive_with_bincode(app, env)
+        .await
+        .expect("drive_with_bincode failed");
+
+    let mut buf = BytesMut::from(&out[..]);
+    let frame = LengthPrefixedProcessor::default()
+        .decode(&mut buf)
+        .expect("decode failed")
+        .expect("frame missing");
+    let (resp, _) = BincodeSerializer
+        .deserialize::<Envelope>(&frame)
+        .expect("deserialize failed");
+    assert_eq!(resp.correlation_id(), 7);
+}

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -9,6 +9,9 @@ use wireframe::{
 };
 use wireframe_testing::drive_with_bincode;
 
+mod correlation_world;
+use correlation_world::CorrelationWorld;
+
 #[rstest]
 #[tokio::test]
 async fn response_echoes_correlation_id() {
@@ -32,4 +35,18 @@ async fn response_echoes_correlation_id() {
         .deserialize::<Envelope>(&frame)
         .expect("deserialize failed");
     assert_eq!(resp.correlation_id(), 7);
+}
+
+#[tokio::test]
+#[should_panic(expected = "assertion failed")]
+async fn mismatched_correlation_id_panics() {
+    let mut world = CorrelationWorld::default();
+    world.set_id(7);
+    world
+        .run_actor_with_frames(
+            vec![Envelope::new(1, 7, vec![1]), Envelope::new(1, 9, vec![2])],
+            1,
+        )
+        .await;
+    world.assert_ids();
 }

--- a/tests/correlation_world.rs
+++ b/tests/correlation_world.rs
@@ -1,0 +1,62 @@
+//! World state for correlation id behavioural tests.
+
+use cucumber::World;
+use futures::{stream, StreamExt};
+use tokio_util::sync::CancellationToken;
+use wireframe::{
+    app::{Envelope, Packet},
+    connection::ConnectionActor,
+    push::PushQueues,
+    response::WireframeError,
+};
+
+#[derive(Default, World)]
+pub struct CorrelationWorld {
+    pub(crate) correlation_id: u32,
+    frames: Vec<Envelope>,
+}
+
+impl std::fmt::Debug for CorrelationWorld {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CorrelationWorld")
+            .field("correlation_id", &self.correlation_id)
+            .field("frames_len", &self.frames.len())
+            .finish()
+    }
+}
+
+impl CorrelationWorld {
+    pub fn set_id(&mut self, id: u32) {
+        self.correlation_id = id;
+    }
+
+    /// Run the connection actor and capture emitted frames.
+    ///
+    /// # Panics
+    /// Panics if the actor fails to run.
+    pub async fn run_actor(&mut self) {
+        let (queues, handle) = PushQueues::bounded(1, 1);
+        let stream_frames = stream::iter(vec![
+            Ok::<Envelope, ()>(Envelope::new(1, self.correlation_id, vec![1])),
+            Ok::<Envelope, ()>(Envelope::new(1, self.correlation_id, vec![2])),
+        ])
+        .map(|r: Result<Envelope, ()>| r.map_err(WireframeError::from));
+        let shutdown = CancellationToken::new();
+        let mut actor: ConnectionActor<Envelope, ()> =
+            ConnectionActor::new(queues, handle, Some(Box::pin(stream_frames)), shutdown);
+        let mut out = Vec::new();
+        actor.run(&mut out).await.expect("actor run failed");
+        self.frames = out;
+    }
+
+    /// Assert that all captured frames carry the expected correlation id.
+    ///
+    /// # Panics
+    /// Panics if any frame has a mismatched identifier.
+    pub fn assert_ids(&self) {
+        assert!(self
+            .frames
+            .iter()
+            .all(|f| f.correlation_id() == self.correlation_id));
+    }
+}

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -10,4 +10,6 @@ use cucumber::World;
 use world::PanicWorld;
 
 #[tokio::main]
-async fn main() { PanicWorld::run("tests/features").await; }
+async fn main() {
+    PanicWorld::run("tests/features/connection_panic.feature").await;
+}

--- a/tests/features/correlation/multi_packet.feature
+++ b/tests/features/correlation/multi_packet.feature
@@ -1,0 +1,5 @@
+Feature: Multi-packet correlation ids
+  Scenario: Response frames carry request correlation id
+    Given a multi-packet response stream with correlation id 7
+    When the connection actor runs to completion
+    Then each emitted frame has correlation id 7

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -102,15 +102,29 @@ async fn teardown_without_setup_does_not_run() {
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
 struct StateEnvelope {
     id: u32,
+    correlation_id: u32,
     msg: Vec<u8>,
 }
 
 impl wireframe::app::Packet for StateEnvelope {
-    fn id(&self) -> u32 { self.id }
+    fn id(&self) -> u32 {
+        self.id
+    }
+    fn correlation_id(&self) -> u32 {
+        self.correlation_id
+    }
 
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    fn into_parts(self) -> (u32, u32, Vec<u8>) {
+        (self.id, self.correlation_id, self.msg)
+    }
 
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    fn from_parts(id: u32, correlation_id: u32, msg: Vec<u8>) -> Self {
+        Self {
+            id,
+            correlation_id,
+            msg,
+        }
+    }
 }
 
 #[tokio::test]
@@ -125,6 +139,7 @@ async fn helpers_propagate_connection_state() {
 
     let env = StateEnvelope {
         id: 1,
+        correlation_id: 0,
         msg: vec![1],
     };
     let bytes = BincodeSerializer

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -60,7 +60,7 @@ async fn metadata_parser_invoked_before_deserialize() {
     let serializer = CountingSerializer(counter.clone());
     let app = mock_wireframe_app_with_serializer(serializer);
 
-    let env = Envelope::new(1, vec![42]);
+    let env = Envelope::new(1, 0, vec![42]);
 
     let out = drive_with_bincode(app, env)
         .await
@@ -105,7 +105,7 @@ async fn falls_back_to_deserialize_after_parse_error() {
     let serializer = FallbackSerializer(parse_calls.clone(), deser_calls.clone());
     let app = mock_wireframe_app_with_serializer(serializer);
 
-    let env = Envelope::new(1, vec![7]);
+    let env = Envelope::new(1, 0, vec![7]);
 
     let out = drive_with_bincode(app, env)
         .await

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -29,7 +29,9 @@ where
 {
     type Output = ModifyService<S>;
 
-    async fn transform(&self, service: S) -> Self::Output { ModifyService { inner: service } }
+    async fn transform(&self, service: S) -> Self::Output {
+        ModifyService { inner: service }
+    }
 }
 
 #[async_trait]
@@ -54,7 +56,7 @@ async fn middleware_modifies_request_and_response() {
     let mw = ModifyMiddleware;
     let wrapped = mw.transform(service).await;
 
-    let request = ServiceRequest::new(vec![1, 2, 3]);
+    let request = ServiceRequest::new(vec![1, 2, 3], 0);
     let response = wrapped.call(request).await.expect("middleware call failed");
     assert_eq!(response.frame(), &[1, 2, 3, b'!', b'?']);
 }

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -64,7 +64,8 @@ async fn middleware_applied_in_reverse_order() {
 
     let (mut client, server) = duplex(256);
 
-    let env = Envelope::new(1, 0, vec![b'X']);
+    // Mirror the request ID to avoid masking correlation bugs.
+    let env = Envelope::new(1, 1, vec![b'X']);
     let serializer = BincodeSerializer;
     let bytes = serializer.serialize(&env).expect("serialization failed");
     // Use the default 4-byte big-endian length prefix for framing
@@ -88,6 +89,6 @@ async fn middleware_applied_in_reverse_order() {
     let (resp, _) = serializer
         .deserialize::<Envelope>(&frame)
         .expect("deserialize failed");
-    let (_, _, bytes) = resp.into_parts();
+    let (_, _corr_id, bytes) = resp.into_parts();
     assert_eq!(bytes, vec![b'X', b'A', b'B', b'B', b'A']);
 }

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -64,7 +64,7 @@ async fn middleware_applied_in_reverse_order() {
 
     let (mut client, server) = duplex(256);
 
-    let env = Envelope::new(1, vec![b'X']);
+    let env = Envelope::new(1, 0, vec![b'X']);
     let serializer = BincodeSerializer;
     let bytes = serializer.serialize(&env).expect("serialization failed");
     // Use the default 4-byte big-endian length prefix for framing
@@ -88,6 +88,6 @@ async fn middleware_applied_in_reverse_order() {
     let (resp, _) = serializer
         .deserialize::<Envelope>(&frame)
         .expect("deserialize failed");
-    let (_, bytes) = resp.into_parts();
+    let (_, _, bytes) = resp.into_parts();
     assert_eq!(bytes, vec![b'X', b'A', b'B', b'B', b'A']);
 }

--- a/tests/steps/correlation_steps.rs
+++ b/tests/steps/correlation_steps.rs
@@ -1,0 +1,21 @@
+//! Steps for correlation id behavioural tests.
+
+use cucumber::{given, then, when};
+
+use crate::correlation_world::CorrelationWorld;
+
+#[given(regex = "a multi-packet response stream with correlation id (\\d+)")]
+fn set_id(world: &mut CorrelationWorld, id: u32) {
+    world.set_id(id);
+}
+
+#[when("the connection actor runs to completion")]
+async fn run(world: &mut CorrelationWorld) {
+    world.run_actor().await;
+}
+
+#[then(regex = "each emitted frame has correlation id (\\d+)")]
+fn verify(world: &mut CorrelationWorld, id: u32) {
+    assert_eq!(world.correlation_id, id);
+    world.assert_ids();
+}


### PR DESCRIPTION
## Summary
- include correlation IDs in packet headers so multi-packet responses can be matched to requests
- validate correlation IDs via unit and behavioural tests
- record correlation ID design and resilience guidance in docs and roadmap

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Cannot find module '../../third_party/mitt/mitt.js')*


------
https://chatgpt.com/codex/tasks/task_e_688ff43688fc8322aaa82f424c41a9bd

## Summary by Sourcery

Introduce a correlation_id header field across the wireframe protocol and propagate it through Packet, Envelope, service routing, and connection actor to enable matching multi-packet responses to their requests, accompanied by tests and documentation updates.

New Features:
- Add correlation_id field to Packet trait signatures and Envelope type, updating into_parts and from_parts to include correlation support
- Propagate correlation IDs through ServiceRequest, ServiceResponse, handler routing, WireframeApp, and ConnectionActor for multi-packet response association
- Add unit, integration, and cucumber behavioural tests to validate correct correlation ID propagation and error handling

Enhancements:
- Update existing examples, middleware, routing, and metadata tests to pass and echo correlation_id parameters

Documentation:
- Document correlation ID design, validation guidance, and feature status in README, resilience guide, roadmap, and related documentation