### PR TITLE
Use tracing in handle_error example

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -46,7 +46,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
     ///     type ProtocolError = String;
     ///
     ///     fn handle_error(&self, error: Self::ProtocolError, _ctx: &mut ConnectionContext) {
-    ///         tracing::error!("Protocol error: {error}");
+    ///         tracing::error!(error = %error, "Protocol error");
     ///         // Custom handling here
     ///     }
     /// }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -46,7 +46,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
     ///     type ProtocolError = String;
     ///
     ///     fn handle_error(&self, error: Self::ProtocolError, _ctx: &mut ConnectionContext) {
-    ///         eprintln!("Protocol error: {error}");
+    ///         tracing::error!("Protocol error: {error}");
     ///         // Custom handling here
     ///     }
     /// }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -46,7 +46,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
     ///     type ProtocolError = String;
     ///
     ///     fn handle_error(&self, error: Self::ProtocolError, _ctx: &mut ConnectionContext) {
-    ///         tracing::error!(error = %error, "Protocol error");
+    ///         tracing::error!(error = %error, "protocol error");
     ///         // Custom handling here
     ///     }
     /// }


### PR DESCRIPTION
## Summary
- replace `eprintln!` with `tracing::error!` in `handle_error` documentation example

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f8006ea248322b9ded1ac47f8fca0

## Summary by Sourcery

Documentation:
- Replace eprintln! with tracing::error! in the handle_error example