### PR TITLE
Add GoReleaser packaging for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@c6559452842af6a83b83429129dccaf910e34562
+      - name: Install cross
+        run: cargo install cross
+      - name: Build binaries
+        run: |
+          cross build --target x86_64-unknown-linux-gnu --release
+          cross build --target x86_64-apple-darwin --release
+          cross build --target x86_64-unknown-freebsd --release
+      - name: Prepare dist
+        run: |
+          mkdir -p dist/wireframe_linux_amd64
+          cp target/x86_64-unknown-linux-gnu/release/wireframe dist/wireframe_linux_amd64/
+          mkdir -p dist/wireframe_darwin_amd64
+          cp target/x86_64-apple-darwin/release/wireframe dist/wireframe_darwin_amd64/
+          mkdir -p dist/wireframe_freebsd_amd64
+          cp target/x86_64-unknown-freebsd/release/wireframe dist/wireframe_freebsd_amd64/
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          distribution: goreleaser
+          version: v1.24.0
+          args: release --clean --skip=build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+project_name: wireframe
+builds:
+  - id: wireframe
+    binary: wireframe
+    goos:
+      - linux
+      - darwin
+      - freebsd
+    goarch:
+      - amd64
+    skip: true
+archives:
+  - id: wireframe-archive
+    builds: [wireframe]
+    format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - LICENSE
+      - README.md
+nfpms:
+  - id: wireframe-nfpm
+    builds: [wireframe]
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [deb, rpm]
+    maintainer: "Payton McIntosh <pmcintosh@df12.net>"
+    description: "An experimental Rust library that simplifies building servers and clients for custom binary protocols."
+    license: ISC
+    homepage: https://github.com/leynos/wireframe
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"


### PR DESCRIPTION
## Summary
- add release workflow that cross-builds and packages binaries with GoReleaser
- package cross-built binaries into archives and Linux deb/rpm packages while keeping standalone binaries

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68b4f9dee17483228592056078f9196b

## Summary by Sourcery

Automate the release process by building wireframe for Linux, macOS, and FreeBSD and packaging the binaries into archives and system packages via GoReleaser.

New Features:
- Automate cross-platform packaging of wireframe binaries into tar.gz, deb, and rpm artifacts

Build:
- Add GoReleaser configuration for archives, Linux deb and rpm packages, and checksum generation

CI:
- Add GitHub Actions workflow to cross-compile and package releases using cross and GoReleaser