### PR TITLE
Pre-allocate handles vector in docs example

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -432,13 +432,14 @@ impl<F> SessionRegistry<F> {
 
     /// Returns all live session handles for broadcast or diagnostics.
     pub fn active_handles(&self) -> Vec<(ConnectionId, PushHandle<F>)> {
-        self.0
-            .iter()
-            .filter_map(|entry| {
-                let id = *entry.key();
-                entry.value().upgrade().map(|h| (id, PushHandle(h)))
-            })
-            .collect()
+        let mut handles = Vec::with_capacity(self.0.len());
+        for entry in self.0.iter() {
+            let id = *entry.key();
+            if let Some(h) = entry.value().upgrade() {
+                handles.push((id, PushHandle(h)));
+            }
+        }
+        handles
     }
 }
 ```


### PR DESCRIPTION
## Summary
- pre-allocate the `active_handles` buffer in the outbound messaging design docs

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: failed copying files from cache to destination for package mermaid)*

------
https://chatgpt.com/codex/tasks/task_e_689003ae05948322ae76257904f68aa3