### PR TITLE
Clarify preamble handler docs and server errors

### DIFF
--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -1,6 +1,5 @@
 //! Binding configuration for [`WireframeServer`].
 
-use core::marker::PhantomData;
 use std::{
     net::{SocketAddr, TcpListener as StdTcpListener},
     sync::Arc,
@@ -92,7 +91,7 @@ where
             state: Bound {
                 listener: Arc::new(tokio),
             },
-            _preamble: PhantomData,
+            _preamble: self._preamble,
         })
     }
 }
@@ -177,7 +176,7 @@ where
             state: Bound {
                 listener: Arc::new(tokio),
             },
-            _preamble: PhantomData,
+            _preamble: self._preamble,
         })
     }
 }

--- a/src/server/config/preamble.rs
+++ b/src/server/config/preamble.rs
@@ -55,6 +55,7 @@ where
         /// Register a handler invoked when the connection preamble decodes successfully.
         ///
         /// The handler must implement [`crate::server::PreambleSuccessHandler`].
+        /// See [`crate::server::PreambleHandler`] for a ready-to-use alias.
         ///
         /// # Examples
         ///

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -64,7 +64,7 @@ async fn process_stream<F, T>(
             if let Some(handler) = on_success.as_ref()
                 && let Err(e) = handler(&preamble, &mut stream).await
             {
-                tracing::error!(error = ?e, ?peer_addr, "preamble handler error");
+                tracing::error!(error = %e, ?peer_addr, "preamble handler error");
             }
             let stream = RewindStream::new(leftover, stream);
             let app = (factory)();

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -5,6 +5,7 @@ use std::io;
 use thiserror::Error;
 
 /// Errors that may occur while configuring or running the server.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 pub enum ServerError {
     /// Binding or configuring the listener failed.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -56,7 +56,7 @@ impl<T, F> PreambleSuccessHandler<T> for F where
 {
 }
 
-/// Handler invoked when a connection preamble decodes successfully.
+/// [`PreambleSuccessHandler`] wrapped in `Arc`.
 pub type PreambleHandler<T> = Arc<dyn PreambleSuccessHandler<T>>;
 
 /// Handler invoked when decoding a connection preamble fails.


### PR DESCRIPTION
## Summary
- trim and clarify preamble handler documentation
- mark `ServerError` as non-exhaustive
- reuse existing `PhantomData` when rebinding

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689796199c5883228eb17280729d1396