### PR TITLE
Extract shared MultiPacket test helper

### DIFF
--- a/tests/multi_packet.rs
+++ b/tests/multi_packet.rs
@@ -1,5 +1,6 @@
 //! Tests for multi-packet responses using channels.
 
+use futures::TryStreamExt;
 use rstest::rstest;
 use tokio::sync::mpsc;
 use wireframe::Response;
@@ -10,77 +11,19 @@ struct TestMsg(u8);
 
 const CAPACITY: usize = 2;
 
+/// Drain all messages from a `FrameStream` for non-channel response variants.
+async fn drain_all<F, E: std::fmt::Debug>(stream: wireframe::FrameStream<F, E>) -> Vec<F> {
+    stream.try_collect::<Vec<_>>().await.expect("stream error")
+}
+
 /// `collect_multi_packet` drains every frame regardless of channel state.
 ///
-/// This covers empty channels, partial sends, and when senders outpace the channel's
-/// capacity.
+/// This covers empty channels, partial sends, and when senders outpace the
+/// channel's capacity.
 #[rstest(count, case(0), case(1), case(2), case(CAPACITY + 1))]
 #[tokio::test]
-<<<<<<< HEAD
-async fn multi_packet_empty_channel() {
-    let (tx, rx) = mpsc::channel(4);
-    drop(tx);
-    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
-    let received = collect_multi_packet(resp).await;
-    assert!(received.is_empty());
-}
-
-/// Stops yielding when the sender is dropped before all messages are sent.
-#[tokio::test]
-async fn multi_packet_sender_dropped_before_all_messages() {
-    let (tx, rx) = mpsc::channel(4);
-    tx.send(TestMsg(1)).await.expect("send");
-    drop(tx);
-    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
-    let received = collect_multi_packet(resp).await;
-    assert_eq!(received, vec![TestMsg(1)]);
-}
-
-/// Test that sending fails after the receiver is dropped.
-#[tokio::test]
-async fn multi_packet_send_fails_after_receiver_dropped() {
-    let (tx, rx) = mpsc::channel::<TestMsg>(2);
-    drop(rx);
-    let error = tx
-        .send(TestMsg(42))
-        .await
-        .expect_err("Send should fail when receiver is dropped");
-    let mpsc::error::SendError(msg) = error;
-    assert_eq!(msg, TestMsg(42));
-}
-
-/// Handles more messages than the channel capacity allows.
-#[tokio::test]
-async fn multi_packet_handles_channel_capacity() {
-    let (tx, rx) = mpsc::channel(2);
-||||||| parent of 047215a (Parameterize multi-packet tests)
-async fn multi_packet_empty_channel() {
-    let (tx, rx) = mpsc::channel(4);
-    drop(tx);
-    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
-    let received = collect_multi_packet(resp).await;
-    assert!(received.is_empty());
-}
-
-/// Stops yielding when the sender is dropped before all messages are sent.
-#[tokio::test]
-async fn multi_packet_sender_dropped_before_all_messages() {
-    let (tx, rx) = mpsc::channel(4);
-    tx.send(TestMsg(1)).await.expect("send");
-    drop(tx);
-    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
-    let received = collect_multi_packet(resp).await;
-    assert_eq!(received, vec![TestMsg(1)]);
-}
-
-/// Handles more messages than the channel capacity allows.
-#[tokio::test]
-async fn multi_packet_handles_channel_capacity() {
-    let (tx, rx) = mpsc::channel(2);
-=======
 async fn multi_packet_drains_all_messages(count: usize) {
     let (tx, rx) = mpsc::channel(CAPACITY);
->>>>>>> 047215a (Parameterize multi-packet tests)
     let send_task = tokio::spawn(async move {
         for i in 0..count {
             tx.send(TestMsg(u8::try_from(i).expect("<= u8::MAX")))
@@ -90,7 +33,6 @@ async fn multi_packet_drains_all_messages(count: usize) {
     });
     let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
     let received = collect_multi_packet(resp).await;
->>>>>>> 5e27dd8 (Add MultiPacket test helper implementation)
     send_task.await.expect("sender join");
     assert_eq!(
         received,

--- a/tests/multi_packet.rs
+++ b/tests/multi_packet.rs
@@ -1,5 +1,6 @@
 //! Tests for multi-packet responses using channels.
 
+use rstest::rstest;
 use tokio::sync::mpsc;
 use wireframe::Response;
 use wireframe_testing::collect_multi_packet;
@@ -7,21 +8,15 @@ use wireframe_testing::collect_multi_packet;
 #[derive(PartialEq, Debug)]
 struct TestMsg(u8);
 
-/// Verifies that all messages sent through the channel are yielded by `Response::MultiPacket`.
-#[tokio::test]
-async fn multi_packet_yields_messages() {
-    let (tx, rx) = mpsc::channel(4);
-    tx.send(TestMsg(1)).await.expect("send");
-    tx.send(TestMsg(2)).await.expect("send");
-    drop(tx);
+const CAPACITY: usize = 2;
 
-    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
-    let received = collect_multi_packet(resp).await;
-    assert_eq!(received, vec![TestMsg(1), TestMsg(2)]);
-}
-
-/// Yields no messages when the channel is immediately closed.
+/// `collect_multi_packet` drains every frame regardless of channel state.
+///
+/// This covers empty channels, partial sends, and when senders outpace the channel's
+/// capacity.
+#[rstest(count, case(0), case(1), case(2), case(CAPACITY + 1))]
 #[tokio::test]
+<<<<<<< HEAD
 async fn multi_packet_empty_channel() {
     let (tx, rx) = mpsc::channel(4);
     drop(tx);
@@ -58,9 +53,39 @@ async fn multi_packet_send_fails_after_receiver_dropped() {
 #[tokio::test]
 async fn multi_packet_handles_channel_capacity() {
     let (tx, rx) = mpsc::channel(2);
+||||||| parent of 047215a (Parameterize multi-packet tests)
+async fn multi_packet_empty_channel() {
+    let (tx, rx) = mpsc::channel(4);
+    drop(tx);
+    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
+    let received = collect_multi_packet(resp).await;
+    assert!(received.is_empty());
+}
+
+/// Stops yielding when the sender is dropped before all messages are sent.
+#[tokio::test]
+async fn multi_packet_sender_dropped_before_all_messages() {
+    let (tx, rx) = mpsc::channel(4);
+    tx.send(TestMsg(1)).await.expect("send");
+    drop(tx);
+    let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
+    let received = collect_multi_packet(resp).await;
+    assert_eq!(received, vec![TestMsg(1)]);
+}
+
+/// Handles more messages than the channel capacity allows.
+#[tokio::test]
+async fn multi_packet_handles_channel_capacity() {
+    let (tx, rx) = mpsc::channel(2);
+=======
+async fn multi_packet_drains_all_messages(count: usize) {
+    let (tx, rx) = mpsc::channel(CAPACITY);
+>>>>>>> 047215a (Parameterize multi-packet tests)
     let send_task = tokio::spawn(async move {
-        for i in 0..4u8 {
-            tx.send(TestMsg(i)).await.expect("send");
+        for i in 0..count {
+            tx.send(TestMsg(u8::try_from(i).expect("<= u8::MAX")))
+                .await
+                .expect("send");
         }
     });
     let resp: Response<TestMsg, ()> = Response::MultiPacket(rx);
@@ -69,7 +94,9 @@ async fn multi_packet_handles_channel_capacity() {
     send_task.await.expect("sender join");
     assert_eq!(
         received,
-        vec![TestMsg(0), TestMsg(1), TestMsg(2), TestMsg(3)]
+        (0..count)
+            .map(|i| TestMsg(u8::try_from(i).expect("<= u8::MAX")))
+            .collect::<Vec<_>>()
     );
 }
 

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -221,7 +221,6 @@ impl MultiPacketWorld {
     /// # Panics
     /// Panics if sending to the channel fails.
     async fn process_messages(&mut self, messages: &[u8]) {
-        self.messages.clear();
         let (tx, ch_rx) = tokio::sync::mpsc::channel(4);
         for &msg in messages {
             tx.send(msg).await.expect("send");

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -8,7 +8,6 @@ use std::{net::SocketAddr, sync::Arc};
 
 use async_stream::try_stream;
 use cucumber::World;
-use futures::TryStreamExt;
 use tokio::{net::TcpStream, sync::oneshot};
 use tokio_util::sync::CancellationToken;
 use wireframe::{
@@ -20,6 +19,7 @@ use wireframe::{
     serializer::BincodeSerializer,
     server::WireframeServer,
 };
+use wireframe_testing::collect_multi_packet;
 
 type TestApp = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
 
@@ -216,15 +216,6 @@ pub struct MultiPacketWorld {
 }
 
 impl MultiPacketWorld {
-    async fn drain(&mut self, resp: wireframe::Response<u8, ()>) {
-        let frames = resp
-            .into_stream()
-            .try_collect::<Vec<_>>()
-            .await
-            .expect("stream error");
-        self.messages.extend(frames);
-    }
-
     /// Helper method to process messages through a multi-packet response.
     ///
     /// # Panics
@@ -237,7 +228,7 @@ impl MultiPacketWorld {
         }
         drop(tx);
         let resp: wireframe::Response<u8, ()> = wireframe::Response::MultiPacket(ch_rx);
-        self.drain(resp).await;
+        self.messages = collect_multi_packet(resp).await;
     }
 
     /// Send messages through a multi-packet response and record them.

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -228,7 +228,7 @@ impl MultiPacketWorld {
         }
         drop(tx);
         let resp: wireframe::Response<u8, ()> = wireframe::Response::MultiPacket(ch_rx);
-        self.messages = collect_multi_packet(resp).await;
+        self.messages.extend(collect_multi_packet(resp).await);
     }
 
     /// Send messages through a multi-packet response and record them.

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -227,7 +227,7 @@ impl MultiPacketWorld {
         }
         drop(tx);
         let resp: wireframe::Response<u8, ()> = wireframe::Response::MultiPacket(ch_rx);
-        self.messages.extend(collect_multi_packet(resp).await);
+        self.messages = collect_multi_packet(resp).await;
     }
 
     /// Send messages through a multi-packet response and record them.

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod helpers;
 pub mod logging;
+pub mod multi_packet;
 
 pub use helpers::{
     TEST_MAX_FRAME,
@@ -39,3 +40,4 @@ pub use helpers::{
     run_with_duplex_server,
 };
 pub use logging::{LoggerHandle, logger};
+pub use multi_packet::collect_multi_packet;

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -40,4 +40,5 @@ pub use helpers::{
     run_with_duplex_server,
 };
 pub use logging::{LoggerHandle, logger};
+#[doc(inline)]
 pub use multi_packet::collect_multi_packet;

--- a/wireframe_testing/src/multi_packet.rs
+++ b/wireframe_testing/src/multi_packet.rs
@@ -1,0 +1,37 @@
+//! Helpers for draining `Response::MultiPacket` values in tests.
+//!
+//! These utilities collect all frames from a [`Response::MultiPacket`] into a
+//! `Vec`, enabling concise assertions in tests and Cucumber steps.
+
+use wireframe::Response;
+
+/// Collect all frames from a [`Response::MultiPacket`].
+///
+/// # Examples
+///
+/// ```rust
+/// use tokio::sync::mpsc;
+/// use wireframe::Response;
+/// use wireframe_testing::collect_multi_packet;
+///
+/// # async fn demo() {
+/// let (tx, rx) = mpsc::channel(4);
+/// tx.send(1u8).await.expect("send");
+/// drop(tx);
+/// let frames = collect_multi_packet(Response::MultiPacket(rx)).await;
+/// assert_eq!(frames, vec![1]);
+/// # }
+/// ```
+#[must_use]
+pub async fn collect_multi_packet<F, E>(resp: Response<F, E>) -> Vec<F> {
+    match resp {
+        Response::MultiPacket(mut rx) => {
+            let mut frames = Vec::new();
+            while let Some(frame) = rx.recv().await {
+                frames.push(frame);
+            }
+            frames
+        }
+        _ => panic!("expected Response::MultiPacket"),
+    }
+}

--- a/wireframe_testing/src/multi_packet.rs
+++ b/wireframe_testing/src/multi_packet.rs
@@ -25,8 +25,10 @@ use wireframe::Response;
 ///
 /// # Panics
 /// Panics if `resp` is not [`Response::MultiPacket`]; the panic message names
-/// the received variant.
+/// the received variant and is attributed to the caller.
 #[must_use]
+#[track_caller]
+#[allow(ungated_async_fn_track_caller)] // track_caller on async is unstable
 pub async fn collect_multi_packet<F, E>(resp: Response<F, E>) -> Vec<F> {
     match resp {
         Response::MultiPacket(mut rx) => {

--- a/wireframe_testing/src/multi_packet.rs
+++ b/wireframe_testing/src/multi_packet.rs
@@ -22,6 +22,10 @@ use wireframe::Response;
 /// assert_eq!(frames, vec![1]);
 /// # }
 /// ```
+///
+/// # Panics
+/// Panics if `resp` is not [`Response::MultiPacket`]; the panic message names
+/// the received variant.
 #[must_use]
 pub async fn collect_multi_packet<F, E>(resp: Response<F, E>) -> Vec<F> {
     match resp {
@@ -32,6 +36,9 @@ pub async fn collect_multi_packet<F, E>(resp: Response<F, E>) -> Vec<F> {
             }
             frames
         }
-        _ => panic!("expected Response::MultiPacket"),
+        Response::Single(_) => panic!("collect_multi_packet received Response::Single"),
+        Response::Vec(_) => panic!("collect_multi_packet received Response::Vec"),
+        Response::Stream(_) => panic!("collect_multi_packet received Response::Stream"),
+        Response::Empty => panic!("collect_multi_packet received Response::Empty"),
     }
 }


### PR DESCRIPTION
## Summary
- add `collect_multi_packet` helper for draining `Response::MultiPacket`
- reuse helper in unit tests and Cucumber world to remove duplicate loops

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3035ab248322b84ad28d8e6f70e2

## Summary by Sourcery

Extract a shared helper for draining Response::MultiPacket values to consolidate duplicate loops in tests and Cucumber steps.

Enhancements:
- Extract collect_multi_packet helper into wireframe_testing crate to reduce code duplication in tests.

Documentation:
- Add documentation comments for the collect_multi_packet helper.

Tests:
- Update multi-packet tests and Cucumber world to use the shared collect_multi_packet helper instead of manual loops.