### PR TITLE
Restore server typestate and split configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,7 +2829,7 @@ dependencies = [
  "rstest",
  "serde",
  "serial_test",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,7 @@ dependencies = [
  "rstest",
  "serde",
  "serial_test",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1.41", features = ["log", "log-always"] }
 tracing-subscriber = "0.3"
 metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true, features = ["http-listener"] }
-thiserror = "1.0.69"
+thiserror = "2.0.12"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { version = "0.1.41", features = ["log", "log-always"] }
 tracing-subscriber = "0.3"
 metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true, features = ["http-listener"] }
+thiserror = "1.0.69"
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -38,13 +38,13 @@ design and possible refinements. See
 
 The implementation must satisfy the following core requirements:
 
-| ID | Requirement |
+| ID | Requirement                                                                                                                                            |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| G1 | Any async task must be able to push frames to a live connection. |
-| G2 | Ordering-safety: Pushed frames must interleave correctly with normal request/response traffic and respect any per-message sequencing rules. |
-| G3 | Back-pressure: Writers must block (or fail fast) when the peer cannot drain the socket, preventing unbounded memory consumption. |
-| G4 | Generic—independent of any particular protocol; usable by both servers and clients built on wireframe. |
-| G5 | Preserve the simple “return a reply” path for code that does not need pushes, ensuring backward compatibility and low friction for existing users. |
+| G1 | Any async task must be able to push frames to a live connection.                                                                                       |
+| G2 | Ordering-safety: Pushed frames must interleave correctly with normal request/response traffic and respect any per-message sequencing rules.            |
+| G3 | Back-pressure: Writers must block (or fail fast) when the peer cannot drain the socket, preventing unbounded memory consumption.                       |
+| G4 | Generic—independent of any particular protocol; usable by both servers and clients built on wireframe.                                                 |
+| G5 | Preserve the simple “return a reply” path for code that does not need pushes, ensuring backward compatibility and low friction for existing users.     |
 
 ## 3. Core Architecture: The Connection Actor
 
@@ -69,7 +69,7 @@ manage two distinct, bounded `tokio::mpsc` channels for pushed frames:
    messages like heartbeats, session control notifications, or protocol-level
    pings.
 
-1. `low_priority_push_rx: mpsc::Receiver<F>`: For standard, non-urgent
+2. `low_priority_push_rx: mpsc::Receiver<F>`: For standard, non-urgent
    background messages like log forwarding or secondary status updates.
 
 The bounded nature of these channels provides an inherent and robust
@@ -89,13 +89,13 @@ The polling order will be:
 1. **Graceful Shutdown Signal:** The `CancellationToken` will be checked first
    to ensure immediate reaction to a server-wide shutdown request.
 
-1. **High-Priority Push Channel:** Messages from `high_priority_push_rx` will be
+2. **High-Priority Push Channel:** Messages from `high_priority_push_rx` will be
    drained next.
 
-1. **Low-Priority Push Channel:** Messages from `low_priority_push_rx` will be
+3. **Low-Priority Push Channel:** Messages from `low_priority_push_rx` will be
    processed after all high-priority messages.
 
-1. **Handler Response Stream:** Frames from the active request's
+4. **Handler Response Stream:** Frames from the active request's
    `Response::Stream` will be processed last.
 
 ```rust
@@ -784,11 +784,11 @@ sequenceDiagram
 
 ## 8. Measurable Objectives & Success Criteria
 
-| Category | Objective | Success Metric |
+| Category        | Objective                                                                                                           | Success Metric                                                                                                                                                                              |
 | --------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| API Correctness | The PushHandle, SessionRegistry, and WireframeProtocol trait are implemented exactly as specified in this document. | 100% of the public API surface is present and correctly typed. |
-| Functionality | Pushed frames are delivered reliably and in the correct order of priority. | A test with concurrent high-priority, low-priority, and streaming producers must show that all frames are delivered and that the final written sequence respects the strict priority order. |
-| Back-pressure | A slow consumer must cause producer tasks to suspend without consuming unbounded memory. | A test with a slow consumer and a fast producer must show the producer's push().await call blocks, and the process memory usage remains stable. |
-| Resilience | The SessionRegistry must not leak memory when connections are terminated. | A long-running test that creates and destroys thousands of connections must show no corresponding growth in the SessionRegistry's size or the process's overall memory footprint. |
-| Performance | The overhead of the push mechanism should be minimal for connections that do not use it. | A benchmark of a simple request-response workload with the push feature enabled (but unused) should show < 2% performance degradation compared to a build without the feature. |
-| Performance | The latency for a high-priority push under no contention should be negligible. | The time from push_high_priority().await returning to the frame being written to the socket buffer should be < 10µs. |
+| API Correctness | The PushHandle, SessionRegistry, and WireframeProtocol trait are implemented exactly as specified in this document. | 100% of the public API surface is present and correctly typed.                                                                                                                              |
+| Functionality   | Pushed frames are delivered reliably and in the correct order of priority.                                          | A test with concurrent high-priority, low-priority, and streaming producers must show that all frames are delivered and that the final written sequence respects the strict priority order. |
+| Back-pressure   | A slow consumer must cause producer tasks to suspend without consuming unbounded memory.                            | A test with a slow consumer and a fast producer must show the producer's push().await call blocks, and the process memory usage remains stable.                                             |
+| Resilience      | The SessionRegistry must not leak memory when connections are terminated.                                           | A long-running test that creates and destroys thousands of connections must show no corresponding growth in the SessionRegistry's size or the process's overall memory footprint.           |
+| Performance     | The overhead of the push mechanism should be minimal for connections that do not use it.                            | A benchmark of a simple request-response workload with the push feature enabled (but unused) should show < 2% performance degradation compared to a build without the feature.              |
+| Performance     | The latency for a high-priority push under no contention should be negligible.                                      | The time from push_high_priority().await returning to the frame being written to the socket buffer should be < 10µs.                                                                        |

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -12,7 +12,7 @@ use wireframe::{
 async fn main() -> Result<(), ServerError> {
     let factory = || {
         WireframeApp::new()
-            .expect("failed to create app")
+            .expect("failed to create WireframeApp")
             .route(
                 1,
                 std::sync::Arc::new(|_: &Envelope| {

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<(), ServerError> {
                     })
                 }),
             )
-            .expect("failed to register route")
+            .expect("failed to register route 1")
     };
 
     WireframeServer::new(factory)

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), ServerError> {
     };
 
     WireframeServer::new(factory)
-        .bind("127.0.0.1:7878".parse().expect("invalid bind address"))?
+        .bind("127.0.0.1:7878".parse().expect("invalid socket address"))?
         .run()
         .await?;
     Ok(())

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -3,15 +3,13 @@
 //! The application listens for incoming frames and simply echoes each
 //! envelope back to the client.
 
-use std::io;
-
 use wireframe::{
     app::{Envelope, WireframeApp},
     server::WireframeServer,
 };
 
 #[tokio::main]
-async fn main() -> io::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let factory = || {
         WireframeApp::new()
             .unwrap()
@@ -30,5 +28,6 @@ async fn main() -> io::Result<()> {
     WireframeServer::new(factory)
         .bind("127.0.0.1:7878".parse().unwrap())?
         .run()
-        .await
+        .await?;
+    Ok(())
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,7 +5,7 @@
 
 use wireframe::{
     app::{Envelope, WireframeApp},
-    server::{WireframeServer, error::ServerError},
+    server::{ServerError, WireframeServer},
 };
 
 #[tokio::main]

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,11 +5,11 @@
 
 use wireframe::{
     app::{Envelope, WireframeApp},
-    server::WireframeServer,
+    server::{WireframeServer, error::ServerError},
 };
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), ServerError> {
     let factory = || {
         WireframeApp::new()
             .unwrap()

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -12,7 +12,7 @@ use wireframe::{
 async fn main() -> Result<(), ServerError> {
     let factory = || {
         WireframeApp::new()
-            .unwrap()
+            .expect("failed to create app")
             .route(
                 1,
                 std::sync::Arc::new(|_: &Envelope| {
@@ -22,11 +22,11 @@ async fn main() -> Result<(), ServerError> {
                     })
                 }),
             )
-            .unwrap()
+            .expect("failed to register route")
     };
 
     WireframeServer::new(factory)
-        .bind("127.0.0.1:7878".parse().unwrap())?
+        .bind("127.0.0.1:7878".parse().expect("invalid bind address"))?
         .run()
         .await?;
     Ok(())

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -60,7 +60,7 @@ impl FrameMetadata for HeaderSerializer {
 struct Ping;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> io::Result<()> {
     let app = WireframeApp::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -60,7 +60,7 @@ impl FrameMetadata for HeaderSerializer {
 struct Ping;
 
 #[tokio::main]
-async fn main() -> io::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let app = WireframeApp::new()
         .unwrap()
         .frame_processor(LengthPrefixedProcessor::default())

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -11,7 +11,7 @@ use wireframe::{
     frame::{LengthFormat, LengthPrefixedProcessor},
     message::Message,
     middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
-    server::{WireframeServer, error::ServerError},
+    server::{ServerError, WireframeServer},
 };
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -3,7 +3,7 @@
 //! The application defines an enum representing different packet variants and
 //! shows how to dispatch handlers based on the variant received.
 
-use std::{collections::HashMap, future::Future, io, pin::Pin};
+use std::{collections::HashMap, future::Future, pin::Pin};
 
 use async_trait::async_trait;
 use wireframe::{
@@ -76,7 +76,7 @@ fn handle_packet(_env: &Envelope) -> Pin<Box<dyn Future<Output = ()> + Send>> {
 }
 
 #[tokio::main]
-async fn main() -> io::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let factory = || {
         WireframeApp::new()
             .expect("Failed to create WireframeApp")
@@ -92,5 +92,6 @@ async fn main() -> io::Result<()> {
     WireframeServer::new(factory)
         .bind(addr.parse().expect("Invalid server address"))?
         .run()
-        .await
+        .await?;
+    Ok(())
 }

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -11,7 +11,7 @@ use wireframe::{
     frame::{LengthFormat, LengthPrefixedProcessor},
     message::Message,
     middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
-    server::WireframeServer,
+    server::{WireframeServer, error::ServerError},
 };
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
@@ -76,7 +76,7 @@ fn handle_packet(_env: &Envelope) -> Pin<Box<dyn Future<Output = ()> + Send>> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), ServerError> {
     let factory = || {
         WireframeApp::new()
             .expect("Failed to create WireframeApp")

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -3,7 +3,7 @@
 //! Demonstrates custom packet structs and middleware that maps `Ping` to
 //! `Pong` responses.
 
-use std::{io, net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc};
 
 use async_trait::async_trait;
 use wireframe::{
@@ -136,15 +136,14 @@ fn build_app() -> AppResult<WireframeApp> {
 }
 
 #[tokio::main]
-async fn main() -> io::Result<()> {
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let factory = || build_app().expect("app build failed");
 
     let default_addr = "127.0.0.1:7878";
     let addr_str = std::env::args()
         .nth(1)
         .unwrap_or_else(|| default_addr.into());
-    let addr: SocketAddr = addr_str
-        .parse()
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e))?;
-    WireframeServer::new(factory).bind(addr)?.run().await
+    let addr: SocketAddr = addr_str.parse()?;
+    WireframeServer::new(factory).bind(addr)?.run().await?;
+    Ok(())
 }

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -11,7 +11,7 @@ use wireframe::{
     message::Message,
     middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
     serializer::BincodeSerializer,
-    server::WireframeServer,
+    server::{WireframeServer, error::ServerError},
 };
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
@@ -136,14 +136,14 @@ fn build_app() -> AppResult<WireframeApp> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), ServerError> {
     let factory = || build_app().expect("app build failed");
 
     let default_addr = "127.0.0.1:7878";
     let addr_str = std::env::args()
         .nth(1)
         .unwrap_or_else(|| default_addr.into());
-    let addr: SocketAddr = addr_str.parse()?;
+    let addr: SocketAddr = addr_str.parse().expect("invalid address");
     WireframeServer::new(factory).bind(addr)?.run().await?;
     Ok(())
 }

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -11,7 +11,7 @@ use wireframe::{
     message::Message,
     middleware::{HandlerService, Service, ServiceRequest, ServiceResponse, Transform},
     serializer::BincodeSerializer,
-    server::{WireframeServer, error::ServerError},
+    server::{ServerError, WireframeServer},
 };
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -9,7 +9,7 @@ use std::{
 use tokio::net::TcpListener;
 
 use super::{Bound, Unbound, WireframeServer};
-use crate::{app::WireframeApp, preamble::Preamble, server::error::ServerError};
+use crate::{app::WireframeApp, preamble::Preamble, server::ServerError};
 
 impl<F, T> WireframeServer<F, T, Unbound>
 where

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -1,0 +1,177 @@
+//! Binding configuration for [`WireframeServer`].
+
+use core::marker::PhantomData;
+use std::{
+    io,
+    net::{SocketAddr, TcpListener as StdTcpListener},
+    sync::Arc,
+};
+
+use tokio::net::TcpListener;
+
+use super::{Bound, Unbound, WireframeServer};
+use crate::{app::WireframeApp, preamble::Preamble};
+
+impl<F, T> WireframeServer<F, T, Unbound>
+where
+    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    T: Preamble,
+{
+    /// Return `None` as the server is not bound.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// assert!(
+    ///     WireframeServer::new(|| WireframeApp::default())
+    ///         .local_addr()
+    ///         .is_none()
+    /// );
+    /// ```
+    #[must_use]
+    pub const fn local_addr(&self) -> Option<SocketAddr> { None }
+
+    /// Bind to a fresh address.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::{Ipv4Addr, SocketAddr};
+    ///
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .bind(addr)
+    ///     .expect("bind failed");
+    /// assert!(server.local_addr().is_some());
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if binding or configuring the listener fails.
+    pub fn bind(self, addr: SocketAddr) -> io::Result<WireframeServer<F, T, Bound>> {
+        let std = StdTcpListener::bind(addr)?;
+        self.bind_listener(std)
+    }
+
+    /// Bind to an existing `StdTcpListener`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::{Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
+    ///
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let std = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .bind_listener(std)
+    ///     .expect("bind failed");
+    /// assert!(server.local_addr().is_some());
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if configuring the listener fails.
+    pub fn bind_listener(self, std: StdTcpListener) -> io::Result<WireframeServer<F, T, Bound>> {
+        std.set_nonblocking(true)?;
+        let tokio = TcpListener::from_std(std)?;
+        Ok(WireframeServer {
+            factory: self.factory,
+            workers: self.workers,
+            on_preamble_success: self.on_preamble_success,
+            on_preamble_failure: self.on_preamble_failure,
+            ready_tx: self.ready_tx,
+            state: Bound {
+                listener: Arc::new(tokio),
+            },
+            _preamble: PhantomData,
+        })
+    }
+}
+
+impl<F, T> WireframeServer<F, T, Bound>
+where
+    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    T: Preamble,
+{
+    /// Returns the bound address, or `None` if retrieving it fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::SocketAddr;
+    ///
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .bind(addr)
+    ///     .expect("bind failed");
+    /// assert!(server.local_addr().is_some());
+    /// ```
+    #[must_use]
+    pub fn local_addr(&self) -> Option<SocketAddr> { self.state.listener.local_addr().ok() }
+
+    /// Rebind to a fresh address.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::{Ipv4Addr, SocketAddr};
+    ///
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .bind(addr)
+    ///     .expect("bind failed");
+    /// let addr2 = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    /// let server = server.bind(addr2).expect("rebind failed");
+    /// assert!(server.local_addr().is_some());
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if binding or configuring the listener fails.
+    pub fn bind(self, addr: SocketAddr) -> io::Result<Self> {
+        let std = StdTcpListener::bind(addr)?;
+        self.bind_listener(std)
+    }
+
+    /// Rebind using an existing `StdTcpListener`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::net::{Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
+    ///
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .bind(addr)
+    ///     .expect("bind failed");
+    /// let std = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
+    /// let server = server.bind_listener(std).expect("rebind failed");
+    /// assert!(server.local_addr().is_some());
+    /// ```
+    ///
+    /// # Errors
+    /// Returns an `io::Error` if configuring the listener fails.
+    pub fn bind_listener(self, std: StdTcpListener) -> io::Result<Self> {
+        std.set_nonblocking(true)?;
+        let tokio = TcpListener::from_std(std)?;
+        Ok(WireframeServer {
+            factory: self.factory,
+            workers: self.workers,
+            on_preamble_success: self.on_preamble_success,
+            on_preamble_failure: self.on_preamble_failure,
+            ready_tx: self.ready_tx,
+            state: Bound {
+                listener: Arc::new(tokio),
+            },
+            _preamble: PhantomData,
+        })
+    }
+}

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -8,8 +8,12 @@ use std::{
 
 use tokio::net::TcpListener;
 
-use super::{Bound, Unbound, WireframeServer};
-use crate::{app::WireframeApp, preamble::Preamble, server::ServerError};
+use super::{Unbound, WireframeServer};
+use crate::{
+    app::WireframeApp,
+    preamble::Preamble,
+    server::{Bound, ServerError},
+};
 
 impl<F, T> WireframeServer<F, T, Unbound>
 where

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -33,7 +33,7 @@ macro_rules! builder_callback {
         where
             H: $($bound)*,
         {
-            self.$field = Some(Arc::new(handler));
+            self.$field = Some(std::sync::Arc::new(handler));
             self
         }
     };
@@ -78,6 +78,8 @@ where
     builder_setter!(
         /// Set the number of worker tasks to spawn for the server.
         ///
+        /// A minimum of one worker is enforced.
+        ///
         /// # Examples
         ///
         /// ```
@@ -85,6 +87,9 @@ where
         ///
         /// let server = WireframeServer::new(|| WireframeApp::default()).workers(4);
         /// assert_eq!(server.worker_count(), 4);
+        ///
+        /// let server = WireframeServer::new(|| WireframeApp::default()).workers(0);
+        /// assert_eq!(server.worker_count(), 1);
         /// ```
         workers, workers, count: usize => count.max(1)
     );

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -9,6 +9,7 @@
 //! on [`Unbound`] servers.
 
 use core::marker::PhantomData;
+
 use tokio::sync::oneshot;
 
 use super::{ServerState, Unbound, WireframeServer};
@@ -65,7 +66,15 @@ where
     #[must_use]
     pub fn new(factory: F) -> Self {
         let workers = std::thread::available_parallelism().map_or(1, std::num::NonZeroUsize::get);
-        Self { factory, workers, on_preamble_success: None, on_preamble_failure: None, ready_tx: None, state: Unbound, _preamble: PhantomData }
+        Self {
+            factory,
+            workers,
+            on_preamble_success: None,
+            on_preamble_failure: None,
+            ready_tx: None,
+            state: Unbound,
+            _preamble: PhantomData,
+        }
     }
 }
 
@@ -122,6 +131,4 @@ where
     #[inline]
     #[must_use]
     pub const fn worker_count(&self) -> usize { self.workers }
-
-
 }

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! Provides a fluent builder for configuring `WireframeServer` instances.
 //! The builder exposes worker count tuning, preamble callbacks,
-//! ready-signal configuration, and TCP binding. The server may be constructed
-//! unbound and later bound via [`bind`](WireframeServer::bind).
+//! ready-signal configuration, and TCP binding via the `binding`
+//! module. Preamble behaviour is customised through the `preamble`
+//! module. The server may be constructed unbound and later bound using
+//! the `binding` module's `bind` functions.
 
 use core::marker::PhantomData;
 use tokio::sync::oneshot;
@@ -11,8 +13,8 @@ use tokio::sync::oneshot;
 use super::{ServerState, Unbound, WireframeServer};
 use crate::{app::WireframeApp, preamble::Preamble};
 
-mod binding;
-mod preamble;
+pub mod binding;
+pub mod preamble;
 
 impl<F> WireframeServer<F, (), Unbound>
 where
@@ -22,7 +24,8 @@ where
     ///
     /// The worker count defaults to the number of available CPU cores (or 1 if
     /// this cannot be determined). The server is initially unbound; call
-    /// `bind` (available on unbound servers) before running the server.
+    /// `bind` (provided by the `binding` module for unbound servers) before
+    /// running the server.
     ///
     /// # Examples
     ///

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! Provides a fluent builder for configuring `WireframeServer` instances.
 //! The builder exposes worker count tuning, preamble callbacks,
-//! ready-signal configuration, and TCP binding via the `binding`
-//! module. Preamble behaviour is customised through the `preamble`
+//! ready-signal configuration, and TCP binding via the [`binding`](self::binding)
+//! module. Preamble behaviour is customised through the [`preamble`](self::preamble)
 //! module. The server may be constructed unbound and later bound using
-//! the `binding` module's `bind` functions.
+//! the [`bind`](WireframeServer::bind) functions on unbound servers.
 
 use core::marker::PhantomData;
 use tokio::sync::oneshot;
@@ -24,8 +24,8 @@ where
     ///
     /// The worker count defaults to the number of available CPU cores (or 1 if
     /// this cannot be determined). The server is initially unbound; call
-    /// `bind` (provided by the `binding` module for unbound servers) before
-    /// running the server.
+    /// [`bind`](WireframeServer::bind) on the unbound server (method provided by the
+    /// [`binding`](self::binding) module) before running the server.
     ///
     /// # Examples
     ///

--- a/src/server/config/preamble.rs
+++ b/src/server/config/preamble.rs
@@ -1,0 +1,101 @@
+//! Preamble configuration for [`WireframeServer`].
+
+use core::marker::PhantomData;
+use std::{io, sync::Arc};
+
+use bincode::error::DecodeError;
+use futures::future::BoxFuture;
+
+use super::WireframeServer;
+use crate::{app::WireframeApp, preamble::Preamble, server::ServerState};
+
+impl<F, T, S> WireframeServer<F, T, S>
+where
+    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    T: Preamble,
+    S: ServerState,
+{
+    /// Converts the server to use a custom preamble type for incoming connections.
+    ///
+    /// Calling this method drops any previously configured preamble decode callbacks.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bincode::{Decode, Encode};
+    /// use wireframe::{app::WireframeApp, preamble::Preamble, server::WireframeServer};
+    ///
+    /// #[derive(Encode, Decode)]
+    /// struct MyPreamble;
+    /// impl Preamble for MyPreamble {}
+    ///
+    /// let server = WireframeServer::new(|| WireframeApp::default()).with_preamble::<MyPreamble>();
+    /// ```
+    #[must_use]
+    pub fn with_preamble<P>(self) -> WireframeServer<F, P, S>
+    where
+        P: Preamble,
+    {
+        WireframeServer {
+            factory: self.factory,
+            workers: self.workers,
+            on_preamble_success: None,
+            on_preamble_failure: None,
+            ready_tx: self.ready_tx,
+            state: self.state,
+            _preamble: PhantomData,
+        }
+    }
+
+    /// Register a callback invoked when the connection preamble decodes successfully.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bincode::{Decode, Encode};
+    /// use futures::FutureExt;
+    /// use wireframe::{app::WireframeApp, preamble::Preamble, server::WireframeServer};
+    ///
+    /// #[derive(Encode, Decode)]
+    /// struct MyPreamble;
+    /// impl Preamble for MyPreamble {}
+    ///
+    /// let server = WireframeServer::new(|| WireframeApp::default())
+    ///     .with_preamble::<MyPreamble>()
+    ///     .on_preamble_decode_success(|_p: &MyPreamble, _s| async { Ok(()) }.boxed());
+    /// ```
+    #[must_use]
+    pub fn on_preamble_decode_success<H>(mut self, handler: H) -> Self
+    where
+        H: for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.on_preamble_success = Some(Arc::new(handler));
+        self
+    }
+
+    /// Register a callback invoked when the connection preamble fails to decode.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bincode::error::DecodeError;
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// let server = WireframeServer::new(|| WireframeApp::default()).on_preamble_decode_failure(
+    ///     |_err: &DecodeError| {
+    ///         eprintln!("Failed to decode preamble");
+    ///     },
+    /// );
+    /// ```
+    #[must_use]
+    pub fn on_preamble_decode_failure<H>(mut self, handler: H) -> Self
+    where
+        H: Fn(&DecodeError) + Send + Sync + 'static,
+    {
+        self.on_preamble_failure = Some(Arc::new(handler));
+        self
+    }
+}

--- a/src/server/config/preamble.rs
+++ b/src/server/config/preamble.rs
@@ -1,13 +1,15 @@
 //! Preamble configuration for [`WireframeServer`].
 
 use core::marker::PhantomData;
-use std::io;
 
 use bincode::error::DecodeError;
-use futures::future::BoxFuture;
 
 use super::WireframeServer;
-use crate::{app::WireframeApp, preamble::Preamble, server::ServerState};
+use crate::{
+    app::WireframeApp,
+    preamble::Preamble,
+    server::{PreambleSuccessHandler, ServerState},
+};
 
 impl<F, T, S> WireframeServer<F, T, S>
 where
@@ -71,7 +73,7 @@ where
         /// ```
         on_preamble_decode_success,
         on_preamble_success,
-        for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>> + Send + Sync + 'static
+        PreambleSuccessHandler<T>
     );
 
     builder_callback!(

--- a/src/server/config/preamble.rs
+++ b/src/server/config/preamble.rs
@@ -47,55 +47,46 @@ where
         }
     }
 
-    /// Register a callback invoked when the connection preamble decodes successfully.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bincode::{Decode, Encode};
-    /// use futures::FutureExt;
-    /// use wireframe::{app::WireframeApp, preamble::Preamble, server::WireframeServer};
-    ///
-    /// #[derive(Encode, Decode)]
-    /// struct MyPreamble;
-    /// impl Preamble for MyPreamble {}
-    ///
-    /// let server = WireframeServer::new(|| WireframeApp::default())
-    ///     .with_preamble::<MyPreamble>()
-    ///     .on_preamble_decode_success(|_p: &MyPreamble, _s| async { Ok(()) }.boxed());
-    /// ```
-    #[must_use]
-    pub fn on_preamble_decode_success<H>(mut self, handler: H) -> Self
-    where
-        H: for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
-            + Send
-            + Sync
-            + 'static,
-    {
-        self.on_preamble_success = Some(Arc::new(handler));
-        self
-    }
+    builder_callback!(
+        /// Register a callback invoked when the connection preamble decodes successfully.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use bincode::{Decode, Encode};
+        /// use futures::FutureExt;
+        /// use wireframe::{app::WireframeApp, preamble::Preamble, server::WireframeServer};
+        ///
+        /// #[derive(Encode, Decode)]
+        /// struct MyPreamble;
+        /// impl Preamble for MyPreamble {}
+        ///
+        /// let server = WireframeServer::new(|| WireframeApp::default())
+        ///     .with_preamble::<MyPreamble>()
+        ///     .on_preamble_decode_success(|_p: &MyPreamble, _s| async { Ok(()) }.boxed());
+        /// ```
+        on_preamble_decode_success,
+        on_preamble_success,
+        for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>> + Send + Sync + 'static
+    );
 
-    /// Register a callback invoked when the connection preamble fails to decode.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bincode::error::DecodeError;
-    /// use wireframe::{app::WireframeApp, server::WireframeServer};
-    ///
-    /// let server = WireframeServer::new(|| WireframeApp::default()).on_preamble_decode_failure(
-    ///     |_err: &DecodeError| {
-    ///         eprintln!("Failed to decode preamble");
-    ///     },
-    /// );
-    /// ```
-    #[must_use]
-    pub fn on_preamble_decode_failure<H>(mut self, handler: H) -> Self
-    where
-        H: Fn(&DecodeError) + Send + Sync + 'static,
-    {
-        self.on_preamble_failure = Some(Arc::new(handler));
-        self
-    }
+    builder_callback!(
+        /// Register a callback invoked when the connection preamble fails to decode.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use bincode::error::DecodeError;
+        /// use wireframe::{app::WireframeApp, server::WireframeServer};
+        ///
+        /// let server = WireframeServer::new(|| WireframeApp::default()).on_preamble_decode_failure(
+        ///     |_err: &DecodeError| {
+        ///         eprintln!("Failed to decode preamble");
+        ///     },
+        /// );
+        /// ```
+        on_preamble_decode_failure,
+        on_preamble_failure,
+        Fn(&DecodeError) + Send + Sync + 'static
+    );
 }

--- a/src/server/config/preamble.rs
+++ b/src/server/config/preamble.rs
@@ -1,7 +1,7 @@
 //! Preamble configuration for [`WireframeServer`].
 
 use core::marker::PhantomData;
-use std::{io, sync::Arc};
+use std::io;
 
 use bincode::error::DecodeError;
 use futures::future::BoxFuture;
@@ -15,9 +15,11 @@ where
     T: Preamble,
     S: ServerState,
 {
-    /// Converts the server to use a custom preamble type for incoming connections.
+    /// Converts the server to use a custom preamble type implementing
+    /// [`crate::preamble::Preamble`] for incoming connections.
     ///
-    /// Calling this method drops any previously configured preamble decode callbacks.
+    /// Calling this method drops any previously configured preamble decode callbacks
+    /// (both success and failure).
     ///
     /// # Examples
     ///
@@ -50,6 +52,8 @@ where
     builder_callback!(
         /// Register a callback invoked when the connection preamble decodes successfully.
         ///
+        /// The handler must implement [`crate::server::PreambleSuccessHandler`].
+        ///
         /// # Examples
         ///
         /// ```
@@ -73,14 +77,15 @@ where
     builder_callback!(
         /// Register a callback invoked when the connection preamble fails to decode.
         ///
+        /// The handler receives a [`bincode::error::DecodeError`].
+        ///
         /// # Examples
         ///
         /// ```
-        /// use bincode::error::DecodeError;
         /// use wireframe::{app::WireframeApp, server::WireframeServer};
         ///
         /// let server = WireframeServer::new(|| WireframeApp::default()).on_preamble_decode_failure(
-        ///     |_err: &DecodeError| {
+        ///     |_err: &bincode::error::DecodeError| {
         ///         eprintln!("Failed to decode preamble");
         ///     },
         /// );

--- a/src/server/config/preamble.rs
+++ b/src/server/config/preamble.rs
@@ -20,7 +20,7 @@ where
     /// Converts the server to use a custom preamble type implementing
     /// [`crate::preamble::Preamble`] for incoming connections.
     ///
-    /// Calling this method drops any previously configured preamble decode callbacks
+    /// Calling this method drops any previously configured preamble handlers
     /// (both success and failure).
     ///
     /// # Examples
@@ -52,7 +52,7 @@ where
     }
 
     builder_callback!(
-        /// Register a callback invoked when the connection preamble decodes successfully.
+        /// Register a handler invoked when the connection preamble decodes successfully.
         ///
         /// The handler must implement [`crate::server::PreambleSuccessHandler`].
         ///
@@ -77,7 +77,7 @@ where
     );
 
     builder_callback!(
-        /// Register a callback invoked when the connection preamble fails to decode.
+        /// Register a handler invoked when the connection preamble fails to decode.
         ///
         /// The handler receives a [`bincode::error::DecodeError`].
         ///

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -4,10 +4,14 @@ use std::io;
 
 use thiserror::Error;
 
-/// Errors that may occur while running the server.
+/// Errors that may occur while configuring or running the server.
 #[derive(Debug, Error)]
 pub enum ServerError {
+    /// Binding or configuring the listener failed.
+    #[error("bind error: {0}")]
+    Bind(#[source] io::Error),
+
     /// Accepting a connection failed.
     #[error("accept error: {0}")]
-    Accept(#[from] io::Error),
+    Accept(#[source] io::Error),
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,0 +1,13 @@
+//! Errors raised by [`WireframeServer`] operations.
+
+use std::io;
+
+use thiserror::Error;
+
+/// Errors that may occur while running the server.
+#[derive(Debug, Error)]
+pub enum ServerError {
+    /// Accepting a connection failed.
+    #[error("accept error: {0}")]
+    Accept(#[from] io::Error),
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -19,7 +19,7 @@ use crate::{app::WireframeApp, preamble::Preamble};
 /// connection is handed off to [`WireframeApp`].
 ///
 /// # Examples
-/// ```
+/// ```no_run
 /// use std::io;
 ///
 /// use futures::future::BoxFuture;
@@ -66,8 +66,8 @@ pub type PreambleErrorCallback = Arc<dyn Fn(&DecodeError) + Send + Sync>;
 ///
 /// The server carries a typestate `S` indicating whether it is
 /// [`Unbound`] (not yet bound to a TCP listener) or [`Bound`]. New
-/// servers start `Unbound` and must call [`binding::bind`] or
-/// [`binding::bind_listener`] before running. A worker task is spawned per
+/// servers start `Unbound` and must call [`binding::WireframeServer::bind`] or
+/// [`binding::WireframeServer::bind_listener`] before running. A worker task is spawned per
 /// thread; each receives its own `WireframeApp` from the provided factory
 /// closure. The server listens for a shutdown signal using
 /// `tokio::signal::ctrl_c` and notifies all workers to stop accepting new
@@ -77,8 +77,8 @@ where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
     // `Preamble` covers types implementing `BorrowDecode` for any lifetime,
     // enabling decoding of borrowed data without external context.
-    // `()` already satisfies this bound via `bincode`, so servers default to
-    // having no preamble.
+    // `()` satisfies this bound via bincode's `BorrowDecode` support for unit,
+    // so servers default to having no preamble.
     T: Preamble,
     S: ServerState,
 {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -116,7 +116,15 @@ pub struct Bound {
 }
 
 /// Trait implemented by [`Unbound`] and [`Bound`] to model binding typestate.
-pub trait ServerState {}
+pub trait ServerState: sealed::Sealed {}
+
+mod sealed {
+    //! Prevent external implementations of [`ServerState`].
+
+    pub trait Sealed {}
+    impl Sealed for super::Unbound {}
+    impl Sealed for super::Bound {}
+}
 
 impl ServerState for Unbound {}
 impl ServerState for Bound {}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -51,6 +51,8 @@ where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
     // `Preamble` covers types implementing `BorrowDecode` for any lifetime,
     // enabling decoding of borrowed data without external context.
+    // `()` already satisfies this bound via `bincode`, so servers default to
+    // having no preamble.
     T: Preamble,
     S: ServerState,
 {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -13,15 +13,17 @@ use tokio::{net::TcpListener, sync::oneshot};
 
 use crate::{app::WireframeApp, preamble::Preamble};
 
-/// Callback invoked when a connection preamble decodes successfully.
+/// Handler invoked when a connection preamble decodes successfully.
 ///
-/// The callback may perform asynchronous I/O on the provided stream before the
+/// The handler may perform asynchronous I/O on the provided stream before the
 /// connection is handed off to [`WireframeApp`].
-pub type PreambleCallback<T> = Arc<
-    dyn for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
-        + Send
-        + Sync,
->;
+pub type PreambleSuccessHandler<T> = dyn for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
+    + Send
+    + Sync
+    + 'static;
+
+/// Callback invoked when a connection preamble decodes successfully.
+pub type PreambleCallback<T> = Arc<PreambleSuccessHandler<T>>;
 
 /// Callback invoked when decoding a connection preamble fails.
 pub type PreambleErrorCallback = Arc<dyn Fn(&DecodeError) + Send + Sync>;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,6 +17,29 @@ use crate::{app::WireframeApp, preamble::Preamble};
 ///
 /// Implementors may perform asynchronous I/O on the provided stream before the
 /// connection is handed off to [`WireframeApp`].
+///
+/// # Examples
+/// ```
+/// use std::io;
+///
+/// use futures::future::BoxFuture;
+/// use tokio::net::TcpStream;
+/// use wireframe::{app::WireframeApp, server::WireframeServer};
+///
+/// #[derive(bincode::Decode, bincode::BorrowDecode)]
+/// struct MyPreamble;
+///
+/// let _server = WireframeServer::new(|| WireframeApp::default())
+///     .with_preamble::<MyPreamble>()
+///     .on_preamble_decode_success(
+///         |_preamble: &MyPreamble, stream: &mut TcpStream| -> BoxFuture<'_, io::Result<()>> {
+///             Box::pin(async move {
+///                 // Perform any initial handshake here.
+///                 Ok(())
+///             })
+///         },
+///     );
+/// ```
 pub trait PreambleSuccessHandler<T>:
     for<'a> Fn(&'a T, &'a mut tokio::net::TcpStream) -> BoxFuture<'a, io::Result<()>>
     + Send

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -60,7 +60,7 @@ impl<T, F> PreambleSuccessHandler<T> for F where
 pub type PreambleCallback<T> = Arc<dyn PreambleSuccessHandler<T>>;
 
 /// Callback invoked when decoding a connection preamble fails.
-pub type PreambleErrorCallback = Arc<dyn Fn(&DecodeError) + Send + Sync>;
+pub type PreambleErrorCallback = Arc<dyn Fn(&DecodeError) + Send + Sync + 'static>;
 
 /// Tokio-based server for [`WireframeApp`] instances.
 ///
@@ -106,7 +106,7 @@ where
 }
 
 /// Marker indicating the server has not yet bound a listener.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct Unbound;
 
 /// Marker indicating the server is bound to a TCP listener.

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -13,11 +13,11 @@ use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 use super::{
     Bound,
-    PreambleCallback,
-    PreambleErrorCallback,
+    PreambleErrorHandler,
+    PreambleHandler,
+    ServerError,
     WireframeServer,
     connection::spawn_connection_task,
-    error::ServerError,
 };
 use crate::{app::WireframeApp, preamble::Preamble};
 
@@ -66,7 +66,7 @@ where
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), wireframe::server::error::ServerError> {
+    /// # async fn main() -> Result<(), wireframe::server::ServerError> {
     /// let server =
     ///     WireframeServer::new(|| WireframeApp::default()).bind(([127, 0, 0, 1], 8080).into())?;
     /// server.run().await?;
@@ -93,7 +93,7 @@ where
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), wireframe::server::error::ServerError> {
+    /// # async fn main() -> Result<(), wireframe::server::ServerError> {
     /// let server =
     ///     WireframeServer::new(|| WireframeApp::default()).bind(([127, 0, 0, 1], 0).into())?;
     ///
@@ -171,8 +171,8 @@ where
 pub(super) async fn accept_loop<F, T>(
     listener: Arc<TcpListener>,
     factory: F,
-    on_success: Option<PreambleCallback<T>>,
-    on_failure: Option<PreambleErrorCallback>,
+    on_success: Option<PreambleHandler<T>>,
+    on_failure: Option<PreambleErrorHandler>,
     shutdown: CancellationToken,
     tracker: TaskTracker,
     backoff_config: BackoffConfig,

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -153,7 +153,7 @@ where
                 on_failure,
                 token,
                 t,
-                backoff_config,
+                BackoffConfig::default(),
             ));
         }
 

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -66,7 +66,7 @@ where
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn main() -> Result<(), wireframe::server::error::ServerError> {
     /// let server =
     ///     WireframeServer::new(|| WireframeApp::default()).bind(([127, 0, 0, 1], 8080).into())?;
     /// server.run().await?;
@@ -93,7 +93,7 @@ where
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
     /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # async fn main() -> Result<(), wireframe::server::error::ServerError> {
     /// let server =
     ///     WireframeServer::new(|| WireframeApp::default()).bind(([127, 0, 0, 1], 0).into())?;
     ///

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -5,9 +5,10 @@ use std::net::{Ipv4Addr, SocketAddr};
 use bincode::{Decode, Encode};
 use rstest::fixture;
 
-use super::WireframeServer;
+use super::{Bound, WireframeServer};
 use crate::app::WireframeApp;
 
+#[allow(dead_code, reason = "Used in builder tests via fixtures")]
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct TestPreamble {
     pub id: u32,
@@ -28,7 +29,7 @@ pub fn free_port() -> SocketAddr {
         .expect("failed to read free port listener address")
 }
 
-pub fn bind_server<F>(factory: F, addr: SocketAddr) -> WireframeServer<F, ()>
+pub fn bind_server<F>(factory: F, addr: SocketAddr) -> WireframeServer<F, (), Bound>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
 {
@@ -37,6 +38,7 @@ where
         .expect("Failed to bind")
 }
 
+#[allow(dead_code, reason = "Only used in configuration tests")]
 pub fn server_with_preamble<F>(factory: F) -> WireframeServer<F, TestPreamble>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -8,7 +8,11 @@ use rstest::fixture;
 use super::{Bound, WireframeServer};
 use crate::app::WireframeApp;
 
-#[allow(dead_code, reason = "Used in builder tests via fixtures")]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "Used in builder tests via fixtures")
+)]
+#[cfg_attr(test, allow(dead_code, reason = "Used in builder tests via fixtures"))]
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct TestPreamble {
     pub id: u32,
@@ -38,7 +42,11 @@ where
         .expect("Failed to bind")
 }
 
-#[allow(dead_code, reason = "Only used in configuration tests")]
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "Only used in configuration tests")
+)]
+#[cfg_attr(test, allow(dead_code, reason = "Only used in configuration tests"))]
 pub fn server_with_preamble<F>(factory: F) -> WireframeServer<F, TestPreamble>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,


### PR DESCRIPTION
## Summary
- enforce compile-time binding with `Bound`/`Unbound` typestate
- introduce `ServerError` and reorganise config into binding and preamble modules

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6893cfc7ed7c83228f453cfa2aec3629

## Summary by Sourcery

Enforce compile-time server binding via typestate markers, reorganise configuration and error handling, and update examples and docs to reflect the new ServerError and typestate API.

New Features:
- Introduce typestate markers (Unbound/Bound) for WireframeServer to enforce compile-time binding state
- Split server configuration into separate binding and preamble modules
- Add a dedicated ServerError enum for runtime errors

Enhancements:
- Update runtime methods to return ServerError instead of io::Error and remove optional listener use
- Refactor examples to use `?` and return `Result<(), Box<dyn Error>>` for unified error handling

Build:
- Add thiserror dependency for error derivation

Documentation:
- Reformat tables and numbering in the asynchronous outbound messaging design document