### PR TITLE
Clarify formatting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,8 +113,10 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-- Run `make fmt`, `make lint`, and `make test` before committing. These targets
-  wrap `cargo fmt`, `cargo clippy`, and `cargo test` with the appropriate flags.
+- Run `make check-fmt`, `make lint`, and `make test` before committing.
+  These targets wrap `cargo fmt --check`, `cargo clippy`, and `cargo test` with
+  the appropriate flags. Use `make fmt` to apply formatting fixes when
+  `make check-fmt` identifies violations.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.


### PR DESCRIPTION
## Summary
- update the contributor guidance to require `make check-fmt`, `make lint`, and `make test` before committing
- note that `make fmt` is available to resolve formatting violations reported by the checks

## Testing
- make fmt

------
https://chatgpt.com/codex/tasks/task_e_68dd0d5508fc83229e58106e2a5e7e8a