### PR TITLE
Group listener binding parameters

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -32,7 +32,7 @@ sequenceDiagram
   participant Tokio as TcpListener::from_std
   participant WSB as WireframeServer<F,T,Bound>
   participant Ready as oneshot::Sender<()>
-  participant Hooks as Preamble Handlers
+  participant Hooks as Preamble handlers
 
   Caller->>WS: bind(addr)
   WS->>OS: create StdTcpListener
@@ -47,6 +47,9 @@ sequenceDiagram
   note over Hooks,WSB: Preamble events trigger handlers during accept loop
   note over Ready,Caller: Send readiness signal when bound
 ```
+
+Readiness is signalled after all worker tasks have been spawned (at
+src/server/runtime.rs:221), immediately before the accept loop begins.
 
 ## Accept loop backoff
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -28,8 +28,7 @@ sequenceDiagram
   actor Caller
   participant WS as WireframeServer<F,T,Unbound>
   participant OS as StdTcpListener
-  participant Helper as bind_with_std_listener
-  participant Bind as bind_std_listener
+  participant Helper as bind_to_listener
   participant Tokio as TcpListener::from_std
   participant WSB as WireframeServer<F,T,Bound>
   participant Ready as oneshot::Sender<()>
@@ -37,13 +36,12 @@ sequenceDiagram
 
   Caller->>WS: bind(addr)
   WS->>OS: create StdTcpListener
-  WS->>Helper: bind_with_std_listener(OS)
-  Helper->>Bind: build BindConfig & delegate
-  Bind->>OS: set_nonblocking(true)
-  Bind->>Tokio: from_std(OS)
-  Bind->>Hooks: register preamble success/failure
-  Bind->>Ready: store readiness sender
-  Bind-->>WSB: return Bound server
+  WS->>Helper: bind_to_listener(OS)
+  Helper->>OS: set_nonblocking(true)
+  Helper->>Tokio: from_std(OS)
+  Helper->>Hooks: register preamble success/failure
+  Helper->>Ready: store readiness sender
+  Helper-->>WSB: return Bound server
   WSB-->>Caller: Bound instance
 
   note over Hooks,WSB: Preamble events trigger handlers during accept loop

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -30,7 +30,7 @@ struct BindConfig<F, T> {
 }
 
 fn bind_std_listener<F, T>(
-    cfg: BindConfig<F, T>,
+    config: BindConfig<F, T>,
     std: StdTcpListener,
 ) -> Result<WireframeServer<F, T, Bound>, ServerError>
 where
@@ -40,16 +40,16 @@ where
     std.set_nonblocking(true).map_err(ServerError::Bind)?;
     let tokio = TcpListener::from_std(std).map_err(ServerError::Bind)?;
     Ok(WireframeServer {
-        factory: cfg.factory,
-        workers: cfg.workers,
-        on_preamble_success: cfg.on_preamble_success,
-        on_preamble_failure: cfg.on_preamble_failure,
-        ready_tx: cfg.ready_tx,
-        backoff_config: cfg.backoff_config,
+        factory: config.factory,
+        workers: config.workers,
+        on_preamble_success: config.on_preamble_success,
+        on_preamble_failure: config.on_preamble_failure,
+        ready_tx: config.ready_tx,
+        backoff_config: config.backoff_config,
         state: Bound {
             listener: Arc::new(tokio),
         },
-        _preamble: cfg._preamble,
+        _preamble: config._preamble,
     })
 }
 
@@ -59,11 +59,11 @@ where
     T: Preamble,
     S: ServerState,
 {
-    fn bind_with_std_listener(
+    fn bind_to_listener(
         self,
         std: StdTcpListener,
     ) -> Result<WireframeServer<F, T, Bound>, ServerError> {
-        let cfg = BindConfig {
+        let config = BindConfig {
             factory: self.factory,
             workers: self.workers,
             on_preamble_success: self.on_preamble_success,
@@ -72,7 +72,7 @@ where
             backoff_config: self.backoff_config,
             _preamble: self._preamble,
         };
-        bind_std_listener(cfg, std)
+        bind_std_listener(config, std)
     }
 }
 
@@ -142,7 +142,7 @@ where
         self,
         std: StdTcpListener,
     ) -> Result<WireframeServer<F, T, Bound>, ServerError> {
-        self.bind_with_std_listener(std)
+        self.bind_to_listener(std)
     }
 }
 
@@ -215,6 +215,6 @@ where
     /// # Errors
     /// Returns a [`ServerError`] if configuring the listener fails.
     pub fn bind_existing_listener(self, std: StdTcpListener) -> Result<Self, ServerError> {
-        self.bind_with_std_listener(std)
+        self.bind_to_listener(std)
     }
 }

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -14,20 +14,10 @@ use crate::{
     server::{Bound, ServerError},
 };
 
-/// Helper trait alias for wireframe factory functions
-#[doc(hidden)]
-pub trait WireframeFactory: Fn() -> WireframeApp + Send + Sync + Clone + 'static {}
-impl<F> WireframeFactory for F where F: Fn() -> WireframeApp + Send + Sync + Clone + 'static {}
-
-/// Helper trait alias for wireframe preambles
-#[doc(hidden)]
-pub trait WireframePreamble: Preamble {}
-impl<T> WireframePreamble for T where T: Preamble {}
-
 impl<F, T, S> WireframeServer<F, T, S>
 where
-    F: WireframeFactory,
-    T: WireframePreamble,
+    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    T: Preamble,
     S: ServerState,
 {
     fn bind_to_listener(
@@ -65,8 +55,8 @@ where
 
 impl<F, T> WireframeServer<F, T, Unbound>
 where
-    F: WireframeFactory,
-    T: WireframePreamble,
+    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    T: Preamble,
 {
     /// Return `None` as the server is not bound.
     ///
@@ -135,8 +125,8 @@ where
 
 impl<F, T> WireframeServer<F, T, Bound>
 where
-    F: WireframeFactory,
-    T: WireframePreamble,
+    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    T: Preamble,
 {
     /// Returns the bound address, or `None` if retrieving it fails.
     ///

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -14,10 +14,20 @@ use crate::{
     server::{Bound, ServerError},
 };
 
+/// Helper trait alias for wireframe factory functions
+trait WireframeFactory: Fn() -> WireframeApp + Send + Sync + Clone + 'static {}
+impl<F> WireframeFactory for F where F: Fn() -> WireframeApp + Send + Sync + Clone + 'static {}
+
+/// Helper trait alias for wireframe preambles
+trait WireframePreamble: Preamble {}
+impl<T> WireframePreamble for T where T: Preamble {}
+
+/// Blanket impl uses private trait aliases; suppress visibility lint
+#[allow(private_bounds)]
 impl<F, T, S> WireframeServer<F, T, S>
 where
-    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    T: Preamble,
+    F: WireframeFactory,
+    T: WireframePreamble,
     S: ServerState,
 {
     fn bind_to_listener(
@@ -55,10 +65,12 @@ where
     }
 }
 
+/// Blanket impl uses private trait aliases; suppress visibility lint
+#[allow(private_bounds)]
 impl<F, T> WireframeServer<F, T, Unbound>
 where
-    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    T: Preamble,
+    F: WireframeFactory,
+    T: WireframePreamble,
 {
     /// Return `None` as the server is not bound.
     ///
@@ -125,10 +137,12 @@ where
     }
 }
 
+/// Blanket impl uses private trait aliases; suppress visibility lint
+#[allow(private_bounds)]
 impl<F, T> WireframeServer<F, T, Bound>
 where
-    F: Fn() -> WireframeApp + Send + Sync + Clone + 'static,
-    T: Preamble,
+    F: WireframeFactory,
+    T: WireframePreamble,
 {
     /// Returns the bound address, or `None` if retrieving it fails.
     ///


### PR DESCRIPTION
## Summary
- group listener binding arguments into `BindConfig`
- centralise listener setup with `bind_std_listener`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a428af8c888322a26bb54a0c3dbf7d

## Summary by Sourcery

Encapsulate listener binding parameters into a configuration struct and centralize the setup of a nonblocking Tokio listener to eliminate duplicated binding code.

Enhancements:
- Introduce BindConfig to group listener binding parameters into a single struct
- Add bind_std_listener helper to handle nonblocking setup and conversion to a Tokio listener
- Refactor existing bind methods to call bind_std_listener via a new bind_with_std_listener method