### PR TITLE
Add package metadata to Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "wireframe"
 version = "0.1.0"
 edition = "2024"
+description = "An experimental Rust library that simplifies building servers and clients for custom binary protocols."
+license = "ISC"
+repository = "https://github.com/leynos/wireframe"
+readme = "README.md"
+keywords = ["async", "networking", "binary-protocol", "protocol", "tokio"]
+categories = ["network-programming", "asynchronous"]
+documentation = "https://docs.rs/wireframe"
 
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["async", "networking", "binary-protocol", "protocol", "tokio"]
 categories = ["network-programming", "asynchronous"]
 documentation = "https://docs.rs/wireframe"
 
+[package.metadata.docs.rs]
+features = ["metrics"]
+
 [dependencies]
 serde = { version = "1.0.219", features = ["derive"] }
 bincode = "2.0.1"


### PR DESCRIPTION
## Summary
- define crate description, licensing, repository, README, keywords, categories and docs URL in Cargo.toml

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint` *(fails: docs/efficiency-report.md line length and formatting)*
- `make nixie` *(fails: missing mermaid dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689e54cd80848322891c20ea54eaeab9