### PR TITLE
Inject clock into fairness tracker

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -390,7 +390,7 @@ where
     }
 
     /// Reset counters after processing a low-priority frame.
-    fn after_low(&mut self) { self.fairness.record_low_priority(); }
+    fn after_low(&mut self) { self.fairness.reset(); }
 
     /// Push a frame from the response stream into `out` or handle completion.
     ///

--- a/src/fairness.rs
+++ b/src/fairness.rs
@@ -2,23 +2,44 @@
 //!
 //! This module encapsulates the logic for deciding when high-priority
 //! processing should yield to low-priority traffic based on configured
-//! thresholds and optional time slices.
+//! thresholds and optional time slices.  A pluggable [`Clock`] allows the
+//! timing logic to be tested without depending on Tokio's global time.
 
 use tokio::time::Instant;
 
 use crate::connection::FairnessConfig;
 
+/// Time source used by [`FairnessTracker`].
+pub(crate) trait Clock: Copy {
+    /// Return the current instant.
+    fn now(&self) -> Instant;
+}
+
+/// Clock implementation backed by [`tokio::time`].
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct TokioClock;
+
+impl Clock for TokioClock {
+    fn now(&self) -> Instant { Instant::now() }
+}
+
 #[derive(Debug)]
-pub(crate) struct Fairness {
+pub(crate) struct FairnessTracker<C: Clock = TokioClock> {
     config: FairnessConfig,
+    clock: C,
     high_counter: usize,
     high_start: Option<Instant>,
 }
 
-impl Fairness {
-    pub(crate) fn new(config: FairnessConfig) -> Self {
+impl FairnessTracker {
+    pub(crate) fn new(config: FairnessConfig) -> Self { Self::with_clock(config, TokioClock) }
+}
+
+impl<C: Clock> FairnessTracker<C> {
+    pub(crate) fn with_clock(config: FairnessConfig, clock: C) -> Self {
         Self {
             config,
+            clock,
             high_counter: 0,
             high_start: None,
         }
@@ -29,27 +50,32 @@ impl Fairness {
         self.reset();
     }
 
-    pub(crate) fn after_high(&mut self) {
+    pub(crate) fn record_high_priority(&mut self) {
         self.high_counter += 1;
         if self.high_counter == 1 {
-            self.high_start = Some(Instant::now());
+            self.high_start = Some(self.clock.now());
         }
     }
 
-    pub(crate) fn should_yield(&self) -> bool {
-        let threshold_hit = self.config.max_high_before_low > 0
-            && self.high_counter >= self.config.max_high_before_low;
-        let time_hit = self
-            .config
-            .time_slice
-            .zip(self.high_start)
-            .is_some_and(|(slice, start)| start.elapsed() >= slice);
-        threshold_hit || time_hit
+    pub(crate) fn should_yield_to_low_priority(&self) -> bool {
+        if self.config.max_high_before_low > 0
+            && self.high_counter >= self.config.max_high_before_low
+        {
+            return true;
+        }
+
+        if let (Some(slice), Some(start)) = (self.config.time_slice, self.high_start) {
+            return self.clock.now().duration_since(start) >= slice;
+        }
+
+        false
     }
 
-    pub(crate) fn after_low(&mut self) { self.reset(); }
+    pub(crate) fn record_low_priority(&mut self) { self.clear(); }
 
-    pub(crate) fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) { self.clear(); }
+
+    fn clear(&mut self) {
         self.high_counter = 0;
         self.high_start = None;
     }
@@ -69,11 +95,11 @@ mod tests {
             max_high_before_low: 2,
             time_slice: None,
         };
-        let mut fairness = Fairness::new(cfg);
-        fairness.after_high();
-        assert!(!fairness.should_yield());
-        fairness.after_high();
-        assert!(fairness.should_yield());
+        let mut fairness = FairnessTracker::new(cfg);
+        fairness.record_high_priority();
+        assert!(!fairness.should_yield_to_low_priority());
+        fairness.record_high_priority();
+        assert!(fairness.should_yield_to_low_priority());
     }
 
     #[rstest]
@@ -83,11 +109,11 @@ mod tests {
             max_high_before_low: 1,
             time_slice: None,
         };
-        let mut fairness = Fairness::new(cfg);
-        fairness.after_high();
-        assert!(fairness.should_yield());
-        fairness.after_low();
-        assert!(!fairness.should_yield());
+        let mut fairness = FairnessTracker::new(cfg);
+        fairness.record_high_priority();
+        assert!(fairness.should_yield_to_low_priority());
+        fairness.record_low_priority();
+        assert!(!fairness.should_yield_to_low_priority());
     }
 
     #[rstest]
@@ -98,9 +124,9 @@ mod tests {
             max_high_before_low: 0,
             time_slice: Some(Duration::from_millis(5)),
         };
-        let mut fairness = Fairness::new(cfg);
-        fairness.after_high();
+        let mut fairness = FairnessTracker::new(cfg);
+        fairness.record_high_priority();
         time::advance(Duration::from_millis(6)).await;
-        assert!(fairness.should_yield());
+        assert!(fairness.should_yield_to_low_priority());
     }
 }


### PR DESCRIPTION
## Summary
- add pluggable `Clock` and `TokioClock` so fairness logic can depend on an injected time source
- rename fairness APIs for clearer intent and consolidate reset logic
- update connection actor to use the new fairness tracker methods

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6891a58bc0008322bacfcab73beb9e64

## Summary by Sourcery

Inject a pluggable Clock abstraction into the fairness tracker for testable time dependence, rename and consolidate fairness APIs for clearer intent, and update the connection actor and tests to use the new FairnessTracker interface.

New Features:
- Introduce a Clock trait and default TokioClock implementation for injecting time sources into FairnessTracker.

Enhancements:
- Rename Fairness to FairnessTracker and update constructors to support clock injection.
- Rename methods for clarity (record_high_priority, should_yield_to_low_priority, record_low_priority) and centralize reset logic.
- Simplify timing checks to use the injected clock and refactor internal clear logic.

Tests:
- Update existing fairness tests to use FairnessTracker, new method names, and the clock abstraction.

Chores:
- Update ConnectionActor to use the new FairnessTracker API and renamed methods.