### PR TITLE
Document multi-packet responses in the user guide

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -216,12 +216,12 @@ stream.
     - [x] Guard against accidental omission by asserting in debug builds and
       covering the behaviour with targeted tests.
 
-  - [ ] When the channel closes, send the end-of-stream marker frame.
-    - [ ] Detect channel closure (`None` from `recv`) and log the termination
+  - [x] When the channel closes, send the end-of-stream marker frame.
+    - [x] Detect channel closure (`None` from `recv`) and log the termination
       reason for operational insight.
-    - [ ] Send the designated end-of-stream marker frame through the same
+    - [x] Send the designated end-of-stream marker frame through the same
       send path, reusing the request's `correlation_id`.
-    - [ ] Notify protocol lifecycle hooks so higher layers can tidy any
+    - [x] Notify protocol lifecycle hooks so higher layers can tidy any
       per-request state when a stream drains naturally.
 
 - [ ] **Ergonomics & API:**

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -203,6 +203,47 @@ fn stream_response() -> Response<Frame> {
 }
 ```
 
+`Response::MultiPacket` exposes a different surface: callers hand ownership of
+the receiving half of a `tokio::sync::mpsc` channel to the connection actor,
+retain the sender, and push frames whenever back-pressure allows. The library
+awaits channel capacity before accepting each frame, so producers can rely on
+the `send().await` future to coordinate flow control with the peer.
+
+```rust
+use tokio::sync::mpsc;
+use wireframe::response::{Frame, Response};
+
+async fn multi_packet() -> Response<Frame> {
+    let (sender, receiver) = mpsc::channel(16);
+
+    tokio::spawn(async move {
+        // Back-pressure: `send` awaits whenever the channel is full.
+        for chunk in [b"alpha".as_slice(), b"beta".as_slice()] {
+            let frame = Frame::from(chunk);
+            if sender.send(frame).await.is_err() {
+                return; // connection dropped; stop producing
+            }
+        }
+
+        // Dropping the last sender releases the channel and triggers the
+        // terminator. Explicitly drop when the stream should end.
+        drop(sender);
+    });
+
+    Response::MultiPacket(receiver)
+}
+```
+
+Multi-packet responders rely on the protocol hook `stream_end_frame` to emit a
+terminator when the producer side of the channel closes naturally. The
+connection actor records why the channel ended (`drained`, `disconnected`, or
+`shutdown`), stamps the stored `correlation_id` on the terminator frame, and
+routes it through the standard `before_send` instrumentation so telemetry and
+higher-level lifecycle hooks observe a consistent end-of-stream signal.
+Dropping all senders causes the channel to close; the connection actor logs the
+termination reason and forwards the terminator through the same hooks used for
+regular frames so existing observability continues to work.
+
 ## Versioning and graceful deprecation
 
 Phase out older message versions without breaking clients:

--- a/src/connection/test_support.rs
+++ b/src/connection/test_support.rs
@@ -6,7 +6,14 @@
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use super::{ActorState, ConnectionActor, DrainContext, ProtocolHooks, QueueKind};
+use super::{
+    ActorState,
+    ConnectionActor,
+    DrainContext,
+    MultiPacketTerminationReason,
+    ProtocolHooks,
+    QueueKind,
+};
 use crate::push::{PushConfigError, PushQueues};
 
 /// Build a connection actor configured with the supplied protocol hooks.
@@ -112,8 +119,11 @@ impl ActorHarness {
 
     /// Handle closure of the multi-packet receiver.
     pub fn handle_multi_packet_closed(&mut self) {
-        self.actor
-            .handle_multi_packet_closed(&mut self.state, &mut self.out);
+        self.actor.handle_multi_packet_closed(
+            MultiPacketTerminationReason::Drained,
+            &mut self.state,
+            &mut self.out,
+        );
     }
 
     /// Attempt a low-priority opportunistic drain.

--- a/tests/features/stream_end.feature
+++ b/tests/features/stream_end.feature
@@ -2,3 +2,7 @@ Feature: Stream terminator frame
   Scenario: Connection actor emits terminator after stream
     When a streaming response completes
     Then an end-of-stream frame is sent
+
+  Scenario: Multi-packet channel emits terminator after completion
+    When a multi-packet channel drains
+    Then a multi-packet end-of-stream frame is sent

--- a/tests/steps/stream_end_steps.rs
+++ b/tests/steps/stream_end_steps.rs
@@ -8,3 +8,9 @@ async fn when_stream(world: &mut StreamEndWorld) { world.process().await; }
 
 #[then("an end-of-stream frame is sent")]
 fn then_end(world: &mut StreamEndWorld) { world.verify(); }
+
+#[when("a multi-packet channel drains")]
+async fn when_multi_channel(world: &mut StreamEndWorld) { world.process_multi().await; }
+
+#[then("a multi-packet end-of-stream frame is sent")]
+fn then_multi_end(world: &mut StreamEndWorld) { world.verify_multi(); }


### PR DESCRIPTION
## Summary
- expand the streaming responses section to describe Response::MultiPacket usage and flow control
- add an end-to-end tokio::sync::mpsc example that drives a multi-packet response and closes the stream
- clarify how dropping senders triggers logging, protocol hooks, and the terminator frame so telemetry stays consistent

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d959d659ec8322a36cfec071bd0b78