### PR TITLE
Use bound listeners in server tests to avoid port races

### DIFF
--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -100,7 +100,7 @@ mod tests {
         app::WireframeApp,
         server::{
             WireframeServer,
-            test_util::{factory, free_port},
+            test_util::{factory, free_listener},
         },
     };
 
@@ -158,7 +158,7 @@ mod tests {
     #[tokio::test]
     async fn connection_panic_is_caught(
         factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-        free_port: std::net::SocketAddr,
+        free_listener: std::net::TcpListener,
     ) {
         let app_factory = move || {
             factory()
@@ -167,7 +167,7 @@ mod tests {
         };
         let server = WireframeServer::new(app_factory)
             .workers(1)
-            .bind(free_port)
+            .bind_listener(free_listener)
             .expect("bind");
         let addr = server
             .local_addr()


### PR DESCRIPTION
## Summary
- replace `free_port` fixture with `free_listener` that keeps the port bound
- adjust helpers and tests to bind servers with a `TcpListener`

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #258

------
https://chatgpt.com/codex/tasks/task_e_6899c162decc8322b0b7b32a672e64a8

## Summary by Sourcery

Use bound TCP listeners in server tests to avoid port races by replacing the free_port fixture with free_listener, adding bind_listener support, and updating test helpers and assertions accordingly

New Features:
- Add free_listener fixture returning a bound TcpListener for tests

Enhancements:
- Replace free_port fixture with free_listener to prevent port race conditions
- Update bind_server helper and all server tests to use bind_listener instead of bind with SocketAddr
- Adjust test assertions to derive expected addresses from the bound listener