### PR TITLE
Signal end of stream with terminator frame

### DIFF
--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -322,6 +322,11 @@ This allows the protocol implementation to serialize a proper error frame
 (e.g., an SQL error code) to send to the client before terminating the current
 operation, rather than just abruptly closing the connection.
 
+When a stream concludes successfully, the connection actor calls the
+`stream_end_frame` hook to produce a terminator frame with no payload. This
+explicit marker lets clients recognise that the logical stream has ended and
+helps avoid lingering resources or stalled state machines.
+
 ### 5.2 Dead Letter Queues (DLQ) for Guaranteed Pushing
 
 In some systems (e.g., financial transactions, critical audit logs), dropping a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -189,7 +189,7 @@ stream.
     is the unique request ID. For each message in a multi-packet response, this
     ID must match the original request's ID.
 
-  - [ ] Define a mechanism to signal the end of a multi-packet stream, such as
+  - [x] Define a mechanism to signal the end of a multi-packet stream, such as
     a frame with a specific flag and no payload.
 
 - [ ] **Core Library Implementation:**

--- a/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
+++ b/docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
@@ -89,6 +89,11 @@ async fn handle_large_query(req: Request) -> io::Result<Response<MyFrame>> {
 
 See `examples/async_stream.rs` for a runnable demonstration of this pattern.
 
+Completion of a streaming response is signalled by a protocol-defined
+terminator frame. The new `stream_end_frame` hook allows implementations to
+emit a frame with an explicit end-of-stream flag and no payload, ensuring
+clients can unambiguously detect when a logical stream has finished.
+
 #### The Connection Actor
 
 The underlying engine for this duplex communication is the

--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -1,8 +1,9 @@
 //! Cucumber test runner for integration tests.
 //!
-//! Orchestrates two distinct test suites:
+//! Orchestrates three distinct test suites:
 //! - `PanicWorld`: Tests server resilience during connection panics
 //! - `CorrelationWorld`: Tests correlation ID propagation in multi-frame responses
+//! - `StreamEndWorld`: Verifies end-of-stream signalling
 //!
 //! # Example
 //!
@@ -10,6 +11,7 @@
 //! ```text
 //! tests/features/connection_panic.feature    -> PanicWorld context
 //! tests/features/correlation_id.feature      -> CorrelationWorld context
+//! tests/features/stream_end.feature          -> StreamEndWorld context
 //! ```
 //!
 //! Each context provides specialised step definitions and state management
@@ -19,10 +21,11 @@ mod steps;
 mod world;
 
 use cucumber::World;
-use world::{CorrelationWorld, PanicWorld};
+use world::{CorrelationWorld, PanicWorld, StreamEndWorld};
 
 #[tokio::main]
 async fn main() {
     PanicWorld::run("tests/features/connection_panic.feature").await;
     CorrelationWorld::run("tests/features/correlation_id.feature").await;
+    StreamEndWorld::run("tests/features/stream_end.feature").await;
 }

--- a/tests/features/stream_end.feature
+++ b/tests/features/stream_end.feature
@@ -1,0 +1,4 @@
+Feature: Stream terminator frame
+  Scenario: Connection actor emits terminator after stream
+    When a streaming response completes
+    Then an end-of-stream frame is sent

--- a/tests/steps/mod.rs
+++ b/tests/steps/mod.rs
@@ -5,3 +5,4 @@
 
 mod correlation_steps;
 mod panic_steps;
+mod stream_end_steps;

--- a/tests/steps/stream_end_steps.rs
+++ b/tests/steps/stream_end_steps.rs
@@ -1,0 +1,10 @@
+//! Steps for stream terminator behavioural tests.
+use cucumber::{then, when};
+
+use crate::world::StreamEndWorld;
+
+#[when("a streaming response completes")]
+async fn when_stream(world: &mut StreamEndWorld) { world.process().await; }
+
+#[then("an end-of-stream frame is sent")]
+fn then_end(world: &mut StreamEndWorld) { world.verify(); }

--- a/tests/stream_end.rs
+++ b/tests/stream_end.rs
@@ -1,0 +1,40 @@
+//! Tests for explicit end-of-stream signalling.
+use std::sync::Arc;
+
+use async_stream::try_stream;
+use rstest::rstest;
+use tokio_util::sync::CancellationToken;
+use wireframe::{
+    connection::ConnectionActor,
+    hooks::{ConnectionContext, ProtocolHooks, WireframeProtocol},
+    push::PushQueues,
+    response::FrameStream,
+};
+
+struct TerminatorProto;
+
+impl WireframeProtocol for TerminatorProto {
+    type Frame = u8;
+    type ProtocolError = ();
+
+    fn stream_end_frame(&self, _ctx: &mut ConnectionContext) -> Option<Self::Frame> { Some(0) }
+}
+
+#[rstest]
+#[tokio::test]
+async fn emits_end_frame() {
+    let stream: FrameStream<u8> = Box::pin(try_stream! {
+        yield 1;
+        yield 2;
+    });
+
+    let (queues, handle) = PushQueues::bounded(1, 1);
+    let shutdown = CancellationToken::new();
+    let hooks = ProtocolHooks::from_protocol(&Arc::new(TerminatorProto));
+    let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);
+
+    let mut out = Vec::new();
+    actor.run(&mut out).await.expect("actor run failed");
+
+    assert_eq!(out, vec![1, 2, 0]);
+}


### PR DESCRIPTION
## Summary
- add `stream_end_frame` hook for protocol-defined terminators
- emit end-of-stream frame when response stream finishes
- document stream termination and mark roadmap item complete

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: Cannot find module 'puppeteer-core')*

------
https://chatgpt.com/codex/tasks/task_e_689e39e7aa708322aa4adefd6a8867d5