### PR TITLE
Add PushQueues builder

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -353,12 +353,19 @@ classDiagram
     class PushQueues~F~ {
         +high_priority_rx: mpsc::Receiver<F>
         +low_priority_rx: mpsc::Receiver<F>
-        +bounded(high_capacity: usize, low_capacity: usize): (PushQueues~F~, PushHandle~F~)
+        +builder(): PushQueuesBuilder~F~
         +recv(): Option<(PushPriority, F)>
+    }
+    class PushQueuesBuilder~F~ {
+        +high_capacity(cap: usize): PushQueuesBuilder~F~
+        +low_capacity(cap: usize): PushQueuesBuilder~F~
+        +rate(rate: Option<usize>): PushQueuesBuilder~F~
+        +dlq(tx: mpsc::Sender<F>): PushQueuesBuilder~F~
+        +build(): Result<(PushQueues~F~, PushHandle~F~), PushConfigError>
     }
 
     PushHandleInner <.. PushHandle~F~ : contains
-    PushQueues~F~ o-- PushHandle~F~ : bounded(high_capacity, low_capacity)
+    PushQueues~F~ o-- PushHandle~F~ : builder()
     PushHandle --> PushPriority
     PushHandle --> PushPolicy
     PushHandle --> PushError

--- a/docs/hardening-wireframe-a-guide-to-production-resilience.md
+++ b/docs/hardening-wireframe-a-guide-to-production-resilience.md
@@ -253,11 +253,20 @@ token-bucket algorithm is ideal.
 use wireframe::push::{PushQueues, MAX_PUSH_RATE};
 
 // Configure a connection to allow at most MAX_PUSH_RATE pushes per second.
-let (queues, handle) = PushQueues::<Frame>::bounded_with_rate(8, 8, Some(MAX_PUSH_RATE))
+let (queues, handle) = PushQueues::<Frame>::builder()
+    .high_capacity(8)
+    .low_capacity(8)
+    .rate(Some(MAX_PUSH_RATE))
+    .build()
     .expect("rate within supported bounds");
 
 // Passing `None` disables rate limiting entirely:
-let (_unlimited, _handle) = PushQueues::<Frame>::bounded_no_rate_limit(8, 8);
+let (_unlimited, _handle) = PushQueues::<Frame>::builder()
+    .high_capacity(8)
+    .low_capacity(8)
+    .rate(None)
+    .build()
+    .unwrap();
 
 // Inside PushHandle::push()
 async fn push(&self, frame: Frame) -> Result<(), PushError> {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -98,7 +98,11 @@ impl Default for FairnessConfig {
 /// use tokio_util::sync::CancellationToken;
 /// use wireframe::{connection::ConnectionActor, push::PushQueues};
 ///
-/// let (queues, handle) = PushQueues::<u8>::bounded(8, 8);
+/// let (queues, handle) = PushQueues::<u8>::builder()
+///     .high_capacity(8)
+///     .low_capacity(8)
+///     .build()
+///     .unwrap();
 /// let shutdown = CancellationToken::new();
 /// let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
 /// # drop(actor);
@@ -129,7 +133,11 @@ where
     /// use tokio_util::sync::CancellationToken;
     /// use wireframe::{connection::ConnectionActor, push::PushQueues};
     ///
-    /// let (queues, handle) = PushQueues::<u8>::bounded(4, 4);
+    /// let (queues, handle) = PushQueues::<u8>::builder()
+    ///     .high_capacity(4)
+    ///     .low_capacity(4)
+    ///     .build()
+    ///     .unwrap();
     /// let token = CancellationToken::new();
     /// let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, token);
     /// # drop(actor);

--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1,0 +1,17 @@
+//! Push subsystem.
+//!
+//! Provides queues and handles for asynchronous frame delivery.
+
+pub mod queues;
+
+pub use queues::{
+    FrameLike,
+    MAX_PUSH_RATE,
+    PushConfigError,
+    PushError,
+    PushHandle,
+    PushPolicy,
+    PushPriority,
+    PushQueues,
+    PushQueuesBuilder,
+};

--- a/src/push/queues.rs
+++ b/src/push/queues.rs
@@ -27,7 +27,7 @@ impl<T> FrameLike for T where T: Send + 'static {}
 // Default maximum pushes per second when no custom rate is specified.
 // This is an internal implementation detail and may change.
 const DEFAULT_PUSH_RATE: usize = 100;
-/// Highest supported rate for [`PushQueues::bounded_with_rate`].
+/// Highest supported rate for [`PushQueuesBuilder::rate`].
 pub const MAX_PUSH_RATE: usize = 10_000;
 
 // Compile-time guard: DEFAULT_PUSH_RATE must not exceed MAX_PUSH_RATE.
@@ -145,7 +145,12 @@ impl<F: FrameLike> PushHandle<F> {
     ///
     /// #[tokio::test]
     /// async fn example() {
-    ///     let (mut queues, handle) = PushQueues::bounded_with_rate(1, 1, Some(1));
+    ///     let (mut queues, handle) = PushQueues::builder()
+    ///         .high_capacity(1)
+    ///         .low_capacity(1)
+    ///         .rate(Some(1))
+    ///         .build()
+    ///         .unwrap();
     ///     handle.push_high_priority(42u8).await.unwrap();
     ///     let (priority, frame) = queues.recv().await.unwrap();
     ///     assert_eq!(priority, PushPriority::High);
@@ -171,7 +176,12 @@ impl<F: FrameLike> PushHandle<F> {
     ///
     /// #[tokio::test]
     /// async fn example() {
-    ///     let (mut queues, handle) = PushQueues::bounded_with_rate(1, 1, Some(1));
+    ///     let (mut queues, handle) = PushQueues::builder()
+    ///         .high_capacity(1)
+    ///         .low_capacity(1)
+    ///         .rate(Some(1))
+    ///         .build()
+    ///         .unwrap();
     ///     handle.push_low_priority(10u8).await.unwrap();
     ///     let (priority, frame) = queues.recv().await.unwrap();
     ///     assert_eq!(priority, PushPriority::Low);
@@ -219,8 +229,13 @@ impl<F: FrameLike> PushHandle<F> {
     /// #[tokio::test]
     /// async fn example() {
     ///     let (dlq_tx, mut dlq_rx) = mpsc::channel(1);
-    ///     let (mut queues, handle) =
-    ///         PushQueues::bounded_with_rate_dlq(1, 1, None, Some(dlq_tx)).unwrap();
+    ///     let (mut queues, handle) = PushQueues::builder()
+    ///         .high_capacity(1)
+    ///         .low_capacity(1)
+    ///         .rate(None)
+    ///         .dlq(Some(dlq_tx))
+    ///         .build()
+    ///         .unwrap();
     ///     handle.push_high_priority(1u8).await.unwrap();
     ///
     ///     handle
@@ -270,6 +285,66 @@ impl<F: FrameLike> PushHandle<F> {
     pub(crate) fn downgrade(&self) -> Weak<PushHandleInner<F>> { Arc::downgrade(&self.0) }
 }
 
+/// Builder for [`PushQueues`].
+#[derive(Debug)]
+pub struct PushQueuesBuilder<F> {
+    high_capacity: usize,
+    low_capacity: usize,
+    rate: Option<usize>,
+    dlq: Option<mpsc::Sender<F>>,
+}
+
+impl<F> Default for PushQueuesBuilder<F> {
+    fn default() -> Self {
+        Self {
+            high_capacity: 1,
+            low_capacity: 1,
+            rate: Some(DEFAULT_PUSH_RATE),
+            dlq: None,
+        }
+    }
+}
+
+impl<F: FrameLike> PushQueuesBuilder<F> {
+    /// Set the high-priority queue capacity.
+    #[must_use]
+    pub fn high_capacity(mut self, capacity: usize) -> Self {
+        self.high_capacity = capacity;
+        self
+    }
+
+    /// Set the low-priority queue capacity.
+    #[must_use]
+    pub fn low_capacity(mut self, capacity: usize) -> Self {
+        self.low_capacity = capacity;
+        self
+    }
+
+    /// Configure a global push rate limit.
+    #[must_use]
+    pub fn rate(mut self, rate: Option<usize>) -> Self {
+        self.rate = rate;
+        self
+    }
+
+    /// Provide a dead-letter queue sender for discarded frames.
+    #[must_use]
+    pub fn dlq(mut self, dlq: Option<mpsc::Sender<F>>) -> Self {
+        self.dlq = dlq;
+        self
+    }
+
+    /// Build queues with the configured settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PushConfigError::InvalidRate`] if `rate` is zero or exceeds
+    /// [`MAX_PUSH_RATE`].
+    pub fn build(self) -> Result<(PushQueues<F>, PushHandle<F>), PushConfigError> {
+        PushQueues::build_with_options(self.high_capacity, self.low_capacity, self.rate, self.dlq)
+    }
+}
+
 /// Receiver ends of the push queues stored by the connection actor.
 pub struct PushQueues<F> {
     pub(crate) high_priority_rx: mpsc::Receiver<F>,
@@ -287,123 +362,36 @@ impl<F: FrameLike> PushQueues<F> {
     ///
     /// #[tokio::test]
     /// async fn example() {
-    ///     let (mut queues, handle) = PushQueues::<u8>::bounded(1, 1);
+    ///     let (mut queues, handle) = PushQueues::<u8>::builder()
+    ///         .high_capacity(1)
+    ///         .low_capacity(1)
+    ///         .build()
+    ///         .unwrap();
     ///     handle.push_high_priority(7u8).await.unwrap();
     ///     let (priority, frame) = queues.recv().await.unwrap();
     ///     assert_eq!(priority, PushPriority::High);
     ///     assert_eq!(frame, 7);
     /// }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if an internal invariant is violated. This should never occur.
-    #[must_use]
-    pub fn bounded(high_capacity: usize, low_capacity: usize) -> (Self, PushHandle<F>) {
-        Self::bounded_with_rate_dlq(high_capacity, low_capacity, Some(DEFAULT_PUSH_RATE), None)
-            .expect("DEFAULT_PUSH_RATE is always valid")
-    }
-
-    /// Create queues with no rate limiting.
+    /// Begin building a new set of queues.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
     /// use wireframe::push::PushQueues;
     ///
-    /// let (_queues, handle) = PushQueues::<u8>::bounded_no_rate_limit(1, 1);
-    /// let _ = handle;
+    /// let (_queues, _handle) = PushQueues::<u8>::builder().build().unwrap();
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if an internal invariant is violated. This should never occur.
     #[must_use]
-    pub fn bounded_no_rate_limit(
-        high_capacity: usize,
-        low_capacity: usize,
-    ) -> (Self, PushHandle<F>) {
-        // `bounded_with_rate_dlq` only fails when given an invalid rate. Passing
-        // `None` disables rate limiting entirely so the call is infallible. The
-        // debug assertion guards against future regressions.
-        let result = Self::bounded_with_rate_dlq(high_capacity, low_capacity, None, None);
-        debug_assert!(result.is_ok(), "bounded_no_rate_limit should not fail");
-        result.expect("bounded_no_rate_limit should not fail")
-    }
+    pub fn builder() -> PushQueuesBuilder<F> { PushQueuesBuilder::default() }
 
-    /// Create queues with a custom rate limit in pushes per second.
-    ///
-    /// The limiter enforces fairness by allowing at most `rate` pushes
-    /// per second across all producers for the returned [`PushHandle`].
-    /// Pass `None` to disable rate limiting entirely.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`PushConfigError::InvalidRate`] if `rate` is zero or greater
-    /// than [`MAX_PUSH_RATE`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// use wireframe::push::PushQueues;
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let (mut queues, handle) = PushQueues::<u8>::bounded_with_rate(1, 1, Some(10)).unwrap();
-    ///     handle.push_low_priority(1u8).await.unwrap();
-    ///     let (_prio, frame) = queues.recv().await.unwrap();
-    ///     assert_eq!(frame, 1);
-    /// }
-    /// ```
-    pub fn bounded_with_rate(
-        high_capacity: usize,
-        low_capacity: usize,
-        rate: Option<usize>,
-    ) -> Result<(Self, PushHandle<F>), PushConfigError> {
-        Self::bounded_with_rate_dlq(high_capacity, low_capacity, rate, None)
-    }
-
-    /// Create queues with a custom rate limit and optional dead letter queue.
-    ///
-    /// Frames that would be dropped by [`try_push`](PushHandle::try_push) when
-    /// using [`PushPolicy::DropIfFull`] or [`PushPolicy::WarnAndDropIfFull`]
-    /// are routed to `dlq` if provided.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`PushConfigError::InvalidRate`] if `rate` is zero or greater
-    /// than [`MAX_PUSH_RATE`].
-    ///
-    /// # Examples
-    ///
-    /// ```rust,no_run
-    /// use tokio::sync::mpsc;
-    /// use wireframe::push::{PushPolicy, PushPriority, PushQueues};
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let (dlq_tx, mut dlq_rx) = mpsc::channel(1);
-    ///     let (mut queues, handle) =
-    ///         PushQueues::<u8>::bounded_with_rate_dlq(1, 1, None, Some(dlq_tx)).unwrap();
-    ///     handle.push_high_priority(1u8).await.unwrap();
-    ///     handle
-    ///         .try_push(2u8, PushPriority::High, PushPolicy::DropIfFull)
-    ///         .unwrap();
-    ///
-    ///     let (_, val) = queues.recv().await.unwrap();
-    ///     assert_eq!(val, 1);
-    ///     assert_eq!(dlq_rx.recv().await.unwrap(), 2);
-    /// }
-    /// ```
-    pub fn bounded_with_rate_dlq(
+    fn build_with_options(
         high_capacity: usize,
         low_capacity: usize,
         rate: Option<usize>,
         dlq: Option<mpsc::Sender<F>>,
     ) -> Result<(Self, PushHandle<F>), PushConfigError> {
         if let Some(r) = rate.filter(|r| *r == 0 || *r > MAX_PUSH_RATE) {
-            // Reject unsupported rates early to avoid building queues that cannot
-            // be used. The bounds prevent runaway resource consumption.
             return Err(PushConfigError::InvalidRate(r));
         }
         let (high_tx, high_rx) = mpsc::channel(high_capacity);
@@ -442,7 +430,11 @@ impl<F: FrameLike> PushQueues<F> {
     ///
     /// #[tokio::test]
     /// async fn example() {
-    ///     let (mut queues, handle) = PushQueues::bounded(1, 1);
+    ///     let (mut queues, handle) = PushQueues::builder()
+    ///         .high_capacity(1)
+    ///         .low_capacity(1)
+    ///         .build()
+    ///         .unwrap();
     ///     handle.push_high_priority(2u8).await.unwrap();
     ///     let (priority, frame) = queues.recv().await.unwrap();
     ///     assert_eq!(priority, PushPriority::High);
@@ -467,7 +459,11 @@ impl<F: FrameLike> PushQueues<F> {
     /// ```rust,no_run
     /// use wireframe::push::PushQueues;
     ///
-    /// let (mut queues, _handle) = PushQueues::<u8>::bounded(1, 1);
+    /// let (mut queues, _handle) = PushQueues::<u8>::builder()
+    ///     .high_capacity(1)
+    ///     .low_capacity(1)
+    ///     .build()
+    ///     .unwrap();
     /// queues.close();
     /// ```
     pub fn close(&mut self) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Weak};
 
 use dashmap::DashMap;
 
-use crate::push::{FrameLike, PushHandle, PushHandleInner};
+use crate::push::{FrameLike, PushHandle, queues::PushHandleInner};
 
 /// Identifier assigned to a connection.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/tests/advanced/concurrency_loom.rs
+++ b/tests/advanced/concurrency_loom.rs
@@ -21,7 +21,11 @@ fn concurrent_push_delivery() {
             .expect("failed to build tokio runtime");
 
         rt.block_on(async {
-            let (queues, handle) = PushQueues::bounded(1, 1);
+            let (queues, handle) = PushQueues::builder()
+                .high_capacity(1)
+                .low_capacity(1)
+                .build()
+                .unwrap();
             let token = CancellationToken::new();
 
             let out = loom::sync::Arc::new(loom::sync::Mutex::new(Vec::new()));

--- a/tests/advanced/interaction_fuzz.rs
+++ b/tests/advanced/interaction_fuzz.rs
@@ -23,7 +23,11 @@ enum Action {
 }
 
 async fn run_actions(actions: &[Action]) -> Vec<u8> {
-    let (queues, handle) = PushQueues::bounded(16, 16);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(16)
+        .low_capacity(16)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
 
     let mut stream: Option<FrameStream<u8, ()>> = None;

--- a/tests/async_stream.rs
+++ b/tests/async_stream.rs
@@ -23,7 +23,11 @@ fn frame_stream() -> impl futures::Stream<Item = Result<u8, WireframeError>> {
 #[rstest]
 #[tokio::test]
 async fn async_stream_frames_processed_in_order() {
-    let (queues, handle) = PushQueues::<u8>::bounded(8, 8);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(8)
+        .low_capacity(8)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let stream: FrameStream<u8> = Box::pin(frame_stream());
 

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -15,7 +15,11 @@ async fn stream_frames_carry_request_correlation_id() {
         yield Envelope::new(1, Some(cid), vec![1]);
         yield Envelope::new(1, Some(cid), vec![2]);
     });
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
     let mut out = Vec::new();

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -10,7 +10,11 @@ use wireframe_testing::{push_expect, recv_expect};
 /// Frames are delivered to queues matching their push priority.
 #[tokio::test]
 async fn frames_routed_to_correct_priority_queues() {
-    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
 
     push_expect!(handle.push_low_priority(1u8));
     push_expect!(handle.push_high_priority(2u8));
@@ -30,7 +34,11 @@ async fn frames_routed_to_correct_priority_queues() {
 /// return `PushError::Full` once the queue is at capacity.
 #[tokio::test]
 async fn try_push_respects_policy() {
-    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
 
     push_expect!(handle.push_high_priority(1u8));
     let result = handle.try_push(2u8, PushPriority::High, PushPolicy::ReturnErrorIfFull);
@@ -46,7 +54,11 @@ async fn try_push_respects_policy() {
 /// Push attempts return `Closed` when all queues have been shut down.
 #[tokio::test]
 async fn push_queues_error_on_closed() {
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
 
     let mut queues = queues;
     queues.close();
@@ -66,8 +78,12 @@ async fn push_queues_error_on_closed() {
 #[tokio::test]
 async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(2)
+        .low_capacity(2)
+        .rate(Some(1))
+        .build()
+        .expect("queue creation failed");
 
     match priority {
         PushPriority::High => push_expect!(handle.push_high_priority(1u8)),
@@ -100,8 +116,12 @@ async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
 #[tokio::test]
 async fn rate_limiter_allows_after_wait() {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(2)
+        .low_capacity(2)
+        .rate(Some(1))
+        .build()
+        .expect("queue creation failed");
     push_expect!(handle.push_high_priority(1u8));
     time::advance(Duration::from_secs(1)).await;
     push_expect!(handle.push_high_priority(2u8));
@@ -117,8 +137,12 @@ async fn rate_limiter_allows_after_wait() {
 #[tokio::test]
 async fn rate_limiter_shared_across_priorities() {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(2)
+        .low_capacity(2)
+        .rate(Some(1))
+        .build()
+        .expect("queue creation failed");
     push_expect!(handle.push_high_priority(1u8));
 
     let attempt = time::timeout(Duration::from_millis(10), handle.push_low_priority(2u8)).await;
@@ -139,7 +163,12 @@ async fn rate_limiter_shared_across_priorities() {
 #[tokio::test]
 async fn unlimited_queues_do_not_block() {
     time::pause();
-    let (mut queues, handle) = PushQueues::bounded_no_rate_limit(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .rate(None)
+        .build()
+        .unwrap();
     push_expect!(handle.push_high_priority(1u8));
     let res = time::timeout(Duration::from_millis(10), handle.push_low_priority(2u8)).await;
     assert!(res.is_ok(), "pushes should not block when unlimited");
@@ -154,8 +183,12 @@ async fn unlimited_queues_do_not_block() {
 #[tokio::test]
 async fn rate_limiter_allows_burst_within_capacity_and_blocks_excess() {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(4, 4, Some(3)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(4)
+        .low_capacity(4)
+        .rate(Some(3))
+        .build()
+        .expect("queue creation failed");
 
     for i in 0u8..3 {
         push_expect!(handle.push_high_priority(i));

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -38,7 +38,11 @@ fn push_policy_behaviour(
 ) {
     rt.block_on(async {
         while logger.pop().is_some() {}
-        let (mut queues, handle) = PushQueues::bounded(1, 1);
+        let (mut queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
 
         handle
             .push_high_priority(1u8)
@@ -76,7 +80,12 @@ fn push_policy_behaviour(
 fn dropped_frame_goes_to_dlq(rt: Runtime) {
     rt.block_on(async {
         let (dlq_tx, mut dlq_rx) = mpsc::channel(1);
-        let (mut queues, handle) = PushQueues::bounded_with_rate_dlq(1, 1, None, Some(dlq_tx))
+        let (mut queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .rate(None)
+            .dlq(Some(dlq_tx))
+            .build()
             .expect("queue creation failed");
 
         handle
@@ -135,7 +144,12 @@ fn dlq_error_scenarios<Setup, AssertFn>(
         let (dlq_tx, dlq_rx) = mpsc::channel(1);
         let mut dlq_rx = Some(dlq_rx);
         setup(&dlq_tx, &mut dlq_rx);
-        let (mut queues, handle) = PushQueues::bounded_with_rate_dlq(1, 1, None, Some(dlq_tx))
+        let (mut queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .rate(None)
+            .dlq(Some(dlq_tx))
+            .build()
             .expect("queue creation failed");
 
         handle

--- a/tests/session_registry.rs
+++ b/tests/session_registry.rs
@@ -17,7 +17,13 @@ fn registry() -> SessionRegistry<u8> { SessionRegistry::default() }
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
-fn push_setup() -> (PushQueues<u8>, PushHandle<u8>) { PushQueues::bounded(1, 1) }
+fn push_setup() -> (PushQueues<u8>, PushHandle<u8>) {
+    PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap()
+}
 
 /// Test that handles can be retrieved whilst the connection remains alive.
 #[rstest]

--- a/tests/stream_end.rs
+++ b/tests/stream_end.rs
@@ -23,7 +23,11 @@ async fn emits_end_frame() {
         yield 2;
     });
 
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let hooks = ProtocolHooks::from_protocol(&Arc::new(Terminator));
     let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);
@@ -51,7 +55,11 @@ async fn emits_no_end_frame_when_none() {
         yield 8;
     });
 
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let hooks = ProtocolHooks::from_protocol(&Arc::new(NoTerminator));
     let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -56,7 +56,11 @@ async fn builder_produces_protocol_hooks() {
         .with_protocol(protocol);
     let mut hooks = app.protocol_hooks();
 
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     hooks.on_connection_setup(handle, &mut ConnectionContext);
     drop(queues); // silence unused warnings
 
@@ -80,7 +84,11 @@ async fn connection_actor_uses_protocol_from_builder() {
         .with_protocol(protocol);
 
     let hooks = app.protocol_hooks();
-    let (queues, handle) = PushQueues::bounded(8, 8);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(8)
+        .low_capacity(8)
+        .build()
+        .unwrap();
     handle
         .push_high_priority(vec![1])
         .await

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -142,7 +142,11 @@ impl CorrelationWorld {
             yield Envelope::new(1, Some(cid), vec![1]);
             yield Envelope::new(1, Some(cid), vec![2]);
         });
-        let (queues, handle) = PushQueues::bounded(1, 1);
+        let (queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
         let shutdown = CancellationToken::new();
         let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
         actor.run(&mut self.frames).await.expect("actor run failed");
@@ -180,7 +184,11 @@ impl StreamEndWorld {
             yield 2u8;
         });
 
-        let (queues, handle) = PushQueues::bounded(1, 1);
+        let (queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
         let shutdown = CancellationToken::new();
         let hooks = ProtocolHooks::from_protocol(&Arc::new(Terminator));
         let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);


### PR DESCRIPTION
## Summary
- add `PushQueuesBuilder` for configuring queue capacities, rate limits, and DLQ
- remove deprecated `bounded*` constructors in favour of the builder API
- switch examples and tests to the builder API

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: KeyboardInterrupt while rendering diagrams)*

------
https://chatgpt.com/codex/tasks/task_e_68ac873c81788322bed6cee969ac8f28