### PR TITLE
Add test for channel send failure after receiver drop

### DIFF
--- a/tests/multi_packet.rs
+++ b/tests/multi_packet.rs
@@ -66,8 +66,12 @@ async fn multi_packet_sender_dropped_before_all_messages() {
 async fn multi_packet_send_fails_after_receiver_dropped() {
     let (tx, rx) = mpsc::channel::<TestMsg>(2);
     drop(rx);
-    let result = tx.send(TestMsg(42)).await;
-    assert!(result.is_err(), "Send should fail when receiver is dropped");
+    let error = tx
+        .send(TestMsg(42))
+        .await
+        .expect_err("Send should fail when receiver is dropped");
+    let mpsc::error::SendError(msg) = error;
+    assert_eq!(msg, TestMsg(42));
 }
 
 /// Handles more messages than the channel capacity allows.

--- a/tests/multi_packet.rs
+++ b/tests/multi_packet.rs
@@ -61,6 +61,15 @@ async fn multi_packet_sender_dropped_before_all_messages() {
     assert_eq!(received, vec![TestMsg(1)]);
 }
 
+/// Test that sending fails after the receiver is dropped.
+#[tokio::test]
+async fn multi_packet_send_fails_after_receiver_dropped() {
+    let (tx, rx) = mpsc::channel::<TestMsg>(2);
+    drop(rx);
+    let result = tx.send(TestMsg(42)).await;
+    assert!(result.is_err(), "Send should fail when receiver is dropped");
+}
+
 /// Handles more messages than the channel capacity allows.
 #[tokio::test]
 async fn multi_packet_handles_channel_capacity() {


### PR DESCRIPTION
## Summary
- add regression test ensuring `mpsc` send fails when receiver is dropped before send

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb304382a08322a683fd877a6e49a6

## Summary by Sourcery

Tests:
- Add asynchronous test verifying that sending on an mpsc channel errors after the receiver is dropped