### PR TITLE
Enforce compile-time binding for WireframeServer

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -33,7 +33,7 @@ pub type PreambleErrorCallback = Arc<dyn Fn(&DecodeError) + Send + Sync>;
 /// closure. The server listens for a shutdown signal using
 /// `tokio::signal::ctrl_c` and notifies all workers to stop
 /// accepting new connections.
-pub struct WireframeServer<F, T = ()>
+pub struct WireframeServer<F, T = (), const BOUND: bool = false>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
     // `Preamble` covers types implementing `BorrowDecode` for any lifetime,

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -28,7 +28,7 @@ pub fn free_port() -> SocketAddr {
         .expect("failed to read free port listener address")
 }
 
-pub fn bind_server<F>(factory: F, addr: SocketAddr) -> WireframeServer<F, ()>
+pub fn bind_server<F>(factory: F, addr: SocketAddr) -> WireframeServer<F, (), true>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
 {
@@ -37,7 +37,7 @@ where
         .expect("Failed to bind")
 }
 
-pub fn server_with_preamble<F>(factory: F) -> WireframeServer<F, TestPreamble>
+pub fn server_with_preamble<F>(factory: F) -> WireframeServer<F, TestPreamble, false>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
 {

--- a/tests/preamble.rs
+++ b/tests/preamble.rs
@@ -41,7 +41,7 @@ fn server_with_handlers<F, S, E>(
     factory: F,
     success: S,
     failure: E,
-) -> WireframeServer<F, HotlinePreamble>
+) -> WireframeServer<F, HotlinePreamble, false>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
     S: for<'a> Fn(&'a HotlinePreamble, &'a mut TcpStream) -> BoxFuture<'a, io::Result<()>>
@@ -58,7 +58,7 @@ where
 }
 
 /// Run the provided server while executing `block`.
-async fn with_running_server<F, T, Fut, B>(server: WireframeServer<F, T>, block: B)
+async fn with_running_server<F, T, Fut, B>(server: WireframeServer<F, T, false>, block: B)
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
     T: wireframe::preamble::Preamble,


### PR DESCRIPTION
## Summary
- add const-generic typestate to `WireframeServer`
- guard `run` APIs behind bound typestate and document panic invariant
- adjust helpers and tests for new typestate

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #263

------
https://chatgpt.com/codex/tasks/task_e_689682c8fe1c83229dcd608c7e5180d2

## Summary by Sourcery

Enforce compile-time binding for WireframeServer by introducing a const-generic typestate to track whether it’s bound, updating bind, bind_listener, and run APIs to only be available on a bound server, and adjusting tests and helpers to match the new signatures.

Enhancements:
- Add a const-generic boolean parameter to WireframeServer to statically track its binding state
- Make bind and bind_listener transition the server to the bound typestate and update run to require the bound state
- Document the panic invariant on run when attempting to execute an unbound server

Tests:
- Update helper functions and tests to use the new WireframeServer<B> typestate parameter