### PR TITLE
Refactor listener binding and tighten address tests

### DIFF
--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -56,7 +56,7 @@ where
     /// Returns a [`ServerError`] if binding or configuring the listener fails.
     pub fn bind(self, addr: SocketAddr) -> Result<WireframeServer<F, T, Bound>, ServerError> {
         let std = StdTcpListener::bind(addr).map_err(ServerError::Bind)?;
-        self.bind_listener(std)
+        self.bind_existing_listener(std)
     }
 
     /// Bind to an existing `StdTcpListener`.
@@ -70,14 +70,14 @@ where
     ///
     /// let std = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
     /// let server = WireframeServer::new(|| WireframeApp::default())
-    ///     .bind_listener(std)
+    ///     .bind_existing_listener(std)
     ///     .expect("bind failed");
     /// assert!(server.local_addr().is_some());
     /// ```
     ///
     /// # Errors
     /// Returns a [`ServerError`] if configuring the listener fails.
-    pub fn bind_listener(
+    pub fn bind_existing_listener(
         self,
         std: StdTcpListener,
     ) -> Result<WireframeServer<F, T, Bound>, ServerError> {
@@ -142,7 +142,7 @@ where
     /// Returns a [`ServerError`] if binding or configuring the listener fails.
     pub fn bind(self, addr: SocketAddr) -> Result<Self, ServerError> {
         let std = StdTcpListener::bind(addr).map_err(ServerError::Bind)?;
-        self.bind_listener(std)
+        self.bind_existing_listener(std)
     }
 
     /// Rebind using an existing `StdTcpListener`.
@@ -159,13 +159,13 @@ where
     ///     .bind(addr)
     ///     .expect("bind failed");
     /// let std = StdTcpListener::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0))).unwrap();
-    /// let server = server.bind_listener(std).expect("rebind failed");
+    /// let server = server.bind_existing_listener(std).expect("rebind failed");
     /// assert!(server.local_addr().is_some());
     /// ```
     ///
     /// # Errors
     /// Returns a [`ServerError`] if configuring the listener fails.
-    pub fn bind_listener(self, std: StdTcpListener) -> Result<Self, ServerError> {
+    pub fn bind_existing_listener(self, std: StdTcpListener) -> Result<Self, ServerError> {
         std.set_nonblocking(true).map_err(ServerError::Bind)?;
         let tokio = TcpListener::from_std(std).map_err(ServerError::Bind)?;
         Ok(WireframeServer {

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -5,8 +5,8 @@
 //! TCP binding is provided via the [`binding`](self::binding) module; preamble
 //! behaviour is customized via the [`preamble`](self::preamble) module. The
 //! server may be constructed unbound and later bound using
-//! [`bind`](WireframeServer::bind) or [`bind_listener`](WireframeServer::bind_listener)
-//! on [`Unbound`] servers.
+//! [`bind`](WireframeServer::bind) or
+//! [`bind_existing_listener`](WireframeServer::bind_existing_listener) on [`Unbound`] servers.
 
 use core::marker::PhantomData;
 
@@ -52,7 +52,7 @@ where
     /// The worker count defaults to the number of available CPU cores (or 1 if
     /// this cannot be determined). The server is initially [`Unbound`]; call
     /// [`bind`](WireframeServer::bind) or
-    /// [`bind_listener`](WireframeServer::bind_listener)
+    /// [`bind_existing_listener`](WireframeServer::bind_existing_listener)
     /// (methods provided by the [`binding`](self::binding) module) before running the server.
     ///
     /// # Examples

--- a/src/server/config/tests.rs
+++ b/src/server/config/tests.rs
@@ -20,7 +20,6 @@ use crate::server::test_util::{
     TestPreamble,
     bind_server,
     factory,
-    free_addr,
     free_listener,
     listener_addr,
     server_with_preamble,
@@ -183,7 +182,8 @@ async fn test_bind_to_multiple_addresses(
     free_listener: std::net::TcpListener,
 ) {
     let addr1 = listener_addr(&free_listener);
-    let addr2 = free_addr();
+    let listener2 = crate::server::test_util::free_listener();
+    let addr2 = listener_addr(&listener2);
 
     let server = WireframeServer::new(factory);
     let server = server
@@ -191,6 +191,7 @@ async fn test_bind_to_multiple_addresses(
         .expect("Failed to bind first address");
     let first = server.local_addr().expect("first bound address missing");
     assert_eq!(first, addr1);
+    drop(listener2);
     let server = server.bind(addr2).expect("Failed to bind second address");
     let second = server.local_addr().expect("second bound address missing");
     assert_eq!(second, addr2);

--- a/src/server/connection.rs
+++ b/src/server/connection.rs
@@ -167,7 +167,7 @@ mod tests {
         };
         let server = WireframeServer::new(app_factory)
             .workers(1)
-            .bind_listener(free_listener)
+            .bind_existing_listener(free_listener)
             .expect("bind");
         let addr = server
             .local_addr()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -67,8 +67,8 @@ pub type PreambleErrorHandler = Arc<dyn Fn(&DecodeError) + Send + Sync + 'static
 /// The server carries a typestate `S` indicating whether it is
 /// [`Unbound`] (not yet bound to a TCP listener) or [`Bound`]. New
 /// servers start `Unbound` and must call [`binding::WireframeServer::bind`] or
-/// [`binding::WireframeServer::bind_listener`] before running. A worker task is spawned per
-/// thread; each receives its own `WireframeApp` from the provided factory
+/// [`binding::WireframeServer::bind_existing_listener`] before running. A worker task is spawned
+/// per thread; each receives its own `WireframeApp` from the provided factory
 /// closure. The server listens for a shutdown signal using
 /// `tokio::signal::ctrl_c` and notifies all workers to stop accepting new
 /// connections.

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -273,7 +273,7 @@ mod tests {
         };
         let server = WireframeServer::new(factory)
             .workers(3)
-            .bind_listener(free_listener)
+            .bind_existing_listener(free_listener)
             .expect("Failed to bind");
         let shutdown_future = async { tokio::time::sleep(Duration::from_millis(10)).await };
         let result = timeout(

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -56,29 +56,6 @@ pub fn listener_addr(listener: &StdTcpListener) -> SocketAddr {
         .expect("failed to get listener address")
 }
 
-/// Reserve a free local port and return its address.
-///
-/// A temporary listener is created and immediately dropped so the port may be
-/// rebound.
-///
-/// # Examples
-///
-/// ```
-/// use wireframe::server::test_util::free_addr;
-///
-/// let addr = free_addr();
-/// assert_eq!(addr.ip(), std::net::Ipv4Addr::LOCALHOST.into());
-/// ```
-#[cfg_attr(test, allow(dead_code, reason = "Used via path in tests"))]
-#[cfg_attr(not(test), expect(dead_code, reason = "Only used in tests"))]
-#[must_use]
-pub fn free_addr() -> SocketAddr {
-    let listener = free_listener();
-    let addr = listener_addr(&listener);
-    drop(listener);
-    addr
-}
-
 pub fn bind_server<F>(factory: F, listener: StdTcpListener) -> WireframeServer<F, (), Bound>
 where
     F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -34,6 +34,24 @@ pub fn free_listener() -> StdTcpListener {
     StdTcpListener::bind(addr).expect("Failed to bind free port listener")
 }
 
+/// Reserve a free local port and return its address.
+///
+/// Creates a temporary listener to obtain an ephemeral port, then immediately
+/// drops it so the port may be rebound. This is inherently subject to a
+/// time-of-check/time-of-use race; only use in tests.
+///
+/// # Examples
+///
+/// ```no_run
+/// use wireframe::server::test_util::free_addr;
+/// let addr = free_addr();
+/// assert_eq!(addr.ip(), std::net::Ipv4Addr::LOCALHOST.into());
+/// ```
+#[cfg(test)]
+#[allow(dead_code, reason = "Used only in doctests")]
+#[must_use]
+pub fn free_addr() -> SocketAddr { listener_addr(&free_listener()) }
+
 /// Extract the bound address from a listener.
 ///
 /// # Examples
@@ -45,7 +63,12 @@ pub fn free_listener() -> StdTcpListener {
 ///
 /// let listener = free_listener();
 /// let addr = listener_addr(&listener);
-/// assert_eq!(listener.local_addr().unwrap(), addr);
+/// assert_eq!(
+///     listener
+///         .local_addr()
+///         .expect("failed to get listener address"),
+///     addr
+/// );
 /// ```
 #[cfg_attr(test, allow(dead_code, reason = "Used via path in tests"))]
 #[cfg_attr(not(test), expect(dead_code, reason = "Only used in tests"))]

--- a/tests/preamble.rs
+++ b/tests/preamble.rs
@@ -69,7 +69,7 @@ where
     B: FnOnce(std::net::SocketAddr) -> Fut,
 {
     let listener = unused_listener();
-    let server = server.bind_listener(listener).expect("bind");
+    let server = server.bind_existing_listener(listener).expect("bind");
     let addr = server.local_addr().expect("addr");
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
     let handle = tokio::spawn(async move {

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -42,7 +42,7 @@ async fn readiness_receiver_dropped() {
     let listener = unused_listener();
     let server = WireframeServer::new(factory())
         .workers(1)
-        .bind_listener(listener)
+        .bind_existing_listener(listener)
         .unwrap();
 
     let addr = server.local_addr().expect("local addr missing");

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -39,7 +39,7 @@ impl PanicServer {
         let listener = unused_listener();
         let server = WireframeServer::new(factory)
             .workers(1)
-            .bind_listener(listener)
+            .bind_existing_listener(listener)
             .expect("bind");
         let addr = server.local_addr().expect("Failed to get server address");
         let (tx_shutdown, rx_shutdown) = oneshot::channel();


### PR DESCRIPTION
## Summary
- rename `bind_listener` to `bind_existing_listener` for clarity
- add helpers for listener address and free port
- assert bound ports and both addresses in server config tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6899c7dbc43c8322942d5a7d90e7cf04

## Summary by Sourcery

Refactor listener binding API to clarify existing listener binding, introduce test utilities for listener addresses, and strengthen address assertions in server tests

New Features:
- Add listener_addr utility to extract a listener's bound SocketAddr
- Add free_addr utility to reserve a free port and return its address

Enhancements:
- Rename bind_listener to bind_existing_listener throughout the server API and codebase

Documentation:
- Update documentation comments to reference bind_existing_listener

Tests:
- Tighten server config tests to assert full socket address equality
- Update tests across modules to use listener_addr, free_addr, and bind_existing_listener