### PR TITLE
Document compile-time binding requirement

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -1,9 +1,9 @@
 # Server configuration
 
 `WireframeServer` provides a builder API for adjusting runtime behaviour. The
-server employs a typestate to ensure that binding occurs before runtime:
-unbound servers do not expose `run` methods. This guide focuses on tuning the
-exponential backoff used when accepting connections fails.
+server employs a typestate (from `Unbound` to `Bound`) to ensure that binding
+occurs before runtime: unbound servers do not expose `run` methods. This guide
+focuses on tuning the exponential backoff used when accepting connections fails.
 
 ```rust,no_run
 use wireframe::{app::WireframeApp, server::WireframeServer};

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -5,10 +5,11 @@
 //! TCP binding is provided via the [`binding`](self::binding) module; preamble
 //! behaviour is customized via the [`preamble`](self::preamble) module. The
 //! server may be constructed unbound and later bound using
-//! [`bind`](WireframeServer::bind) or
-//! [`bind_existing_listener`](WireframeServer::bind_existing_listener) on
-//! [`Unbound`] servers. The `run` methods are available only once the server
-//! is [`Bound`](super::Bound), enforcing at compile time that the binding step
+//! [`bind`](super::WireframeServer::bind) or
+//! [`bind_existing_listener`](super::WireframeServer::bind_existing_listener) on
+//! [`Unbound`](super::Unbound) servers. The `run` methods are available only once
+//! the server is [`Bound`](super::Bound), enforcing at compile time that the
+//! binding step
 //! cannot be skipped.
 
 use core::marker::PhantomData;

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -129,6 +129,22 @@ where
     /// # }
     /// ```
     ///
+    /// Attempting to run a server without binding fails to compile:
+    ///
+    /// Binding specifies the network address for the server to listen on.
+    /// It is required so the server knows where to accept incoming connections.
+    ///
+    /// ```compile_fail
+    /// use wireframe::{app::WireframeApp, server::WireframeServer};
+    ///
+    /// async fn try_run_with_shutdown() {
+    ///     WireframeServer::new(|| WireframeApp::default())
+    ///         .run_with_shutdown(async {})
+    ///         .await
+    ///         .expect("unbound servers do not expose run_with_shutdown()");
+    /// }
+    /// ```
+    ///
     /// # Errors
     ///
     /// Returns a [`ServerError`] if runtime initialisation fails.


### PR DESCRIPTION
## Summary
- document compile-time guard against running an unbound `WireframeServer`
- clarify that `run`/`run_with_shutdown` are only available once bound
- note typestate binding in server configuration docs

Closes #263

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Error running command bun x --bun @mermaid-js/mermaid-cli ... FileNotFound: failed copying files from cache to destination for package chromium-bidi)*

------
https://chatgpt.com/codex/tasks/task_e_689b0a91fb4083229d44da3554e76160

## Summary by Sourcery

Document the compile-time binding requirement for WireframeServer using typestate and update documentation accordingly

Enhancements:
- Add a compile_fail example to enforce that run/run_with_shutdown cannot be called on an unbound server

Documentation:
- Clarify in runtime API docs that binding is required before running the server
- Update server configuration guide to mention typestate-binding ensures servers must be bound before use