### PR TITLE
Document accept backoff configuration

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -59,3 +59,5 @@ the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
   Strategies for taming code complexity and refactoring.
 - [Documentation style guide](documentation-style-guide.md) Conventions for
   writing project documentation.
+- [Server configuration](server/configuration.md) Tuning accept loop backoff
+  behaviour and builder options.

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -1,0 +1,34 @@
+# Server configuration
+
+`WireframeServer` provides a builder API for adjusting runtime behaviour. This
+guide focuses on tuning the exponential backoff used when accepting connections
+fails.
+
+## Accept loop backoff
+
+The accept loop retries failed `accept()` calls using exponential backoff. Use
+`accept_backoff(initial_delay, max_delay)` to set both bounds in one call.
+These values are stored in `BackoffConfig`:
+
+- `initial_delay` – starting delay for the first retry, clamped to at least 1
+  millisecond.
+- `max_delay` – maximum delay for retries, never less than `initial_delay`.
+
+### Behaviour
+
+- If `initial_delay` exceeds `max_delay`, the values are swapped.
+- `max_delay` is raised to match `initial_delay` when required.
+
+### Example
+
+```rust
+use std::time::Duration;
+
+use wireframe::{app::WireframeApp, server::WireframeServer};
+
+let server = WireframeServer::new(|| WireframeApp::default())
+    .accept_backoff(Duration::from_millis(5), Duration::from_millis(500));
+```
+
+`accept_initial_delay` and `accept_max_delay` allow adjusting each parameter
+individually.

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -6,9 +6,9 @@ fails.
 
 ## Accept loop backoff
 
-The accept loop retries failed `accept()` calls using exponential backoff. Use
-`accept_backoff(initial_delay, max_delay)` to set both bounds in one call.
-These values are stored in `BackoffConfig`:
+The accept loop retries failed `accept()` calls using exponential backoff.
+`accept_backoff(initial_delay, max_delay)` sets both bounds in one call. These
+values are stored in `BackoffConfig`:
 
 - `initial_delay` – starting delay for the first retry, clamped to at least 1
   millisecond.

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -302,7 +302,7 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let server = WireframeServer::new(|| WireframeApp::default())(important - comment)
+    /// let server = WireframeServer::new(|| WireframeApp::default())
     ///     .accept_initial_delay(Duration::from_millis(5));
     /// ```
     #[must_use]
@@ -323,7 +323,7 @@ where
     ///
     /// use wireframe::{app::WireframeApp, server::WireframeServer};
     ///
-    /// let server = WireframeServer::new(|| WireframeApp::default())(important - comment)
+    /// let server = WireframeServer::new(|| WireframeApp::default())
     ///     .accept_max_delay(Duration::from_millis(500));
     /// ```
     #[must_use]

--- a/src/server/config/tests.rs
+++ b/src/server/config/tests.rs
@@ -209,8 +209,9 @@ fn test_accept_backoff_configuration(
     assert_eq!(server.backoff_config.max_delay, max);
 }
 
+/// Behaviour test verifying exponential delay doubling and capping.
 #[test]
-fn test_accept_exponential_backoff_behavior() {
+fn test_accept_exponential_backoff_doubles_and_caps() {
     use std::{
         thread,
         time::{Duration, Instant},


### PR DESCRIPTION
## Summary
- remove stray comments from accept delay examples
- document accept loop backoff and BackoffConfig in server guide
- clarify exponential backoff test naming

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command mmdc -p /tmp/tmpm31eo4p1.json -i /tmp/tmpap7_ciod/async_stream_2.mmd -o /tmp/tmpap7_ciod/async_stream_2.svg for file 'examples/async_stream.md' (diagram 2): Error: Failed to launch the browser process! /root/.cache/puppeteer/chrome-headless-shell/linux-131.0.6778.204/chrome-headless-shell-linux64/chrome-headless-shell: error while loading shared libraries: libXcomposite.so.1: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68963277cb6c83228122a225eebbf642

## Summary by Sourcery

Document the accept loop backoff configuration in the server guide, clean up stray example comments, and clarify the exponential backoff test naming

Documentation:
- Add a new server configuration guide detailing the accept loop exponential backoff and BackoffConfig
- Update the documentation table of contents to link to the server configuration guide

Tests:
- Rename the exponential backoff behavior test to test_accept_exponential_backoff_doubles_and_caps for clarity

Chores:
- Remove stray placeholder comments from the accept delay code examples