### PR TITLE
Add helper for multi-packet responses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,9 +137,9 @@ project:
     cargo test --workspace
     ```
 
-    running the full workspace test suite.
-  Use `make fmt` (`cargo fmt --workspace`) to apply formatting fixes reported
-  by the formatter check.
+    running the full workspace test suite. Use `make fmt`
+    (`cargo fmt --workspace`) to apply formatting fixes reported by the
+    formatter check.
 - Clippy warnings MUST be disallowed.
 - Fix any warnings emitted during tests in the code itself rather than
   silencing them.

--- a/docs/multi-packet-and-streaming-responses-design.md
+++ b/docs/multi-packet-and-streaming-responses-design.md
@@ -219,6 +219,19 @@ here for implementation in the follow-up to ADR 0001):
   `Empty`) alongside the multi-packet receiver so the connection actor can
   first emit the up-front frames and then enter streaming mode.
 
+#### 4.2.1 Implemented helper: `Response::with_channel`
+
+`Response::with_channel` is now available. It forwards to Tokio's
+`mpsc::channel`, returning the sender with a `Response::MultiPacket` that owns
+the receiver. The helper intentionally mirrors Tokio's panic on zero capacity;
+propagating this behaviour keeps the API predictable for developers already
+familiar with Tokio channels. Unit tests assert that the helper enforces
+bounded capacity and drains frames in order, while the multi-packet Cucumber
+feature exercises the helper end-to-end through a background producer task. The
+fixture demonstrates the intended tuple return pattern: spawn a producer,
+stream frames through the sender, and rely on the connection actor to manage
+delivery and shutdown semantics.
+
 When a tuple is returned, the connection actor:
 
 - sends any frames embedded in the initial `Response` before transitioning into

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -224,15 +224,15 @@ stream.
     - [x] Notify protocol lifecycle hooks so higher layers can tidy any
       per-request state when a stream drains naturally.
 
-- [ ] **Ergonomics & API:**
+- [x] **Ergonomics & API:**
 
-  - [ ] Provide a helper (for example `Response::with_channel`) that returns a
+  - [x] Provide a helper (for example `Response::with_channel`) that returns a
     bounded channel sender alongside a `Response::MultiPacket` so handlers can
     opt into streaming ergonomically.[^adr-0001]
-  - [ ] Update the multi-packet design documentation and user guide with tuple
+  - [x] Update the multi-packet design documentation and user guide with tuple
     return examples that explain initial-frame handling, back-pressure, and
     graceful termination.[^adr-0001]
-  - [ ] Add an example handler (or test fixture) demonstrating spawning a
+  - [x] Add an example handler (or test fixture) demonstrating spawning a
     background task that pushes frames through the returned sender while the
     connection actor manages delivery.
 

--- a/tests/features/multi_packet.feature
+++ b/tests/features/multi_packet.feature
@@ -1,9 +1,9 @@
 @multi_packet
 Feature: Multi-packet responses
-  Scenario: messages from a multi-packet response are delivered sequentially
-    When a multi-packet response emits messages
+  Scenario: Response::with_channel streams frames sequentially
+    When a handler uses the with_channel helper to emit messages
     Then all messages are received in order
 
   Scenario: no messages are emitted from a multi-packet response
-    When a multi-packet response emits no messages
+    When a handler uses the with_channel helper to emit no messages
     Then no messages are received

--- a/tests/features/multi_packet.feature
+++ b/tests/features/multi_packet.feature
@@ -7,3 +7,7 @@ Feature: Multi-packet responses
   Scenario: no messages are emitted from a multi-packet response
     When a handler uses the with_channel helper to emit no messages
     Then no messages are received
+
+  Scenario: Channel capacity overflow
+    When a handler emits more messages than the channel capacity
+    Then overflow messages are handled according to channel policy

--- a/tests/steps/multi_packet_steps.rs
+++ b/tests/steps/multi_packet_steps.rs
@@ -3,13 +3,13 @@ use cucumber::{then, when};
 
 use crate::world::MultiPacketWorld;
 
-#[when("a multi-packet response emits messages")]
+#[when("a handler uses the with_channel helper to emit messages")]
 async fn when_multi(world: &mut MultiPacketWorld) { world.process().await; }
 
 #[then("all messages are received in order")]
 fn then_multi(world: &mut MultiPacketWorld) { world.verify(); }
 
-#[when("a multi-packet response emits no messages")]
+#[when("a handler uses the with_channel helper to emit no messages")]
 async fn when_multi_empty(world: &mut MultiPacketWorld) { world.process_empty().await; }
 
 #[then("no messages are received")]

--- a/tests/steps/multi_packet_steps.rs
+++ b/tests/steps/multi_packet_steps.rs
@@ -14,3 +14,9 @@ async fn when_multi_empty(world: &mut MultiPacketWorld) { world.process_empty().
 
 #[then("no messages are received")]
 fn then_multi_empty(world: &mut MultiPacketWorld) { world.verify_empty(); }
+
+#[when("a handler emits more messages than the channel capacity")]
+async fn when_multi_overflow(world: &mut MultiPacketWorld) { world.process_overflow().await; }
+
+#[then("overflow messages are handled according to channel policy")]
+fn then_multi_overflow(world: &mut MultiPacketWorld) { world.verify_overflow(); }

--- a/tests/world.rs
+++ b/tests/world.rs
@@ -12,7 +12,10 @@ use cucumber::World;
 use log::Level;
 use tokio::{
     net::TcpStream,
-    sync::{mpsc, oneshot},
+    sync::{
+        mpsc::{self, error::TrySendError},
+        oneshot,
+    },
 };
 use tokio_util::sync::CancellationToken;
 use wireframe::{
@@ -438,9 +441,22 @@ impl StreamEndWorld {
 #[derive(Debug, Default, World)]
 pub struct MultiPacketWorld {
     messages: Vec<u8>,
+    overflow_error: bool,
 }
 
 impl MultiPacketWorld {
+    async fn collect_frames_from(rx: mpsc::Receiver<u8>) -> Vec<u8> {
+        let (queues, handle) = build_small_queues::<u8>();
+        let shutdown = CancellationToken::new();
+        let mut actor: ConnectionActor<_, ()> =
+            ConnectionActor::new(queues, handle, None, shutdown);
+        actor.set_multi_packet(Some(rx));
+
+        let mut frames = Vec::new();
+        actor.run(&mut frames).await.expect("actor run failed");
+        frames
+    }
+
     /// Helper method to process messages through a multi-packet response built
     /// via [`Response::with_channel`].
     ///
@@ -462,16 +478,10 @@ impl MultiPacketWorld {
             drop(sender);
         });
 
-        let (queues, handle) = build_small_queues::<u8>();
-        let shutdown = CancellationToken::new();
-        let mut actor: ConnectionActor<_, ()> =
-            ConnectionActor::new(queues, handle, None, shutdown);
-        actor.set_multi_packet(Some(rx));
-
-        let mut frames = Vec::new();
-        actor.run(&mut frames).await.expect("actor run failed");
+        let frames = Self::collect_frames_from(rx).await;
         producer.await.expect("producer task panicked");
         self.messages = frames;
+        self.overflow_error = false;
     }
 
     /// Send messages through a multi-packet response and record them.
@@ -485,6 +495,34 @@ impl MultiPacketWorld {
     /// # Panics
     /// Does not panic.
     pub async fn process_empty(&mut self) { self.process_messages(&[]).await; }
+
+    /// Attempt to send more messages than the channel can buffer at once.
+    ///
+    /// # Panics
+    /// Panics if sending to the channel fails unexpectedly or the producer task panics.
+    pub async fn process_overflow(&mut self) {
+        let (sender, response): (mpsc::Sender<u8>, Response<u8, ()>) = Response::with_channel(1);
+        let Response::MultiPacket(rx) = response else {
+            panic!("helper did not return a MultiPacket response");
+        };
+
+        sender.try_send(1).expect("send initial frame");
+        let overflow_error = matches!(sender.try_send(2), Err(TrySendError::Full(2)));
+
+        let producer = tokio::spawn(async move {
+            sender
+                .send(2)
+                .await
+                .expect("send follow-up frame after draining");
+            drop(sender);
+        });
+
+        let frames = Self::collect_frames_from(rx).await;
+        producer.await.expect("producer task panicked");
+
+        self.messages = frames;
+        self.overflow_error = overflow_error;
+    }
 
     /// Verify that no messages were received.
     ///
@@ -501,5 +539,17 @@ impl MultiPacketWorld {
     /// Panics if the messages are not in the expected order.
     pub fn verify(&self) {
         assert_eq!(self.messages, vec![1, 2, 3]);
+    }
+
+    /// Verify that the channel enforced back-pressure.
+    ///
+    /// # Panics
+    /// Panics if no overflow occurred or if the expected messages are missing.
+    pub fn verify_overflow(&self) {
+        assert!(
+            self.overflow_error,
+            "expected overflow error when channel capacity was exceeded",
+        );
+        assert_eq!(self.messages, vec![1, 2]);
     }
 }


### PR DESCRIPTION
## Summary
- add `Response::with_channel` to construct a bounded multi-packet channel and return its sender alongside the response
- exercise the helper from the multi-packet behavioural world and update the feature wording to describe the helper-driven flow
- document the helper in the design doc, user guide, and roadmap, including the background-task streaming example and completion status

## Testing
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`

------
https://chatgpt.com/codex/tasks/task_e_68e062b89c108322a92f83a3cae8b6a5

## Summary by Sourcery

Provide an ergonomic helper for streaming multi-packet responses, update code and examples to use it, and align documentation and tests accordingly

New Features:
- Add Response::with_channel helper to create a bounded multi-packet response channel alongside its sender

Enhancements:
- Refactor multi-packet world and feature tests to use the new helper instead of manual channel setup

Documentation:
- Document the with_channel helper in the design doc, user guide, roadmap, and cucumber scenarios

Tests:
- Add a unit test for with_channel capacity and ordering and update behavioural tests to exercise the helper