### PR TITLE
Mark multi-packet core library roadmap item complete

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -192,7 +192,7 @@ stream.
   - [x] Define a mechanism to signal the end of a multi-packet stream, such as
     a frame with a specific flag and no payload.
 
-- [ ] **Core Library Implementation:**
+- [x] **Core Library Implementation:**
 
   - [x] Introduce a `Response::MultiPacket` variant that contains a channel
     `Receiver<Message>`.


### PR DESCRIPTION
## Summary
- mark the Phase 6 core library implementation milestone as complete in the roadmap

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68dac2f308ec8322888f275a847ad77c

## Summary by Sourcery

Documentation:
- Check off the core library implementation item as completed in docs/roadmap.md