### PR TITLE
Add correlation id to frame header

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ WireframeServer::new(|| {
 ```
 
 This example showcases how derive macros and the framing abstraction simplify a
-binary protocol server. See the
-<!-- markdownlint-disable-next-line MD013 -->
+binary protocol server. See the <!-- markdownlint-disable-next-line MD013 -->
 [full example](docs/rust-binary-router-library-design.md#5-6-illustrative-api-usage-examples)
  in the design document for further details.
 
@@ -99,12 +98,15 @@ payload bytes. Applications can supply their own envelope type by calling
 use wireframe::app::{Packet, WireframeApp};
 
 #[derive(bincode::Encode, bincode::BorrowDecode)]
-struct MyEnv { id: u32, data: Vec<u8> }
+struct MyEnv { id: u32, correlation_id: u64, data: Vec<u8> }
 
 impl Packet for MyEnv {
     fn id(&self) -> u32 { self.id }
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.data) }
-    fn from_parts(id: u32, data: Vec<u8>) -> Self { Self { id, data } }
+    fn correlation_id(&self) -> u64 { self.correlation_id }
+    fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.data) }
+    fn from_parts(id: u32, correlation_id: u64, data: Vec<u8>) -> Self {
+        Self { id, correlation_id, data }
+    }
 }
 
 let app = WireframeApp::<_, _, MyEnv>::new()

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -179,7 +179,7 @@ stream.
 
 - [ ] **Protocol Enhancement:**
 
-  - [ ] Add a `correlation_id` field to the `Frame` header. For a request, this
+  - [x] Add a `correlation_id` field to the `Frame` header. For a request, this
     is the unique request ID. For each message in a multi-packet response, this
     ID must match the original request's ID.
 

--- a/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
+++ b/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
@@ -59,9 +59,9 @@ pub enum Response<F = Frame, E = MyProtocolError> {
 }
 ```
 
-Every frame header now carries a 64-bit `correlation_id`. This value is set by
-the request and echoed on each message in a multi-packet response so clients
-can tie fragments back to their origin.
+Each frame header now carries a 64-bit `correlation_id`. Requests set this
+value, and every packet in a multi-part response repeats it, so clients can
+match frames to the originating request.
 
 This design is powered by the `async-stream` crate, which allows developers to
 write imperative-looking logic that generates a declarative `Stream` object. It

--- a/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
+++ b/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
@@ -59,6 +59,10 @@ pub enum Response<F = Frame, E = MyProtocolError> {
 }
 ```
 
+Every frame header now carries a 64-bit `correlation_id`. This value is set by
+the request and echoed on each message in a multi-packet response so clients
+can tie fragments back to their origin.
+
 This design is powered by the `async-stream` crate, which allows developers to
 write imperative-looking logic that generates a declarative `Stream` object. It
 provides the best of both worlds: the intuitive feel of a `for` loop for

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -52,7 +52,7 @@ impl FrameMetadata for HeaderSerializer {
         // `parse` receives the complete frame because `LengthPrefixedProcessor`
         // ensures `src` contains exactly one message. Returning `src.len()` is
         // therefore correct for this demo.
-        Ok((Envelope::new(id, payload), src.len()))
+        Ok((Envelope::new(id, 0, payload), src.len()))
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -163,9 +163,12 @@ impl From<io::Error> for SendError {
 /// impl Packet for CustomEnvelope {
 ///     fn id(&self) -> u32 { self.id }
 ///
-///     fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.payload) }
+///     fn correlation_id(&self) -> u64 { 0 }
 ///
-///     fn from_parts(id: u32, msg: Vec<u8>) -> Self {
+///     fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, 0, self.payload) }
+///
+///     fn from_parts(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self {
+///         let _ = correlation_id;
 ///         Self {
 ///             id,
 ///             payload: msg,
@@ -178,39 +181,57 @@ pub trait Packet: Message + Send + Sync + 'static {
     /// Return the message identifier used for routing.
     fn id(&self) -> u32;
 
-    /// Consume the packet and return its identifier and payload bytes.
-    fn into_parts(self) -> (u32, Vec<u8>);
+    /// Return the correlation identifier tying this frame to a request.
+    fn correlation_id(&self) -> u64;
 
-    /// Construct a new packet from an id and raw payload bytes.
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self;
+    /// Consume the packet and return its identifier, correlation id and payload bytes.
+    fn into_parts(self) -> (u32, u64, Vec<u8>);
+
+    /// Construct a new packet from id, correlation id and raw payload bytes.
+    fn from_parts(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self;
 }
 
 /// Basic envelope type used by [`handle_connection`].
 ///
 /// Incoming frames are deserialized into an `Envelope` containing the
 /// message identifier and raw payload bytes.
-#[derive(bincode::Decode, bincode::Encode)]
+#[derive(bincode::Decode, bincode::Encode, Debug)]
 pub struct Envelope {
     pub(crate) id: u32,
+    pub(crate) correlation_id: u64,
     pub(crate) msg: Vec<u8>,
 }
 
 impl Envelope {
-    /// Create a new [`Envelope`] with the provided id and payload.
+    /// Create a new [`Envelope`] with the provided identifiers and payload.
     #[must_use]
-    pub fn new(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    pub fn new(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self {
+        Self {
+            id,
+            correlation_id,
+            msg,
+        }
+    }
 
-    /// Consume the envelope, returning its id and payload bytes.
+    /// Consume the envelope, returning its identifiers and payload bytes.
     #[must_use]
-    pub fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    pub fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.msg) }
 }
 
 impl Packet for Envelope {
     fn id(&self) -> u32 { self.id }
 
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    fn correlation_id(&self) -> u64 { self.correlation_id }
 
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.msg) }
+
+    fn from_parts(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self {
+        Self {
+            id,
+            correlation_id,
+            msg,
+        }
+    }
 }
 
 /// Number of idle polls before terminating a connection.
@@ -266,13 +287,21 @@ where
     /// #[derive(bincode::Encode, bincode::BorrowDecode)]
     /// struct MyEnv {
     ///     id: u32,
+    ///     correlation_id: u64,
     ///     data: Vec<u8>,
     /// }
     ///
     /// impl Packet for MyEnv {
     ///     fn id(&self) -> u32 { self.id }
-    ///     fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.data) }
-    ///     fn from_parts(id: u32, data: Vec<u8>) -> Self { Self { id, data } }
+    ///     fn correlation_id(&self) -> u64 { self.correlation_id }
+    ///     fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.data) }
+    ///     fn from_parts(id: u32, correlation_id: u64, data: Vec<u8>) -> Self {
+    ///         Self {
+    ///             id,
+    ///             correlation_id,
+    ///             data,
+    ///         }
+    ///     }
     /// }
     ///
     /// let app = WireframeApp::<_, _, MyEnv>::new().expect("failed to create app");
@@ -694,11 +723,12 @@ where
         };
 
         if let Some(service) = routes.get(&env.id) {
-            let request = ServiceRequest::new(env.msg);
+            let request = ServiceRequest::new(env.msg, env.correlation_id);
             match service.call(request).await {
                 Ok(resp) => {
                     let response = Envelope {
                         id: env.id,
+                        correlation_id: env.correlation_id,
                         msg: resp.into_inner(),
                     };
                     if let Err(e) = self.send_response(stream, &response).await {

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -1,0 +1,24 @@
+//! Tests for `correlation_id` propagation in streaming responses.
+use async_stream::try_stream;
+use tokio_util::sync::CancellationToken;
+use wireframe::{
+    app::{Envelope, Packet},
+    connection::ConnectionActor,
+    push::PushQueues,
+    response::FrameStream,
+};
+
+#[tokio::test]
+async fn stream_frames_carry_request_correlation_id() {
+    let cid = 42u64;
+    let stream: FrameStream<Envelope> = Box::pin(try_stream! {
+        yield Envelope::new(1, cid, vec![1]);
+        yield Envelope::new(1, cid, vec![2]);
+    });
+    let (queues, handle) = PushQueues::bounded(1, 1);
+    let shutdown = CancellationToken::new();
+    let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
+    let mut out = Vec::new();
+    actor.run(&mut out).await.expect("actor run failed");
+    assert!(out.iter().all(|e| e.correlation_id() == cid));
+}

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -7,7 +7,10 @@ mod steps;
 mod world;
 
 use cucumber::World;
-use world::PanicWorld;
+use world::{CorrelationWorld, PanicWorld};
 
 #[tokio::main]
-async fn main() { PanicWorld::run("tests/features").await; }
+async fn main() {
+    PanicWorld::run("tests/features/connection_panic.feature").await;
+    CorrelationWorld::run("tests/features/correlation_id.feature").await;
+}

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,8 +1,19 @@
 //! Cucumber test runner for integration tests.
 //!
-//! Runs behavioural tests defined in `tests/features/` using appropriate
-//! test contexts to verify server panic handling and correlation ID
-//! propagation.
+//! Orchestrates two distinct test suites:
+//! - `PanicWorld`: Tests server resilience during connection panics
+//! - `CorrelationWorld`: Tests correlation ID propagation in multi-frame responses
+//!
+//! # Example
+//!
+//! The runner executes feature files sequentially:
+//! ```text
+//! tests/features/connection_panic.feature    -> PanicWorld context
+//! tests/features/correlation_id.feature      -> CorrelationWorld context
+//! ```
+//!
+//! Each context provides specialised step definitions and state management
+//! for their respective test scenarios.
 
 mod steps;
 mod world;

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,7 +1,8 @@
-//! Cucumber test runner for panic resilience integration tests.
+//! Cucumber test runner for integration tests.
 //!
-//! Runs behavioural tests defined in `tests/features/` using the
-//! `PanicWorld` test context to verify server panic handling.
+//! Runs behavioural tests defined in `tests/features/` using appropriate
+//! test contexts to verify server panic handling and correlation ID
+//! propagation.
 
 mod steps;
 mod world;

--- a/tests/features/correlation_id.feature
+++ b/tests/features/correlation_id.feature
@@ -1,0 +1,5 @@
+Feature: Multi-packet response correlation
+  Scenario: Streamed frames reuse the request correlation id
+    Given a correlation id 7
+    When a stream of frames is processed
+    Then each emitted frame uses correlation id 7

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -102,15 +102,24 @@ async fn teardown_without_setup_does_not_run() {
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
 struct StateEnvelope {
     id: u32,
+    correlation_id: u64,
     msg: Vec<u8>,
 }
 
 impl wireframe::app::Packet for StateEnvelope {
     fn id(&self) -> u32 { self.id }
 
-    fn into_parts(self) -> (u32, Vec<u8>) { (self.id, self.msg) }
+    fn correlation_id(&self) -> u64 { self.correlation_id }
 
-    fn from_parts(id: u32, msg: Vec<u8>) -> Self { Self { id, msg } }
+    fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.msg) }
+
+    fn from_parts(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self {
+        Self {
+            id,
+            correlation_id,
+            msg,
+        }
+    }
 }
 
 #[tokio::test]
@@ -125,6 +134,7 @@ async fn helpers_propagate_connection_state() {
 
     let env = StateEnvelope {
         id: 1,
+        correlation_id: 0,
         msg: vec![1],
     };
     let bytes = BincodeSerializer

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -60,7 +60,7 @@ async fn metadata_parser_invoked_before_deserialize() {
     let serializer = CountingSerializer(counter.clone());
     let app = mock_wireframe_app_with_serializer(serializer);
 
-    let env = Envelope::new(1, vec![42]);
+    let env = Envelope::new(1, 0, vec![42]);
 
     let out = drive_with_bincode(app, env)
         .await
@@ -105,7 +105,7 @@ async fn falls_back_to_deserialize_after_parse_error() {
     let serializer = FallbackSerializer(parse_calls.clone(), deser_calls.clone());
     let app = mock_wireframe_app_with_serializer(serializer);
 
-    let env = Envelope::new(1, vec![7]);
+    let env = Envelope::new(1, 0, vec![7]);
 
     let out = drive_with_bincode(app, env)
         .await

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -54,7 +54,7 @@ async fn middleware_modifies_request_and_response() {
     let mw = ModifyMiddleware;
     let wrapped = mw.transform(service).await;
 
-    let request = ServiceRequest::new(vec![1, 2, 3]);
+    let request = ServiceRequest::new(vec![1, 2, 3], 0);
     let response = wrapped.call(request).await.expect("middleware call failed");
     assert_eq!(response.frame(), &[1, 2, 3, b'!', b'?']);
 }

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -88,6 +88,6 @@ async fn middleware_applied_in_reverse_order() {
     let (resp, _) = serializer
         .deserialize::<Envelope>(&frame)
         .expect("deserialize failed");
-    let (_, _, bytes) = resp.into_parts();
+    let (_, bytes) = resp.into_parts();
     assert_eq!(bytes, vec![b'X', b'A', b'B', b'B', b'A']);
 }

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -64,7 +64,7 @@ async fn middleware_applied_in_reverse_order() {
 
     let (mut client, server) = duplex(256);
 
-    let env = Envelope::new(1, vec![b'X']);
+    let env = Envelope::new(1, 7, vec![b'X']);
     let serializer = BincodeSerializer;
     let bytes = serializer.serialize(&env).expect("serialization failed");
     // Use the default 4-byte big-endian length prefix for framing
@@ -88,6 +88,6 @@ async fn middleware_applied_in_reverse_order() {
     let (resp, _) = serializer
         .deserialize::<Envelope>(&frame)
         .expect("deserialize failed");
-    let (_, bytes) = resp.into_parts();
+    let (_, _, bytes) = resp.into_parts();
     assert_eq!(bytes, vec![b'X', b'A', b'B', b'B', b'A']);
 }

--- a/tests/steps/correlation_steps.rs
+++ b/tests/steps/correlation_steps.rs
@@ -1,0 +1,16 @@
+//! Steps for `correlation_id` behavioural tests.
+use cucumber::{given, then, when};
+
+use crate::world::CorrelationWorld;
+
+#[given(expr = "a correlation id {int}")]
+fn given_cid(world: &mut CorrelationWorld, id: u64) { world.set_cid(id); }
+
+#[when("a stream of frames is processed")]
+async fn when_process(world: &mut CorrelationWorld) { world.process().await; }
+
+#[then(expr = "each emitted frame uses correlation id {int}")]
+fn then_verify(world: &mut CorrelationWorld, id: u64) {
+    assert_eq!(world.cid(), id);
+    world.verify();
+}

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -3,4 +3,5 @@
 //! This module exposes all Given-When-Then steps used by the
 //! behaviour-driven tests under `tests/features`.
 
+mod correlation_steps;
 mod panic_steps;

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -125,10 +125,13 @@ pub struct CorrelationWorld {
 impl CorrelationWorld {
     pub fn set_cid(&mut self, cid: u64) { self.cid = cid; }
 
-    #[allow(clippy::must_use_candidate)]
+    #[must_use]
     pub fn cid(&self) -> u64 { self.cid }
 
-    #[allow(clippy::missing_panics_doc)]
+    /// Run the connection actor and collect frames for later verification.
+    ///
+    /// # Panics
+    /// Panics if the actor fails to run successfully.
     pub async fn process(&mut self) {
         let cid = self.cid;
         let stream: FrameStream<Envelope> = Box::pin(try_stream! {
@@ -141,7 +144,11 @@ impl CorrelationWorld {
         actor.run(&mut self.frames).await.expect("actor run failed");
     }
 
-    #[allow(clippy::missing_panics_doc)]
+    /// Verify that all received frames carry the expected correlation id.
+    ///
+    /// # Panics
+    /// Panics if any frame has a `correlation_id` that does not match the
+    /// expected value.
     pub fn verify(&self) {
         assert!(self.frames.iter().all(|f| f.correlation_id() == self.cid));
     }


### PR DESCRIPTION
## Summary
- extend `Packet` and default `Envelope` with a `correlation_id`
- propagate the `correlation_id` through middleware and responses
- document and test multi-frame correlation handling

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package lodash-es)*

------
https://chatgpt.com/codex/tasks/task_e_6893ad465ea0832283260e3170a19ecb

## Summary by Sourcery

Add support for request correlation IDs in frame headers and propagate them through packet APIs, middleware, service handlers, and response streams.

New Features:
- Introduce a 64-bit correlation_id field in the frame header and update Packet and Envelope APIs to include the correlation ID

Enhancements:
- Refactor Envelope to embed a PacketHeader struct and adapt middleware (ServiceRequest) and route services to handle correlation IDs
- Update server handling logic to forward the correlation ID in multi-frame responses
- Update examples to demonstrate correlation ID usage

Documentation:
- Extend documentation, README, design docs, and roadmap to describe the new correlation_id feature and usage

Tests:
- Add unit and integration tests (including Cucumber scenarios) to verify correlation ID propagation in single- and multi-frame streams