### PR TITLE
Expose length codec helper and streamline frame decoding tests

### DIFF
--- a/docs/asynchronous-outbound-messaging-design.md
+++ b/docs/asynchronous-outbound-messaging-design.md
@@ -745,11 +745,12 @@ features of the 1.0 release.
 
 ```rust
 // Codec stack with explicit frame-size limits and fragmentation.
-use tokio_util::codec::LengthDelimitedCodec;
+use wireframe::app::WireframeApp;
 const MAX_FRAME: usize = 64 * 1024;
-let codec = LengthDelimitedCodec::builder()
-    .max_frame_length(MAX_FRAME) // 64 KiB cap to prevent OOM
-    .new_codec();
+let app = WireframeApp::new()
+    .expect("failed to create app")
+    .buffer_capacity(MAX_FRAME);
+let codec = app.length_codec();
 
 // Wrap the length-delimited frames with the fragmentation adapter.
 // Pseudocode pending actual adapter API naming:

--- a/docs/generic-message-fragmentation-and-re-assembly-design.md
+++ b/docs/generic-message-fragmentation-and-re-assembly-design.md
@@ -166,13 +166,7 @@ codec chain via the `WireframeApp` builder.
 WireframeServer::new(|| {
     let mut app = WireframeApp::new();
     app
-        .codec({
-            // Match the application buffer capacity to avoid default 8 MiB limits.
-            let cap = app.buffer_capacity();
-            LengthDelimitedCodec::builder()
-                .max_frame_length(cap)
-                .new_codec()
-        })
+        .codec(app.length_codec())
         .codec(FragmentAdapter::new(MySqlStrategy::new()))
         .route(/* ... */)
 })

--- a/src/app/connection.rs
+++ b/src/app/connection.rs
@@ -39,7 +39,8 @@ where
 {
     /// Construct a length-delimited codec capped by the application's buffer
     /// capacity.
-    fn new_length_codec(&self) -> LengthDelimitedCodec {
+    #[must_use]
+    pub fn length_codec(&self) -> LengthDelimitedCodec {
         LengthDelimitedCodec::builder()
             .max_frame_length(self.buffer_capacity)
             .new_codec()
@@ -63,7 +64,7 @@ where
             .serializer
             .serialize(msg)
             .map_err(SendError::Serialize)?;
-        let mut codec = self.new_length_codec();
+        let mut codec = self.length_codec();
         let mut framed = BytesMut::with_capacity(bytes.len() + 4);
         codec
             .encode(bytes.into(), &mut framed)
@@ -166,7 +167,7 @@ where
     where
         W: AsyncRead + AsyncWrite + Unpin,
     {
-        let codec = self.new_length_codec();
+        let codec = self.length_codec();
         let mut framed = Framed::new(stream, codec);
         framed.read_buffer_mut().reserve(self.buffer_capacity);
         let mut deser_failures = 0u32;

--- a/src/frame/format.rs
+++ b/src/frame/format.rs
@@ -104,3 +104,26 @@ impl LengthFormat {
 impl Default for LengthFormat {
     fn default() -> Self { Self::u32_be() }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(1)]
+    #[case(8)]
+    fn new_accepts_valid_width(#[case] bytes: usize) {
+        let fmt = LengthFormat::new(bytes, Endianness::Big);
+        assert_eq!(fmt.bytes(), bytes);
+    }
+
+    #[rstest]
+    #[case(0)]
+    #[case(9)]
+    fn new_panics_on_invalid_width(#[case] bytes: usize) {
+        let res = std::panic::catch_unwind(|| LengthFormat::new(bytes, Endianness::Big));
+        assert!(res.is_err());
+    }
+}

--- a/src/frame/format.rs
+++ b/src/frame/format.rs
@@ -113,10 +113,17 @@ mod tests {
 
     #[rstest]
     #[case(1)]
+    #[case(2)]
+    #[case(3)]
+    #[case(4)]
+    #[case(5)]
+    #[case(6)]
+    #[case(7)]
     #[case(8)]
     fn new_accepts_valid_width(#[case] bytes: usize) {
         let fmt = LengthFormat::new(bytes, Endianness::Big);
         assert_eq!(fmt.bytes(), bytes);
+        assert_eq!(fmt.endianness(), Endianness::Big);
     }
 
     #[rstest]
@@ -124,6 +131,42 @@ mod tests {
     #[case(9)]
     fn new_panics_on_invalid_width(#[case] bytes: usize) {
         let res = std::panic::catch_unwind(|| LengthFormat::new(bytes, Endianness::Big));
-        assert!(res.is_err());
+        let err = res.expect_err("expected panic");
+        let msg = err
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| err.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or_default();
+        assert!(
+            msg.contains("invalid length-prefix width"),
+            "unexpected panic message: {msg}"
+        );
+    }
+
+    #[rstest]
+    #[case(1)]
+    #[case(8)]
+    fn try_new_accepts_valid_width(#[case] bytes: usize) {
+        let fmt =
+            LengthFormat::try_new(bytes, Endianness::Little).expect("valid width must succeed");
+        assert_eq!(fmt.bytes(), bytes);
+        assert_eq!(fmt.endianness(), Endianness::Little);
+    }
+
+    #[rstest]
+    #[case(0)]
+    #[case(9)]
+    fn try_new_rejects_invalid_width(#[case] bytes: usize) {
+        let err =
+            LengthFormat::try_new(bytes, Endianness::Big).expect_err("invalid width must error");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(err.to_string(), "invalid length-prefix width");
+    }
+
+    #[test]
+    fn default_is_u32_be() {
+        let d = LengthFormat::default();
+        assert_eq!(d.bytes(), 4);
+        assert_eq!(d.endianness(), Endianness::Big);
     }
 }

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -165,6 +165,7 @@ async fn helpers_preserve_correlation_id_and_run_callbacks() {
     assert!(!out.is_empty());
 
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (resp, _) = BincodeSerializer
         .deserialize::<StateEnvelope>(&frames[0])
         .expect("deserialize failed");

--- a/tests/lifecycle.rs
+++ b/tests/lifecycle.rs
@@ -12,12 +12,18 @@ use std::{
 };
 
 use bytes::BytesMut;
-use tokio_util::codec::{Decoder, Encoder};
+use tokio_util::codec::Encoder;
 use wireframe::{
     app::{Envelope, Packet, PacketParts},
     serializer::{BincodeSerializer, Serializer},
 };
-use wireframe_testing::{TEST_MAX_FRAME, new_test_codec, run_app, run_with_duplex_server};
+use wireframe_testing::{
+    TEST_MAX_FRAME,
+    decode_frames,
+    new_test_codec,
+    run_app,
+    run_with_duplex_server,
+};
 
 type App<E> = wireframe::app::WireframeApp<BincodeSerializer, u32, E>;
 type BasicApp = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
@@ -158,14 +164,9 @@ async fn helpers_preserve_correlation_id_and_run_callbacks() {
         .expect("app run failed");
     assert!(!out.is_empty());
 
-    let mut buf = BytesMut::from(&out[..]);
-    let decoded = codec
-        .decode(&mut buf)
-        .expect("decode failed")
-        .expect("frame missing");
-    assert!(buf.is_empty(), "unexpected trailing bytes after decode");
+    let frames = decode_frames(out);
     let (resp, _) = BincodeSerializer
-        .deserialize::<StateEnvelope>(&decoded)
+        .deserialize::<StateEnvelope>(&frames[0])
         .expect("deserialize failed");
     assert_eq!(resp.correlation_id, Some(0));
 

--- a/tests/middleware_order.rs
+++ b/tests/middleware_order.rs
@@ -86,6 +86,7 @@ async fn middleware_applied_in_reverse_order() {
     handle.await.expect("join failed");
 
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (resp, _) = serializer
         .deserialize::<Envelope>(&frames[0])
         .expect("deserialize failed");

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -67,6 +67,7 @@ async fn send_response_encodes_and_frames() {
         .expect("send_response failed");
 
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (decoded, _) = TestResp::from_bytes(&frames[0]).expect("deserialize failed");
     assert_eq!(decoded, TestResp(7));
 }
@@ -223,6 +224,7 @@ async fn send_response_honours_buffer_capacity() {
         .expect("send_response failed");
 
     let frames = decode_frames_with_max(out, LARGE_FRAME);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (decoded, _) = Large::from_bytes(&frames[0]).expect("deserialize failed");
     assert_eq!(decoded.0.len(), payload.len());
 }
@@ -252,6 +254,7 @@ async fn process_stream_honours_buffer_capacity() {
         .expect("run_app failed");
 
     let frames = decode_frames_with_max(out, LARGE_FRAME);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (resp_env, _) = BincodeSerializer
         .deserialize::<Envelope>(&frames[0])
         .expect("deserialize failed");

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -15,7 +15,7 @@ use wireframe::{
     message::Message,
     serializer::BincodeSerializer,
 };
-use wireframe_testing::{decode_frames, decode_frames_with_max, run_app};
+use wireframe_testing::{decode_frames, decode_frames_with_max, encode_frame, run_app};
 
 mod common;
 use common::TestApp;
@@ -239,13 +239,8 @@ async fn process_stream_honours_buffer_capacity() {
     let bytes = BincodeSerializer.serialize(&env).expect("serialize failed");
 
     let mut codec = app.length_codec();
-    let header_len = LengthFormat::default().bytes();
-    let mut encoded = BytesMut::with_capacity(bytes.len() + header_len);
-    codec
-        .encode(bytes.into(), &mut encoded)
-        .expect("encode frame failed");
-
-    let out = run_app(app, vec![encoded.to_vec()], Some(10 * 1024 * 1024))
+    let frame = encode_frame(&mut codec, bytes);
+    let out = run_app(app, vec![frame], Some(10 * 1024 * 1024))
         .await
         .expect("run_app failed");
 

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -243,8 +243,9 @@ async fn process_stream_honours_buffer_capacity() {
     let env = Envelope::new(1, None, payload.clone());
     let bytes = BincodeSerializer.serialize(&env).expect("serialize failed");
 
-    let mut codec = new_test_codec(LARGE_FRAME);
-    let mut encoded = BytesMut::with_capacity(bytes.len() + 4);
+    let mut codec = app.length_codec();
+    let header_len = LengthFormat::default().bytes();
+    let mut encoded = BytesMut::with_capacity(bytes.len() + header_len);
     codec
         .encode(bytes.into(), &mut encoded)
         .expect("encode frame failed");

--- a/tests/routes.rs
+++ b/tests/routes.rs
@@ -89,6 +89,7 @@ async fn handler_receives_message_and_echoes_response() {
         .expect("drive_with_bincode failed");
 
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (resp_env, _) = BincodeSerializer
         .deserialize::<TestEnvelope>(&frames[0])
         .expect("deserialize failed");
@@ -117,6 +118,7 @@ async fn handler_echoes_with_none_correlation_id() {
 
     let out = drive_with_bincode(app, env).await.expect("drive failed");
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (resp_env, _) = BincodeSerializer
         .deserialize::<TestEnvelope>(&frames[0])
         .expect("deserialize failed");
@@ -160,6 +162,7 @@ async fn multiple_frames_processed_in_sequence() {
         .expect("drive_with_frames failed");
 
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 2, "expected two response frames");
     let (env1, _) = BincodeSerializer
         .deserialize::<TestEnvelope>(&frames[0])
         .expect("deserialize failed");
@@ -206,6 +209,7 @@ async fn single_frame_propagates_correlation_id(#[case] cid: Option<u64>) {
         .await
         .expect("drive failed");
     let frames = decode_frames(out);
+    assert_eq!(frames.len(), 1, "expected a single response frame");
     let (resp, _) = BincodeSerializer
         .deserialize::<TestEnvelope>(&frames[0])
         .expect("deserialize failed");

--- a/wireframe_testing/src/helpers.rs
+++ b/wireframe_testing/src/helpers.rs
@@ -8,7 +8,7 @@ use std::io;
 use bincode::config;
 use bytes::BytesMut;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
-use tokio_util::codec::{Encoder, LengthDelimitedCodec};
+use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 use wireframe::{
     app::{Envelope, Packet, WireframeApp},
     frame::FrameMetadata,
@@ -100,6 +100,36 @@ pub fn new_test_codec(max_len: usize) -> LengthDelimitedCodec {
     let mut builder = LengthDelimitedCodec::builder();
     builder.max_frame_length(max_len);
     builder.new_codec()
+}
+
+/// Decode all length-prefixed `frames` using a test codec and assert no bytes remain.
+///
+/// This helper constructs a [`LengthDelimitedCodec`] capped at [`TEST_MAX_FRAME`]
+/// and decodes each frame in `bytes`, ensuring the buffer is fully consumed.
+///
+/// ```rust
+/// # use wireframe_testing::decode_frames;
+/// let frames = decode_frames(vec![0, 0, 0, 1, 42]);
+/// assert_eq!(frames, vec![vec![42]]);
+/// ```
+#[must_use]
+pub fn decode_frames(bytes: Vec<u8>) -> Vec<Vec<u8>> {
+    decode_frames_with_max(bytes, TEST_MAX_FRAME)
+}
+
+/// Decode `bytes` into frames using a codec capped at `max_len`.
+///
+/// Asserts that no trailing bytes remain after all frames are decoded.
+#[must_use]
+pub fn decode_frames_with_max(bytes: Vec<u8>, max_len: usize) -> Vec<Vec<u8>> {
+    let mut codec = new_test_codec(max_len);
+    let mut buf = BytesMut::from(&bytes[..]);
+    let mut frames = Vec::new();
+    while let Some(frame) = codec.decode(&mut buf).expect("decode failed") {
+        frames.push(frame.to_vec());
+    }
+    assert!(buf.is_empty(), "unexpected trailing bytes after decode");
+    frames
 }
 
 macro_rules! forward_default {

--- a/wireframe_testing/src/helpers.rs
+++ b/wireframe_testing/src/helpers.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream, duplex};
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 use wireframe::{
     app::{Envelope, Packet, WireframeApp},
-    frame::FrameMetadata,
+    frame::{FrameMetadata, LengthFormat},
     serializer::Serializer,
 };
 
@@ -413,6 +413,18 @@ where
 /// # Ok(())
 /// # }
 /// ```
+
+/// Encode bytes with a length-delimited `codec`, preallocating the prefix.
+///
+/// Panics if encoding fails.
+#[must_use]
+pub fn encode_frame(codec: &mut LengthDelimitedCodec, bytes: Vec<u8>) -> Vec<u8> {
+    let header_len = LengthFormat::default().bytes();
+    let mut buf = BytesMut::with_capacity(bytes.len() + header_len);
+    codec.encode(bytes.into(), &mut buf).expect("encode failed");
+    buf.to_vec()
+}
+
 pub async fn run_app<S, C, E>(
     app: WireframeApp<S, C, E>,
     frames: Vec<Vec<u8>>,

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -33,6 +33,7 @@ pub use helpers::{
     drive_with_frames,
     drive_with_frames_mut,
     drive_with_frames_with_capacity,
+    encode_frame,
     new_test_codec,
     run_app,
     run_with_duplex_server,

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -24,6 +24,8 @@ pub mod logging;
 pub use helpers::{
     TEST_MAX_FRAME,
     TestSerializer,
+    decode_frames,
+    decode_frames_with_max,
     drive_with_bincode,
     drive_with_frame,
     drive_with_frame_mut,


### PR DESCRIPTION
## Summary
- add shared `decode_frames` helper to simplify frame assertions in tests
- expose `WireframeApp::length_codec` and test `LengthFormat::new` panic path
- update example and docs to use the public codec helper

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68b45c4715448322b048a056e012462d

## Summary by Sourcery

Streamline frame decoding in tests by introducing shared decode_frames helpers, expose a public length_codec on WireframeApp, update tests, examples, and documentation to use the new API, and add validation tests for the LengthFormat constructor.

New Features:
- Add decode_frames and decode_frames_with_max helpers for decoding length-prefixed frames in tests
- Expose public length_codec method on WireframeApp to create a length-delimited codec based on buffer_capacity

Enhancements:
- Refactor tests to use decode_frames helpers instead of manual LengthDelimitedCodec decoding
- Update examples and design documentation to use WireframeApp::length_codec and buffer_capacity for framing

Documentation:
- Revise asynchronous messaging and fragmentation design docs to showcase the public codec helper

Tests:
- Add unit tests for LengthFormat::new to verify valid widths and panic on invalid widths

Chores:
- Remove unused tokio_util::codec::Decoder imports in test modules