### PR TITLE
Ignore tracing in protocol hooks doctest

### DIFF
--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -35,7 +35,7 @@ pub trait WireframeProtocol: Send + Sync + 'static {
 
     /// Called when a handler returns a [`crate::WireframeError::Protocol`].
     ///
-    /// ```rust,no_run
+    /// ```rust,ignore
     /// use wireframe::{ConnectionContext, WireframeProtocol};
     ///
     /// struct MyProtocol;


### PR DESCRIPTION
## Summary
- ignore the tracing-based doctest in `WireframeProtocol::handle_error`

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #321

------
https://chatgpt.com/codex/tasks/task_e_68a0811775b08322822430872e180293

## Summary by Sourcery

Bug Fixes:
- Mark the WireframeProtocol handle_error doctest as ignored instead of no_run to skip tracing-based tests