### PR TITLE
Implement multi-packet streaming responses

### DIFF
--- a/docs/multi-packet-and-streaming-responses-design.md
+++ b/docs/multi-packet-and-streaming-responses-design.md
@@ -266,6 +266,11 @@ not hang.
   `select!` loop rather than by a detached task. This keeps a single locus for
   back-pressure, aligns with the production resilience guidance on avoiding
   orphaned tasks, and ensures orderly shutdown propagates to streaming work.
+- The `ConnectionActor` owns the channel receiver and polls it via the
+  main `select!` loop. Frames pass through `process_frame_common` so protocol
+  hooks and metrics observe every packet. When the channel drains, the actor
+  emits the protocol end-of-stream marker and invokes `on_command_end` to
+  release per-request state.
 - The actor captures the request's `correlation_id` before iterating the
   channel and stamps it onto every serialised frame. This preserves protocol
   invariants without requiring handlers to mutate frames post-creation and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -197,14 +197,14 @@ stream.
   - [x] Introduce a `Response::MultiPacket` variant that contains a channel
     `Receiver<Message>`.
 
-  - [ ] Modify the `Connection` actor: upon receiving `Response::MultiPacket`,
+  - [x] Modify the `Connection` actor: upon receiving `Response::MultiPacket`,
     it should consume messages from the receiver and send each one as a `Frame`.
-    - [ ] Extend the outbound `select!` loop to own the receiver so
+    - [x] Extend the outbound `select!` loop to own the receiver so
       multi-packet responses share the same back-pressure and shutdown handling
       as other frame sources.
-    - [ ] Convert each received `Message` into a `Frame` via the existing
+    - [x] Convert each received `Message` into a `Frame` via the existing
       serialization helpers rather than bypassing protocol hooks or metrics.
-    - [ ] Emit tracing and metrics for each forwarded frame so streaming
+    - [x] Emit tracing and metrics for each forwarded frame so streaming
       traffic remains visible to observability pipelines.
 
   - [ ] Each sent frame must carry the correct `correlation_id` from the


### PR DESCRIPTION
## Summary
- extend the `ConnectionActor` to poll multi-packet channels alongside other frame sources, drive protocol hooks, and emit terminators on completion
- add unit and behavioural coverage for draining multi-packet channels and asserting end-of-stream frames
- document the design decision and mark the roadmap item complete

## Testing
- cargo fmt --all
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68cddb8843588322ab4e4102a4af980f