### PR TITLE
Add builder for push queues

### DIFF
--- a/src/push/mod.rs
+++ b/src/push/mod.rs
@@ -1,0 +1,5 @@
+//! Prioritised queues used for asynchronously pushing frames to a connection.
+
+mod queues;
+
+pub use queues::*;

--- a/tests/advanced/concurrency_loom.rs
+++ b/tests/advanced/concurrency_loom.rs
@@ -21,7 +21,8 @@ fn concurrent_push_delivery() {
             .expect("failed to build tokio runtime");
 
         rt.block_on(async {
-            let (queues, handle) = PushQueues::bounded(1, 1);
+            let (queues, handle) =
+                PushQueues::builder().high_capacity(1).low_capacity(1).build().unwrap();
             let token = CancellationToken::new();
 
             let out = loom::sync::Arc::new(loom::sync::Mutex::new(Vec::new()));

--- a/tests/advanced/interaction_fuzz.rs
+++ b/tests/advanced/interaction_fuzz.rs
@@ -23,7 +23,11 @@ enum Action {
 }
 
 async fn run_actions(actions: &[Action]) -> Vec<u8> {
-    let (queues, handle) = PushQueues::bounded(16, 16);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(16)
+        .low_capacity(16)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
 
     let mut stream: Option<FrameStream<u8, ()>> = None;

--- a/tests/async_stream.rs
+++ b/tests/async_stream.rs
@@ -23,7 +23,11 @@ fn frame_stream() -> impl futures::Stream<Item = Result<u8, WireframeError>> {
 #[rstest]
 #[tokio::test]
 async fn async_stream_frames_processed_in_order() {
-    let (queues, handle) = PushQueues::<u8>::bounded(8, 8);
+    let (queues, handle) = PushQueues::<u8>::builder()
+        .high_capacity(8)
+        .low_capacity(8)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let stream: FrameStream<u8> = Box::pin(frame_stream());
 

--- a/tests/connection_actor.rs
+++ b/tests/connection_actor.rs
@@ -22,7 +22,13 @@ use wireframe_testing::push_expect;
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
-fn queues() -> (PushQueues<u8>, wireframe::push::PushHandle<u8>) { PushQueues::bounded(8, 8) }
+fn queues() -> (PushQueues<u8>, wireframe::push::PushHandle<u8>) {
+    PushQueues::builder()
+        .high_capacity(8)
+        .low_capacity(8)
+        .build()
+        .unwrap()
+}
 
 #[fixture]
 #[allow(
@@ -380,7 +386,11 @@ async fn interleaved_shutdown_during_stream(
 #[tokio::test]
 #[serial]
 async fn push_queue_exhaustion_backpressure() {
-    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     push_expect!(handle.push_high_priority(1), "push high-priority");
 
     let blocked = timeout(Duration::from_millis(50), handle.push_high_priority(2)).await;
@@ -467,7 +477,11 @@ async fn graceful_shutdown_waits_for_tasks() {
 
     let mut handles = Vec::new();
     for _ in 0..5 {
-        let (queues, handle) = PushQueues::<u8>::bounded(1, 1);
+        let (queues, handle) = PushQueues::<u8>::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
         let mut actor: ConnectionActor<_, ()> =
             ConnectionActor::new(queues, handle.clone(), None, token.clone());
         handles.push(handle);

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -15,7 +15,11 @@ async fn stream_frames_carry_request_correlation_id() {
         yield Envelope::new(1, Some(cid), vec![1]);
         yield Envelope::new(1, Some(cid), vec![2]);
     });
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
     let mut out = Vec::new();

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -10,7 +10,11 @@ use wireframe_testing::{push_expect, recv_expect};
 /// Frames are delivered to queues matching their push priority.
 #[tokio::test]
 async fn frames_routed_to_correct_priority_queues() {
-    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
 
     push_expect!(handle.push_low_priority(1u8));
     push_expect!(handle.push_high_priority(2u8));
@@ -30,7 +34,11 @@ async fn frames_routed_to_correct_priority_queues() {
 /// return `PushError::Full` once the queue is at capacity.
 #[tokio::test]
 async fn try_push_respects_policy() {
-    let (mut queues, handle) = PushQueues::bounded(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
 
     push_expect!(handle.push_high_priority(1u8));
     let result = handle.try_push(2u8, PushPriority::High, PushPolicy::ReturnErrorIfFull);
@@ -46,7 +54,11 @@ async fn try_push_respects_policy() {
 /// Push attempts return `Closed` when all queues have been shut down.
 #[tokio::test]
 async fn push_queues_error_on_closed() {
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
 
     let mut queues = queues;
     queues.close();
@@ -66,8 +78,12 @@ async fn push_queues_error_on_closed() {
 #[tokio::test]
 async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(2)
+        .low_capacity(2)
+        .rate(Some(1))
+        .build()
+        .expect("queue creation failed");
 
     match priority {
         PushPriority::High => push_expect!(handle.push_high_priority(1u8)),
@@ -100,8 +116,12 @@ async fn rate_limiter_blocks_when_exceeded(#[case] priority: PushPriority) {
 #[tokio::test]
 async fn rate_limiter_allows_after_wait() {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(2)
+        .low_capacity(2)
+        .rate(Some(1))
+        .build()
+        .expect("queue creation failed");
     push_expect!(handle.push_high_priority(1u8));
     time::advance(Duration::from_secs(1)).await;
     push_expect!(handle.push_high_priority(2u8));
@@ -117,8 +137,12 @@ async fn rate_limiter_allows_after_wait() {
 #[tokio::test]
 async fn rate_limiter_shared_across_priorities() {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(2, 2, Some(1)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(2)
+        .low_capacity(2)
+        .rate(Some(1))
+        .build()
+        .expect("queue creation failed");
     push_expect!(handle.push_high_priority(1u8));
 
     let attempt = time::timeout(Duration::from_millis(10), handle.push_low_priority(2u8)).await;
@@ -139,7 +163,12 @@ async fn rate_limiter_shared_across_priorities() {
 #[tokio::test]
 async fn unlimited_queues_do_not_block() {
     time::pause();
-    let (mut queues, handle) = PushQueues::bounded_no_rate_limit(1, 1);
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .rate(None)
+        .build()
+        .unwrap();
     push_expect!(handle.push_high_priority(1u8));
     let res = time::timeout(Duration::from_millis(10), handle.push_low_priority(2u8)).await;
     assert!(res.is_ok(), "pushes should not block when unlimited");
@@ -154,8 +183,12 @@ async fn unlimited_queues_do_not_block() {
 #[tokio::test]
 async fn rate_limiter_allows_burst_within_capacity_and_blocks_excess() {
     time::pause();
-    let (mut queues, handle) =
-        PushQueues::bounded_with_rate(4, 4, Some(3)).expect("queue creation failed");
+    let (mut queues, handle) = PushQueues::builder()
+        .high_capacity(4)
+        .low_capacity(4)
+        .rate(Some(3))
+        .build()
+        .expect("queue creation failed");
 
     for i in 0u8..3 {
         push_expect!(handle.push_high_priority(i));

--- a/tests/push_policies.rs
+++ b/tests/push_policies.rs
@@ -38,7 +38,11 @@ fn push_policy_behaviour(
 ) {
     rt.block_on(async {
         while logger.pop().is_some() {}
-        let (mut queues, handle) = PushQueues::bounded(1, 1);
+        let (mut queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
 
         handle
             .push_high_priority(1u8)
@@ -76,7 +80,12 @@ fn push_policy_behaviour(
 fn dropped_frame_goes_to_dlq(rt: Runtime) {
     rt.block_on(async {
         let (dlq_tx, mut dlq_rx) = mpsc::channel(1);
-        let (mut queues, handle) = PushQueues::bounded_with_rate_dlq(1, 1, None, Some(dlq_tx))
+        let (mut queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .rate(None)
+            .dlq(Some(dlq_tx))
+            .build()
             .expect("queue creation failed");
 
         handle
@@ -135,7 +144,12 @@ fn dlq_error_scenarios<Setup, AssertFn>(
         let (dlq_tx, dlq_rx) = mpsc::channel(1);
         let mut dlq_rx = Some(dlq_rx);
         setup(&dlq_tx, &mut dlq_rx);
-        let (mut queues, handle) = PushQueues::bounded_with_rate_dlq(1, 1, None, Some(dlq_tx))
+        let (mut queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .rate(None)
+            .dlq(Some(dlq_tx))
+            .build()
             .expect("queue creation failed");
 
         handle

--- a/tests/session_registry.rs
+++ b/tests/session_registry.rs
@@ -17,7 +17,13 @@ fn registry() -> SessionRegistry<u8> { SessionRegistry::default() }
     unused_braces,
     reason = "rustc false positive for single line rstest fixtures"
 )]
-fn push_setup() -> (PushQueues<u8>, PushHandle<u8>) { PushQueues::bounded(1, 1) }
+fn push_setup() -> (PushQueues<u8>, PushHandle<u8>) {
+    PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap()
+}
 
 /// Test that handles can be retrieved whilst the connection remains alive.
 #[rstest]

--- a/tests/stream_end.rs
+++ b/tests/stream_end.rs
@@ -23,7 +23,11 @@ async fn emits_end_frame() {
         yield 2;
     });
 
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let hooks = ProtocolHooks::from_protocol(&Arc::new(Terminator));
     let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);
@@ -51,7 +55,11 @@ async fn emits_no_end_frame_when_none() {
         yield 8;
     });
 
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     let shutdown = CancellationToken::new();
     let hooks = ProtocolHooks::from_protocol(&Arc::new(NoTerminator));
     let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -56,7 +56,11 @@ async fn builder_produces_protocol_hooks() {
         .with_protocol(protocol);
     let mut hooks = app.protocol_hooks();
 
-    let (queues, handle) = PushQueues::bounded(1, 1);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(1)
+        .low_capacity(1)
+        .build()
+        .unwrap();
     hooks.on_connection_setup(handle, &mut ConnectionContext);
     drop(queues); // silence unused warnings
 
@@ -80,7 +84,11 @@ async fn connection_actor_uses_protocol_from_builder() {
         .with_protocol(protocol);
 
     let hooks = app.protocol_hooks();
-    let (queues, handle) = PushQueues::bounded(8, 8);
+    let (queues, handle) = PushQueues::builder()
+        .high_capacity(8)
+        .low_capacity(8)
+        .build()
+        .unwrap();
     handle
         .push_high_priority(vec![1])
         .await

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -142,7 +142,11 @@ impl CorrelationWorld {
             yield Envelope::new(1, Some(cid), vec![1]);
             yield Envelope::new(1, Some(cid), vec![2]);
         });
-        let (queues, handle) = PushQueues::bounded(1, 1);
+        let (queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
         let shutdown = CancellationToken::new();
         let mut actor = ConnectionActor::new(queues, handle, Some(stream), shutdown);
         actor.run(&mut self.frames).await.expect("actor run failed");
@@ -180,7 +184,11 @@ impl StreamEndWorld {
             yield 2u8;
         });
 
-        let (queues, handle) = PushQueues::bounded(1, 1);
+        let (queues, handle) = PushQueues::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .unwrap();
         let shutdown = CancellationToken::new();
         let hooks = ProtocolHooks::from_protocol(&Arc::new(Terminator));
         let mut actor = ConnectionActor::with_hooks(queues, handle, Some(stream), shutdown, hooks);


### PR DESCRIPTION
## Summary
- add `PushQueuesBuilder` with configuration setters
- deprecate `bounded*` constructors and expose `PushQueues::builder`
- update tests to use the new builder

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aeba8d630c8322bcab55de80b2ef06

## Summary by Sourcery

Introduce a builder pattern for PushQueues to allow flexible configuration of capacities, rate limiting, and dead-letter queues, deprecate the old constructors in favor of PushQueues::builder, and update tests and docs accordingly.

New Features:
- Add PushQueuesBuilder with methods for configuring queue capacities, rate limits, and optional dead-letter queue

Enhancements:
- Deprecate legacy bounded*, bounded_with_rate, and bounded_with_rate_dlq constructors in favor of the new builder
- Expose PushQueues::builder for fluent queue and handle construction
- Simplify internal building logic by consolidating constructors into builder implementation

Tests:
- Update all existing tests and examples to use the new builder API instead of deprecated constructors