### PR TITLE
Replace free_port fixture with free_listener to avoid race

### DIFF
--- a/src/server/config/tests.rs
+++ b/src/server/config/tests.rs
@@ -20,7 +20,7 @@ use crate::server::test_util::{
     TestPreamble,
     bind_server,
     factory,
-    free_port,
+    free_listener,
     server_with_preamble,
 };
 
@@ -65,14 +65,18 @@ fn test_with_preamble_type_conversion(
 #[tokio::test]
 async fn test_bind_success(
     factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    free_port: SocketAddr,
+    free_listener: std::net::TcpListener,
 ) {
+    let addr = free_listener
+        .local_addr()
+        .expect("failed to read listener address");
+    drop(free_listener);
     let local_addr = WireframeServer::new(factory)
-        .bind(free_port)
+        .bind(addr)
         .expect("Failed to bind")
         .local_addr()
         .expect("local address missing");
-    assert_eq!(local_addr.ip(), free_port.ip());
+    assert_eq!(local_addr.ip(), addr.ip());
 }
 
 #[rstest]
@@ -84,10 +88,13 @@ fn test_local_addr_before_bind(factory: impl Fn() -> WireframeApp + Send + Sync 
 #[tokio::test]
 async fn test_local_addr_after_bind(
     factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    free_port: SocketAddr,
+    free_listener: std::net::TcpListener,
 ) {
-    let local_addr = bind_server(factory, free_port).local_addr().unwrap();
-    assert_eq!(local_addr.ip(), free_port.ip());
+    let local_addr = bind_server(factory, free_listener).local_addr().unwrap();
+    assert_eq!(
+        local_addr.ip(),
+        std::net::IpAddr::from(std::net::Ipv4Addr::LOCALHOST)
+    );
 }
 
 #[rstest]
@@ -128,7 +135,7 @@ async fn test_preamble_callback_registration(
 #[tokio::test]
 async fn test_method_chaining(
     factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    free_port: SocketAddr,
+    free_listener: std::net::TcpListener,
 ) {
     let callback_invoked = Arc::new(AtomicUsize::new(0));
     let counter = callback_invoked.clone();
@@ -143,7 +150,7 @@ async fn test_method_chaining(
             })
         })
         .on_preamble_decode_failure(|_: &DecodeError| {})
-        .bind(free_port)
+        .bind_listener(free_listener)
         .expect("Failed to bind");
     assert_eq!(server.worker_count(), 2);
     assert!(server.local_addr().is_some());
@@ -154,11 +161,11 @@ async fn test_method_chaining(
 #[tokio::test]
 async fn test_server_configuration_persistence(
     factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    free_port: SocketAddr,
+    free_listener: std::net::TcpListener,
 ) {
     let server = WireframeServer::new(factory)
         .workers(5)
-        .bind(free_port)
+        .bind_listener(free_listener)
         .expect("Failed to bind");
     assert_eq!(server.worker_count(), 5);
     assert!(server.local_addr().is_some());
@@ -176,7 +183,7 @@ fn test_extreme_worker_counts(factory: impl Fn() -> WireframeApp + Send + Sync +
 #[tokio::test]
 async fn test_bind_to_multiple_addresses(
     factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    free_port: SocketAddr,
+    free_listener: std::net::TcpListener,
 ) {
     let listener2 =
         std::net::TcpListener::bind(SocketAddr::new(std::net::Ipv4Addr::LOCALHOST.into(), 0))
@@ -188,7 +195,7 @@ async fn test_bind_to_multiple_addresses(
 
     let server = WireframeServer::new(factory);
     let server = server
-        .bind(free_port)
+        .bind_listener(free_listener)
         .expect("Failed to bind first address");
     let first = server.local_addr().expect("first bound address missing");
     let server = server.bind(addr2).expect("Failed to bind second address");

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -100,7 +100,7 @@ mod tests {
         app::WireframeApp,
         server::{
             WireframeServer,
-            test_util::{factory, free_port},
+            test_util::{factory, free_listener},
         },
     };
 
@@ -158,7 +158,7 @@ mod tests {
     #[tokio::test]
     async fn connection_panic_is_caught(
         factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-        free_port: std::net::SocketAddr,
+        free_listener: std::net::TcpListener,
     ) {
         let app_factory = move || {
             factory()
@@ -167,7 +167,7 @@ mod tests {
         };
         let server = WireframeServer::new(app_factory)
             .workers(1)
-            .bind(free_port)
+            .bind_listener(free_listener)
             .expect("bind");
         let addr = server
             .local_addr()

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -189,15 +189,15 @@ mod tests {
     };
 
     use super::*;
-    use crate::server::test_util::{bind_server, factory, free_port};
+    use crate::server::test_util::{bind_server, factory, free_listener};
 
     #[rstest]
     #[tokio::test]
     async fn test_run_with_immediate_shutdown(
         factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-        free_port: std::net::SocketAddr,
+        free_listener: std::net::TcpListener,
     ) {
-        let server = bind_server(factory, free_port);
+        let server = bind_server(factory, free_listener);
         let shutdown_future = async { tokio::time::sleep(Duration::from_millis(10)).await };
         let result = timeout(
             Duration::from_millis(1000),
@@ -212,9 +212,9 @@ mod tests {
     #[tokio::test]
     async fn test_server_graceful_shutdown_with_ctrl_c_simulation(
         factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-        free_port: std::net::SocketAddr,
+        free_listener: std::net::TcpListener,
     ) {
-        let server = bind_server(factory, free_port);
+        let server = bind_server(factory, free_listener);
         let (tx, rx) = oneshot::channel();
         let handle = tokio::spawn(async move {
             server
@@ -230,7 +230,7 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_multiple_worker_creation(free_port: std::net::SocketAddr) {
+    async fn test_multiple_worker_creation(free_listener: std::net::TcpListener) {
         let call_count = Arc::new(AtomicUsize::new(0));
         let clone = call_count.clone();
         let factory = move || {
@@ -239,7 +239,7 @@ mod tests {
         };
         let server = WireframeServer::new(factory)
             .workers(3)
-            .bind(free_port)
+            .bind_listener(free_listener)
             .expect("Failed to bind");
         let shutdown_future = async { tokio::time::sleep(Duration::from_millis(10)).await };
         let result = timeout(

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -1,6 +1,6 @@
 //! Test helpers shared across server modules.
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr, TcpListener as StdTcpListener};
 
 use bincode::{Decode, Encode};
 use rstest::fixture;
@@ -20,20 +20,21 @@ pub fn factory() -> impl Fn() -> WireframeApp + Send + Sync + Clone + 'static {
 }
 
 #[fixture]
-pub fn free_port() -> SocketAddr {
+/// Returns a bound listener on a free port.
+///
+/// Keeping the listener alive reserves the port, avoiding races where another
+/// process might claim it before the test is ready.
+pub fn free_listener() -> StdTcpListener {
     let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 0);
-    let listener = std::net::TcpListener::bind(addr).expect("failed to bind free port listener");
-    listener
-        .local_addr()
-        .expect("failed to read free port listener address")
+    StdTcpListener::bind(addr).expect("failed to bind free port listener")
 }
 
-pub fn bind_server<F>(factory: F, addr: SocketAddr) -> WireframeServer<F, ()>
+pub fn bind_server<F>(factory: F, std_listener: StdTcpListener) -> WireframeServer<F, ()>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
 {
     WireframeServer::new(factory)
-        .bind(addr)
+        .bind_listener(std_listener)
         .expect("Failed to bind")
 }
 


### PR DESCRIPTION
## Summary
- replace free_port test fixture with free_listener to reserve ports
- update server tests to accept TcpListener or bind_listener

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #258

------
https://chatgpt.com/codex/tasks/task_e_68968271b3f48322a1a492bf547f28d1

## Summary by Sourcery

Update test utilities and server tests to replace the free_port fixture with a bound TcpListener via a new free_listener fixture and bind_listener method, ensuring ports are reserved during test setup to avoid race conditions.

Enhancements:
- Replace free_port fixture with free_listener that returns a bound TcpListener to reserve ports and avoid races
- Introduce bind_listener method and update bind_server util to accept TcpListener instead of SocketAddr

Tests:
- Refactor server tests to use free_listener fixture and bind_listener, extracting addresses from the listener
- Update assertions in tests to compare IPs against the listener’s local address or localhost