### PR TITLE
Add tracing dev dependency for doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ serial_test = "3.2.0"
 # Permit compatible bug fixes but block breaking updates
 cucumber = "0.21.1"
 metrics-util = "0.20.0"
+tracing = { version = "0.1.41", features = ["log", "log-always"] }
 tracing-test = "0.2.5"
 mockall = "0.13.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.10.1"
 log = "0.4.27"
 dashmap = "6.1.0"
 leaky-bucket = "1.1.2"
-tracing = { version = "^0.1.41", features = ["log", "log-always"] }
+tracing = { version = "0.1.41", features = ["log", "log-always"] }
 tracing-subscriber = "0.3"
 metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true, features = ["http-listener"] }
@@ -50,7 +50,7 @@ serial_test = "3.2.0"
 # Permit compatible bug fixes but block breaking updates
 cucumber = "0.21.1"
 metrics-util = "0.20.0"
-tracing = { version = "^0.1.41", features = ["log", "log-always"] }
+tracing = { version = "0.1.41", features = ["log", "log-always"] }
 tracing-test = "0.2.5"
 mockall = "0.13.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytes = "1.10.1"
 log = "0.4.27"
 dashmap = "6.1.0"
 leaky-bucket = "1.1.2"
-tracing = { version = "0.1.41", features = ["log", "log-always"] }
+tracing = { version = "^0.1.41", features = ["log", "log-always"] }
 tracing-subscriber = "0.3"
 metrics = { version = "0.24.2", optional = true }
 metrics-exporter-prometheus = { version = "0.17.2", optional = true, features = ["http-listener"] }
@@ -50,7 +50,7 @@ serial_test = "3.2.0"
 # Permit compatible bug fixes but block breaking updates
 cucumber = "0.21.1"
 metrics-util = "0.20.0"
-tracing = { version = "0.1.41", features = ["log", "log-always"] }
+tracing = { version = "^0.1.41", features = ["log", "log-always"] }
 tracing-test = "0.2.5"
 mockall = "0.13.1"
 


### PR DESCRIPTION
## Summary
- include tracing in dev-dependencies so doctest examples compile

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #321

------
https://chatgpt.com/codex/tasks/task_e_68a0aeab0f0083229eefaa1c76e2de49