### PR TITLE
Introduce PacketParts and optional correlation IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,19 @@ payload bytes. Applications can supply their own envelope type by calling
 `Packet` trait:
 
 ```rust
-use wireframe::app::{Packet, WireframeApp};
+use wireframe::app::{Packet, PacketParts, WireframeApp};
 
 #[derive(bincode::Encode, bincode::BorrowDecode)]
-struct MyEnv { id: u32, correlation_id: u64, data: Vec<u8> }
+struct MyEnv { id: u32, correlation_id: Option<u64>, data: Vec<u8> }
 
 impl Packet for MyEnv {
     fn id(&self) -> u32 { self.id }
-    fn correlation_id(&self) -> u64 { self.correlation_id }
-    fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.data) }
-    fn from_parts(id: u32, correlation_id: u64, data: Vec<u8>) -> Self {
-        Self { id, correlation_id, data }
+    fn correlation_id(&self) -> Option<u64> { self.correlation_id }
+    fn into_parts(self) -> PacketParts {
+        PacketParts { id: self.id, correlation_id: self.correlation_id, msg: self.data }
+    }
+    fn from_parts(parts: PacketParts) -> Self {
+        Self { id: parts.id, correlation_id: parts.correlation_id, data: parts.msg }
     }
 }
 

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -52,7 +52,7 @@ impl FrameMetadata for HeaderSerializer {
         // `parse` receives the complete frame because `LengthPrefixedProcessor`
         // ensures `src` contains exactly one message. Returning `src.len()` is
         // therefore correct for this demo.
-        Ok((Envelope::new(id, 0, payload), src.len()))
+        Ok((Envelope::new(id, Some(0), payload), src.len()))
     }
 }
 

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -8,6 +8,8 @@ use std::{convert::Infallible, sync::Arc};
 
 use async_trait::async_trait;
 
+use crate::app::PacketParts;
+
 /// Generic container for request and response frame data.
 #[derive(Debug, Default)]
 pub struct FrameContainer<F> {
@@ -36,13 +38,13 @@ impl<F> FrameContainer<F> {
 #[derive(Debug)]
 pub struct ServiceRequest {
     inner: FrameContainer<Vec<u8>>,
-    correlation_id: u64,
+    correlation_id: Option<u64>,
 }
 
 impl ServiceRequest {
     /// Create a new [`ServiceRequest`] from raw frame bytes.
     #[must_use]
-    pub fn new(frame: Vec<u8>, correlation_id: u64) -> Self {
+    pub fn new(frame: Vec<u8>, correlation_id: Option<u64>) -> Self {
         Self {
             inner: FrameContainer::new(frame),
             correlation_id,
@@ -53,9 +55,9 @@ impl ServiceRequest {
     #[must_use]
     pub fn frame(&self) -> &[u8] { self.inner.frame().as_slice() }
 
-    /// Return the correlation identifier associated with this request.
+    /// Return the correlation identifier associated with this request, if any.
     #[must_use]
-    pub fn correlation_id(&self) -> u64 { self.correlation_id }
+    pub fn correlation_id(&self) -> Option<u64> { self.correlation_id }
 
     /// Mutable access to the inner frame bytes.
     #[must_use]
@@ -70,14 +72,16 @@ impl ServiceRequest {
 #[derive(Debug, Default)]
 pub struct ServiceResponse {
     inner: FrameContainer<Vec<u8>>,
+    correlation_id: Option<u64>,
 }
 
 impl ServiceResponse {
     /// Create a new [`ServiceResponse`] containing the given frame bytes.
     #[must_use]
-    pub fn new(frame: Vec<u8>) -> Self {
+    pub fn new(frame: Vec<u8>, correlation_id: Option<u64>) -> Self {
         Self {
             inner: FrameContainer::new(frame),
+            correlation_id,
         }
     }
 
@@ -88,6 +92,10 @@ impl ServiceResponse {
     /// Mutable access to the response frame bytes.
     #[must_use]
     pub fn frame_mut(&mut self) -> &mut Vec<u8> { self.inner.frame_mut() }
+
+    /// Return the correlation identifier associated with this response, if any.
+    #[must_use]
+    pub fn correlation_id(&self) -> Option<u64> { self.correlation_id }
 
     /// Consume the response, yielding the raw frame bytes.
     #[must_use]
@@ -303,10 +311,15 @@ impl<E: Packet> Service for RouteService<E> {
     async fn call(&self, req: ServiceRequest) -> Result<ServiceResponse, Self::Error> {
         // The handler only borrows the envelope, allowing us to consume it
         // afterwards to extract the response payload.
-        let env = E::from_parts(self.id, req.correlation_id(), req.into_inner());
+        let parts = PacketParts {
+            id: self.id,
+            correlation_id: req.correlation_id(),
+            msg: req.into_inner(),
+        };
+        let env = E::from_parts(parts);
         (self.handler.as_ref())(&env).await;
-        let (_, _, bytes) = env.into_parts();
-        Ok(ServiceResponse::new(bytes))
+        let parts = env.into_parts();
+        Ok(ServiceResponse::new(parts.msg, parts.correlation_id))
     }
 }
 

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -12,13 +12,13 @@ use wireframe::{
 async fn stream_frames_carry_request_correlation_id() {
     let cid = 42u64;
     let stream: FrameStream<Envelope> = Box::pin(try_stream! {
-        yield Envelope::new(1, cid, vec![1]);
-        yield Envelope::new(1, cid, vec![2]);
+        yield Envelope::new(1, Some(cid), vec![1]);
+        yield Envelope::new(1, Some(cid), vec![2]);
     });
     let (queues, handle) = PushQueues::bounded(1, 1);
     let shutdown = CancellationToken::new();
     let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
     let mut out = Vec::new();
     actor.run(&mut out).await.expect("actor run failed");
-    assert!(out.iter().all(|e| e.correlation_id() == cid));
+    assert!(out.iter().all(|e| e.correlation_id() == Some(cid)));
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -13,7 +13,7 @@ use std::{
 
 use bytes::BytesMut;
 use wireframe::{
-    app::{Envelope, Packet, WireframeApp},
+    app::{Envelope, Packet, PacketParts, WireframeApp},
     frame::{FrameProcessor, LengthPrefixedProcessor},
     serializer::{BincodeSerializer, Serializer},
 };
@@ -102,22 +102,28 @@ async fn teardown_without_setup_does_not_run() {
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
 struct StateEnvelope {
     id: u32,
-    correlation_id: u64,
+    correlation_id: Option<u64>,
     msg: Vec<u8>,
 }
 
-impl wireframe::app::Packet for StateEnvelope {
+impl Packet for StateEnvelope {
     fn id(&self) -> u32 { self.id }
 
-    fn correlation_id(&self) -> u64 { self.correlation_id }
+    fn correlation_id(&self) -> Option<u64> { self.correlation_id }
 
-    fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.msg) }
+    fn into_parts(self) -> PacketParts {
+        PacketParts {
+            id: self.id,
+            correlation_id: self.correlation_id,
+            msg: self.msg,
+        }
+    }
 
-    fn from_parts(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self {
+    fn from_parts(parts: PacketParts) -> Self {
         Self {
-            id,
-            correlation_id,
-            msg,
+            id: parts.id,
+            correlation_id: parts.correlation_id,
+            msg: parts.msg,
         }
     }
 }
@@ -134,7 +140,7 @@ async fn helpers_propagate_connection_state() {
 
     let env = StateEnvelope {
         id: 1,
-        correlation_id: 0,
+        correlation_id: Some(0),
         msg: vec![1],
     };
     let bytes = BincodeSerializer

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -60,7 +60,7 @@ async fn metadata_parser_invoked_before_deserialize() {
     let serializer = CountingSerializer(counter.clone());
     let app = mock_wireframe_app_with_serializer(serializer);
 
-    let env = Envelope::new(1, 0, vec![42]);
+    let env = Envelope::new(1, Some(0), vec![42]);
 
     let out = drive_with_bincode(app, env)
         .await
@@ -105,7 +105,7 @@ async fn falls_back_to_deserialize_after_parse_error() {
     let serializer = FallbackSerializer(parse_calls.clone(), deser_calls.clone());
     let app = mock_wireframe_app_with_serializer(serializer);
 
-    let env = Envelope::new(1, 0, vec![7]);
+    let env = Envelope::new(1, Some(0), vec![7]);
 
     let out = drive_with_bincode(app, env)
         .await

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -64,7 +64,7 @@ async fn middleware_applied_in_reverse_order() {
 
     let (mut client, server) = duplex(256);
 
-    let env = Envelope::new(1, 7, vec![b'X']);
+    let env = Envelope::new(1, Some(7), vec![b'X']);
     let serializer = BincodeSerializer;
     let bytes = serializer.serialize(&env).expect("serialization failed");
     // Use the default 4-byte big-endian length prefix for framing
@@ -88,6 +88,6 @@ async fn middleware_applied_in_reverse_order() {
     let (resp, _) = serializer
         .deserialize::<Envelope>(&frame)
         .expect("deserialize failed");
-    let (_, bytes) = resp.into_parts();
-    assert_eq!(bytes, vec![b'X', b'A', b'B', b'B', b'A']);
+    let parts = resp.into_parts();
+    assert_eq!(parts.msg, vec![b'X', b'A', b'B', b'B', b'A']);
 }

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -11,7 +11,7 @@ use bytes::BytesMut;
 use rstest::rstest;
 use wireframe::{
     Serializer,
-    app::WireframeApp,
+    app::{Packet, PacketParts, WireframeApp},
     frame::{FrameProcessor, LengthPrefixedProcessor},
     message::Message,
     serializer::BincodeSerializer,
@@ -21,22 +21,28 @@ use wireframe_testing::{drive_with_bincode, drive_with_frames};
 #[derive(bincode::Encode, bincode::BorrowDecode, PartialEq, Debug)]
 struct TestEnvelope {
     id: u32,
-    correlation_id: u64,
+    correlation_id: Option<u64>,
     msg: Vec<u8>,
 }
 
-impl wireframe::app::Packet for TestEnvelope {
+impl Packet for TestEnvelope {
     fn id(&self) -> u32 { self.id }
 
-    fn correlation_id(&self) -> u64 { self.correlation_id }
+    fn correlation_id(&self) -> Option<u64> { self.correlation_id }
 
-    fn into_parts(self) -> (u32, u64, Vec<u8>) { (self.id, self.correlation_id, self.msg) }
+    fn into_parts(self) -> PacketParts {
+        PacketParts {
+            id: self.id,
+            correlation_id: self.correlation_id,
+            msg: self.msg,
+        }
+    }
 
-    fn from_parts(id: u32, correlation_id: u64, msg: Vec<u8>) -> Self {
+    fn from_parts(parts: PacketParts) -> Self {
         Self {
-            id,
-            correlation_id,
-            msg,
+            id: parts.id,
+            correlation_id: parts.correlation_id,
+            msg: parts.msg,
         }
     }
 }
@@ -66,7 +72,7 @@ async fn handler_receives_message_and_echoes_response() {
     let msg_bytes = Echo(42).to_bytes().expect("encode failed");
     let env = TestEnvelope {
         id: 1,
-        correlation_id: 99,
+        correlation_id: Some(99),
         msg: msg_bytes,
     };
 
@@ -82,7 +88,7 @@ async fn handler_receives_message_and_echoes_response() {
     let (resp_env, _) = BincodeSerializer
         .deserialize::<TestEnvelope>(&frame)
         .expect("deserialize failed");
-    assert_eq!(resp_env.correlation_id, 99);
+    assert_eq!(resp_env.correlation_id, Some(99));
     let (echo, _) = Echo::from_bytes(&resp_env.msg).expect("decode echo failed");
     assert_eq!(echo, Echo(42));
     assert_eq!(called.load(Ordering::SeqCst), 1);
@@ -104,7 +110,7 @@ async fn multiple_frames_processed_in_sequence() {
             let msg_bytes = Echo(id).to_bytes().expect("encode failed");
             let env = TestEnvelope {
                 id: 1,
-                correlation_id: u64::from(id),
+                correlation_id: Some(u64::from(id)),
                 msg: msg_bytes,
             };
             let env_bytes = BincodeSerializer
@@ -139,8 +145,8 @@ async fn multiple_frames_processed_in_sequence() {
         .deserialize::<TestEnvelope>(&second)
         .expect("deserialize failed");
     let (echo2, _) = Echo::from_bytes(&env2.msg).expect("decode echo failed");
-    assert_eq!(env1.correlation_id, 1);
-    assert_eq!(env2.correlation_id, 2);
+    assert_eq!(env1.correlation_id, Some(1));
+    assert_eq!(env2.correlation_id, Some(2));
     assert_eq!(echo1, Echo(1));
     assert_eq!(echo2, Echo(2));
 }

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -135,8 +135,8 @@ impl CorrelationWorld {
     pub async fn process(&mut self) {
         let cid = self.cid;
         let stream: FrameStream<Envelope> = Box::pin(try_stream! {
-            yield Envelope::new(1, cid, vec![1]);
-            yield Envelope::new(1, cid, vec![2]);
+            yield Envelope::new(1, Some(cid), vec![1]);
+            yield Envelope::new(1, Some(cid), vec![2]);
         });
         let (queues, handle) = PushQueues::bounded(1, 1);
         let shutdown = CancellationToken::new();
@@ -150,6 +150,10 @@ impl CorrelationWorld {
     /// Panics if any frame has a `correlation_id` that does not match the
     /// expected value.
     pub fn verify(&self) {
-        assert!(self.frames.iter().all(|f| f.correlation_id() == self.cid));
+        assert!(
+            self.frames
+                .iter()
+                .all(|f| f.correlation_id() == Some(self.cid))
+        );
     }
 }


### PR DESCRIPTION
## Summary
- replace raw `correlation_id` fields with `Option<u64>` and add `PacketParts`
- flatten `Envelope` and propagate correlation IDs through middleware
- log `correlation_id` alongside message IDs for easier debugging

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68953cfe46648322978c741264be93a3