### PR TITLE
Fix rustdoc link warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ All notable changes to this project will be documented in this file.
   instead.
 - Breaking: Marked `ServerError` as `#[non_exhaustive]`. Downstream consumers
   must add a wildcard arm when matching it.
+- Exposed `MAX_PUSH_RATE` for configuring push queue rate limits.

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -253,8 +253,8 @@ token-bucket algorithm is ideal.
 use wireframe::push::{PushQueues, MAX_PUSH_RATE};
 
 // Configure a connection to allow at most MAX_PUSH_RATE pushes per second.
-let (queues, handle) =
-    PushQueues::<Frame>::bounded_with_rate(8, 8, Some(MAX_PUSH_RATE)).unwrap();
+let (queues, handle) = PushQueues::<Frame>::bounded_with_rate(8, 8, Some(MAX_PUSH_RATE))
+    .expect("rate within supported bounds");
 
 // Passing `None` disables rate limiting entirely:
 let (_unlimited, _handle) = PushQueues::<Frame>::bounded_no_rate_limit(8, 8);

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -250,11 +250,11 @@ token-bucket algorithm is ideal.
 **Implementation Sketch:**
 
 ```rust
-use wireframe::push::PushQueues;
+use wireframe::push::{PushQueues, MAX_PUSH_RATE};
 
-// Configure a connection to allow at most 100 pushes per second.
+// Configure a connection to allow at most MAX_PUSH_RATE pushes per second.
 let (queues, handle) =
-    PushQueues::<Frame>::bounded_with_rate(8, 8, Some(100)).unwrap();
+    PushQueues::<Frame>::bounded_with_rate(8, 8, Some(MAX_PUSH_RATE)).unwrap();
 
 // Passing `None` disables rate limiting entirely:
 let (_unlimited, _handle) = PushQueues::<Frame>::bounded_no_rate_limit(8, 8);

--- a/src/app.rs
+++ b/src/app.rs
@@ -201,7 +201,7 @@ pub struct PacketParts {
     payload: Vec<u8>,
 }
 
-/// Basic envelope type used by [`handle_connection`].
+/// Basic envelope type used by [`WireframeApp::handle_connection`].
 ///
 /// Incoming frames are deserialized into an `Envelope` containing the
 /// message identifier and raw payload bytes.
@@ -425,7 +425,7 @@ where
 
     /// Store a shared state value accessible to request extractors.
     ///
-    /// The value can later be retrieved using [`SharedState<T>`]. Registering
+    /// The value can later be retrieved using [`crate::extractor::SharedState`]. Registering
     /// another value of the same type overwrites the previous one.
     #[must_use]
     pub fn app_data<T>(mut self, state: T) -> Self

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -18,7 +18,7 @@ use crate::message::Message as WireMessage;
 /// Request context passed to extractors.
 ///
 /// This type contains metadata about the current connection and provides
-/// access to application state registered with [`WireframeApp`].
+/// access to application state registered with [`crate::app::WireframeApp`].
 #[derive(Default)]
 pub struct MessageRequest {
     /// Address of the peer that sent the current message.

--- a/src/extractor.rs
+++ b/src/extractor.rs
@@ -1,10 +1,8 @@
 //! Extractor and request context definitions.
 //!
-//! This module provides [`MessageRequest`], which carries connection
-//! metadata and shared application state, along with a set of extractor
-//! types. Implement [`FromMessageRequest`] for custom extractors to
-//! parse payload bytes or inspect connection info before your handler
-//! runs.
+//! [`MessageRequest`] carries connection metadata and shared application
+//! state. Implement [`FromMessageRequest`] for custom extractors to parse
+//! payload bytes or inspect connection info before your handler runs.
 
 use std::{
     any::{Any, TypeId},

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -34,7 +34,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
     /// Invoked when a request/response cycle completes.
     fn on_command_end(&self, _ctx: &mut ConnectionContext) {}
 
-    /// Called when a handler returns a [`WireframeError::Protocol`].
+    /// Called when a handler returns a [`crate::WireframeError::Protocol`].
     ///
     /// ```no_run
     /// use wireframe::{ConnectionContext, WireframeProtocol};

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -35,7 +35,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
 
     /// Called when a handler returns a [`crate::WireframeError::Protocol`].
     ///
-    /// ```no_run
+    /// ```rust,no_run
     /// use wireframe::{ConnectionContext, WireframeProtocol};
     ///
     /// struct MyProtocol;

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,9 +1,8 @@
-//! Internal protocol hooks called by the connection actor.
+//! Internal protocol hooks invoked by the connection actor.
 //!
-//! This module defines [`ProtocolHooks`] along with the public
-//! [`WireframeProtocol`] trait. `ProtocolHooks` stores optional callbacks
-//! invoked during connection output. Applications configure these callbacks via
-//! an implementation of [`WireframeProtocol`].
+//! [`ProtocolHooks`] stores optional callbacks executed during output, while
+//! [`WireframeProtocol`] exposes the public interface applications implement to
+//! configure those callbacks.
 
 use std::sync::Arc;
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -30,6 +30,9 @@ const DEFAULT_PUSH_RATE: usize = 100;
 /// Highest supported rate for [`PushQueues::bounded_with_rate`].
 pub const MAX_PUSH_RATE: usize = 10_000;
 
+// Compile-time guard: DEFAULT_PUSH_RATE must not exceed MAX_PUSH_RATE.
+const _: usize = MAX_PUSH_RATE - DEFAULT_PUSH_RATE;
+
 /// Priority level for outbound messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PushPriority {

--- a/src/push.rs
+++ b/src/push.rs
@@ -26,7 +26,7 @@ impl<T> FrameLike for T where T: Send + 'static {}
 /// Default maximum pushes allowed per second when no custom rate is specified.
 const DEFAULT_PUSH_RATE: usize = 100;
 /// Highest supported rate for [`PushQueues::bounded_with_rate`].
-const MAX_PUSH_RATE: usize = 10_000;
+pub const MAX_PUSH_RATE: usize = 10_000;
 
 /// Priority level for outbound messages.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,10 +1,11 @@
-//! Prioritized queues used for asynchronously pushing frames to a connection.
+//! Prioritised queues used for asynchronously pushing frames to a connection.
 //!
 //! `PushQueues` maintain separate high- and low-priority channels so
 //! background tasks can send messages without blocking the request/response
 //! cycle. Producers interact with these queues through a cloneable
 //! [`PushHandle`]. Queued frames are delivered in FIFO order within each
-//! priority level.
+//! priority level. An optional rate limiter caps throughput at
+//! [`MAX_PUSH_RATE`] pushes per second.
 
 use std::{
     sync::{Arc, Weak},
@@ -23,7 +24,8 @@ pub trait FrameLike: Send + 'static {}
 
 impl<T> FrameLike for T where T: Send + 'static {}
 
-/// Default maximum pushes allowed per second when no custom rate is specified.
+// Default maximum pushes per second when no custom rate is specified.
+// This is an internal implementation detail and may change.
 const DEFAULT_PUSH_RATE: usize = 100;
 /// Highest supported rate for [`PushQueues::bounded_with_rate`].
 pub const MAX_PUSH_RATE: usize = 10_000;

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -2,8 +2,8 @@
 //!
 //! Provides a fluent builder for configuring server instances. Worker counts,
 //! ready-signal channels and optional callbacks are set here. TCP binding lives
-//! in the [`binding`](self::binding) module; preamble behaviour is customised
-//! via [`preamble`](self::preamble). Servers start [`Unbound`](super::Unbound)
+//! in the [`binding`] module; preamble behaviour is customised
+//! via [`preamble`]. Servers start [`Unbound`](super::Unbound)
 //! and must call [`bind`](super::WireframeServer::bind) or
 //! [`bind_existing_listener`](super::WireframeServer::bind_existing_listener)
 //! before running. The `run` methods are available only once the server is

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -57,7 +57,7 @@ where
     /// this cannot be determined). The server is initially [`Unbound`]; call
     /// [`bind`](WireframeServer::bind) or
     /// [`bind_existing_listener`](WireframeServer::bind_existing_listener)
-    /// (methods provided by the [`binding`](self::binding) module) before running the server.
+    /// (methods provided by the [`binding`] module) before running the server.
     ///
     /// # Examples
     ///

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -1,16 +1,13 @@
 //! Configuration utilities for [`WireframeServer`].
 //!
-//! Provides a fluent builder for configuring `WireframeServer` instances.
-//! The builder exposes worker count tuning and ready-signal configuration here.
-//! TCP binding is provided via the [`binding`](self::binding) module; preamble
-//! behaviour is customized via the [`preamble`](self::preamble) module. The
-//! server may be constructed unbound and later bound using
-//! [`bind`](super::WireframeServer::bind) or
-//! [`bind_existing_listener`](super::WireframeServer::bind_existing_listener) on
-//! [`Unbound`](super::Unbound) servers. The `run` methods are available only once
-//! the server is [`Bound`](super::Bound), enforcing at compile time that the
-//! binding step
-//! cannot be skipped.
+//! Provides a fluent builder for configuring server instances. Worker counts,
+//! ready-signal channels and optional callbacks are set here. TCP binding lives
+//! in the [`binding`](self::binding) module; preamble behaviour is customised
+//! via [`preamble`](self::preamble). Servers start [`Unbound`](super::Unbound)
+//! and must call [`bind`](super::WireframeServer::bind) or
+//! [`bind_existing_listener`](super::WireframeServer::bind_existing_listener)
+//! before running. The `run` methods are available only once the server is
+//! [`Bound`](super::Bound).
 
 use core::marker::PhantomData;
 

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -1,4 +1,4 @@
-//! Errors raised by [`WireframeServer`] operations.
+//! Errors raised by [`super::WireframeServer`] operations.
 
 use std::io;
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -66,8 +66,8 @@ pub type PreambleErrorHandler = Arc<dyn Fn(&DecodeError) + Send + Sync + 'static
 ///
 /// The server carries a typestate `S` indicating whether it is
 /// [`Unbound`] (not yet bound to a TCP listener) or [`Bound`]. New
-/// servers start `Unbound` and must call [`binding::WireframeServer::bind`] or
-/// [`binding::WireframeServer::bind_existing_listener`] before running. A worker task is spawned
+/// servers start `Unbound` and must call [`WireframeServer::bind`] or
+/// [`WireframeServer::bind_existing_listener`] before running. A worker task is spawned
 /// per thread; each receives its own `WireframeApp` from the provided factory
 /// closure. The server listens for a shutdown signal using
 /// `tokio::signal::ctrl_c` and notifies all workers to stop accepting new

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,7 @@
-//! Tokio-based server for `WireframeApp` instances.
+//! Tokio-based server for [`WireframeApp`] instances.
 //!
-//! `WireframeServer` spawns worker tasks to accept TCP connections,
-//! optionally decoding a connection preamble before handing the
-//! stream to the application.
+//! [`WireframeServer`] spawns worker tasks to accept TCP connections and can
+//! decode an optional preamble before handing the stream to the application.
 
 use core::marker::PhantomData;
 use std::{io, sync::Arc};

--- a/src/session.rs
+++ b/src/session.rs
@@ -82,7 +82,7 @@ impl<F: FrameLike> SessionRegistry<F> {
 
     /// Prune stale weak references, then collect the remaining live handles.
     ///
-    /// This method mutates the registry. Use [`prune`] from a maintenance task
+    /// This method mutates the registry. Use [`Self::prune`] from a maintenance task
     /// to clean up without collecting handles. `DashMap::retain` holds
     /// per-bucket write locks while iterating.
     #[must_use]
@@ -92,7 +92,7 @@ impl<F: FrameLike> SessionRegistry<F> {
 
     /// Prune stale weak references, then return the IDs of the live connections.
     ///
-    /// This method mutates the registry. Use [`prune`] from a maintenance task
+    /// This method mutates the registry. Use [`Self::prune`] from a maintenance task
     /// to clean up without collecting handles. `DashMap::retain` holds
     /// per-bucket write locks while iterating.
     #[must_use]


### PR DESCRIPTION
## Summary
- fix broken intra-doc links across app, extractor and server modules
- expose `MAX_PUSH_RATE` so docs reference a public constant
- clarify protocol hook documentation for `WireframeError::Protocol`

## Testing
- `cargo doc --no-deps`
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e54048724832288ec3a7fea3daa6e

## Summary by Sourcery

Fix broken intra-doc links throughout the codebase and expose the MAX_PUSH_RATE constant for public documentation.

New Features:
- Expose MAX_PUSH_RATE as a public constant

Bug Fixes:
- Fix broken intra-doc links across app, extractor, server, session, hooks, and config modules

Enhancements:
- Clarify the protocol hook documentation for WireframeError::Protocol