### PR TITLE
Clarify run error docs and use expect in tests

### DIFF
--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -94,7 +94,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns a [`ServerError`] if runtime initialisation fails.
+    /// Returns an [`io::Error`] if the server was not bound to a listener.
+    /// Accept failures are retried with exponential back-off and do not
+    /// surface as errors.
     pub async fn run(self) -> Result<(), ServerError> {
         self.run_with_shutdown(async {
             let _ = signal::ctrl_c().await;
@@ -133,7 +135,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns a [`ServerError`] if runtime initialisation fails.
+    /// Returns an [`io::Error`] if the server was not bound to a listener.
+    /// Accept failures are retried with exponential back-off and do not
+    /// surface as errors.
     pub async fn run_with_shutdown<S>(self, shutdown: S) -> Result<(), ServerError>
     where
         S: Future<Output = ()> + Send,
@@ -316,7 +320,7 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
-        assert!(result.unwrap().is_ok());
+        assert!(result.expect("server did not finish in time").is_ok());
     }
 
     #[rstest]
@@ -359,7 +363,7 @@ mod tests {
         )
         .await;
         assert!(result.is_ok());
-        assert!(result.unwrap().is_ok());
+        assert!(result.expect("server did not finish in time").is_ok());
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary
- document that run and run_with_shutdown only fail when no listener is bound and accept errors are retried
- replace unwrap with expect in runtime tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689bc4a3406883229b90bbdf38275bd4

## Summary by Sourcery

Clarify error semantics in server runtime methods and improve test failure messages by switching from unwrap to expect

Enhancements:
- Document that run and run_with_shutdown only error when no listener is bound and that accept failures are retried without surfacing errors

Tests:
- Replace unwrap() with expect() in runtime tests to provide descriptive failure messages