### PR TITLE
Fix rustdoc link warnings

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -201,7 +201,7 @@ pub struct PacketParts {
     payload: Vec<u8>,
 }
 
-/// Basic envelope type used by [`handle_connection`].
+/// Basic envelope type used by [`WireframeApp::handle_connection`].
 ///
 /// Incoming frames are deserialized into an `Envelope` containing the
 /// message identifier and raw payload bytes.
@@ -425,7 +425,7 @@ where
 
     /// Store a shared state value accessible to request extractors.
     ///
-    /// The value can later be retrieved using [`SharedState<T>`]. Registering
+    /// The value can later be retrieved using [`crate::extractor::SharedState`]. Registering
     /// another value of the same type overwrites the previous one.
     #[must_use]
     pub fn app_data<T>(mut self, state: T) -> Self

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -18,7 +18,7 @@ use crate::message::Message as WireMessage;
 /// Request context passed to extractors.
 ///
 /// This type contains metadata about the current connection and provides
-/// access to application state registered with [`WireframeApp`].
+/// access to application state registered with [`crate::app::WireframeApp`].
 #[derive(Default)]
 pub struct MessageRequest {
     /// Address of the peer that sent the current message.

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -34,7 +34,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
     /// Invoked when a request/response cycle completes.
     fn on_command_end(&self, _ctx: &mut ConnectionContext) {}
 
-    /// Called when a handler returns a [`WireframeError::Protocol`].
+    /// Called when a handler returns a [`crate::WireframeError::Protocol`].
     ///
     /// ```no_run
     /// use wireframe::{ConnectionContext, WireframeProtocol};

--- a/src/push.rs
+++ b/src/push.rs
@@ -26,7 +26,7 @@ impl<T> FrameLike for T where T: Send + 'static {}
 /// Default maximum pushes allowed per second when no custom rate is specified.
 const DEFAULT_PUSH_RATE: usize = 100;
 /// Highest supported rate for [`PushQueues::bounded_with_rate`].
-const MAX_PUSH_RATE: usize = 10_000;
+pub const MAX_PUSH_RATE: usize = 10_000;
 
 /// Priority level for outbound messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -57,7 +57,7 @@ where
     /// this cannot be determined). The server is initially [`Unbound`]; call
     /// [`bind`](WireframeServer::bind) or
     /// [`bind_existing_listener`](WireframeServer::bind_existing_listener)
-    /// (methods provided by the [`binding`](self::binding) module) before running the server.
+    /// (methods provided by the [`binding`] module) before running the server.
     ///
     /// # Examples
     ///

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,4 +1,4 @@
-//! Errors raised by [`WireframeServer`] operations.
+//! Errors raised by [`super::WireframeServer`] operations.
 
 use std::io;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -66,8 +66,8 @@ pub type PreambleErrorHandler = Arc<dyn Fn(&DecodeError) + Send + Sync + 'static
 ///
 /// The server carries a typestate `S` indicating whether it is
 /// [`Unbound`] (not yet bound to a TCP listener) or [`Bound`]. New
-/// servers start `Unbound` and must call [`binding::WireframeServer::bind`] or
-/// [`binding::WireframeServer::bind_existing_listener`] before running. A worker task is spawned
+/// servers start `Unbound` and must call [`WireframeServer::bind`] or
+/// [`WireframeServer::bind_existing_listener`] before running. A worker task is spawned
 /// per thread; each receives its own `WireframeApp` from the provided factory
 /// closure. The server listens for a shutdown signal using
 /// `tokio::signal::ctrl_c` and notifies all workers to stop accepting new

--- a/src/session.rs
+++ b/src/session.rs
@@ -82,7 +82,7 @@ impl<F: FrameLike> SessionRegistry<F> {
 
     /// Prune stale weak references, then collect the remaining live handles.
     ///
-    /// This method mutates the registry. Use [`prune`] from a maintenance task
+    /// This method mutates the registry. Use [`Self::prune`] from a maintenance task
     /// to clean up without collecting handles. `DashMap::retain` holds
     /// per-bucket write locks while iterating.
     #[must_use]
@@ -92,7 +92,7 @@ impl<F: FrameLike> SessionRegistry<F> {
 
     /// Prune stale weak references, then return the IDs of the live connections.
     ///
-    /// This method mutates the registry. Use [`prune`] from a maintenance task
+    /// This method mutates the registry. Use [`Self::prune`] from a maintenance task
     /// to clean up without collecting handles. `DashMap::retain` holds
     /// per-bucket write locks while iterating.
     #[must_use]


### PR DESCRIPTION
## Summary
- fix broken intra-doc links across app, extractor and server modules
- expose `MAX_PUSH_RATE` so docs reference a public constant
- clarify protocol hook documentation for `WireframeError::Protocol`

## Testing
- `cargo doc --no-deps`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e54048724832288ec3a7fea3daa6e