### PR TITLE
ADR-001: Replace Cucumber with rstest-bdd for BDD tests

### DIFF
--- a/docs/adr-001-replace-cucumber-with-rstest-bdd.md
+++ b/docs/adr-001-replace-cucumber-with-rstest-bdd.md
@@ -24,7 +24,7 @@ behavioural tests in the same execution environment as unit and integration
 tests. It reuses familiar fixtures, supports compile-time validation of step
 coverage, and keeps Gherkin feature files as the source of truth for behaviour
 specifications. The `rstest-bdd` user's guide documents the current feature set
-and its limitations, which we must account for in a migration plan.
+and its limitations, which must be accounted for in a migration plan.
 [^rstest-bdd-guide]
 
 ## Decision
@@ -60,7 +60,10 @@ step bindings with `rstest-bdd` scenarios and fixtures.
 - Enable `rstest-bdd-macros` compile-time validation and tighten to
   strict validation once all step definitions are local to the Wireframe
   workspace.
-- Remove the Cucumber runner and dependencies only after parity is established
+- Use explicit async boundaries for current async steps, such as helper layers
+  that `block_on` async operations inside a shared test runtime fixture, while
+  keeping async-heavy scenarios on Cucumber until support lands.
+- Remove the Cucumber runner and dependencies only after parity is established,
   and behavioural coverage is fully represented in the new suite.
 
 ## Consequences
@@ -82,7 +85,7 @@ step bindings with `rstest-bdd` scenarios and fixtures.
 
 ## Roadmap
 
-### Phase 1: establish the rstest-bdd foundation
+### Phase 1: Establish the rstest-bdd foundation
 
 - Step: Add the new toolchain and skeleton tests.
   - Task: Add `rstest-bdd` and `rstest-bdd-macros` v0.2.0 as dev-dependencies
@@ -91,18 +94,18 @@ step bindings with `rstest-bdd` scenarios and fixtures.
     runs under `cargo test`.
   - Task: Document the new test layout and invocation in the testing guides.
 
-### Phase 2: migrate existing scenarios
+### Phase 2: Migrate existing scenarios
 
 - Step: Port core behavioural coverage from Cucumber to `rstest-bdd`.
   - Task: Convert each Cucumber world into a `rstest` fixture or
-    `ScenarioState` struct and move shared helpers into `wireframe_testing` as
+    `ScenarioState` struct, and move shared helpers into `wireframe_testing` as
     needed.
   - Task: Translate step definitions to `#[given]`, `#[when]`, and `#[then]`
     functions, keeping the same feature file wording wherever possible.
   - Task: Ensure each migrated scenario passes under `cargo test` and that
     feature coverage matches the existing suite.
 
-### Phase 3: retire Cucumber
+### Phase 3: Retire Cucumber
 
 - Step: Remove the legacy runner and dependencies once parity is confirmed.
   - Task: Delete `tests/cucumber.rs`, Cucumber-specific world modules, and the
@@ -111,5 +114,12 @@ step bindings with `rstest-bdd` scenarios and fixtures.
     `cargo test` for behavioural coverage.
   - Task: Replace or retire documentation that refers to Cucumber, including
     guides and examples in `docs/`.
+
+## Mitigation and rollback
+
+- If `rstest-bdd` limitations block parity, keep the affected scenarios on the
+  Cucumber runner and document the gap in the migration tracker.
+- Continue running both suites until the missing capabilities land or a
+  suitable alternative is agreed, then resume the migration work.
 
 [^rstest-bdd-guide]: See [rstest-bdd user's guide](rstest-bdd-users-guide.md).


### PR DESCRIPTION
## Summary
This PR adds ADR-001 documenting the migration from Cucumber to rstest-bdd for Wireframe's behavioural tests. It outlines the rationale, approach, consequences, and a phased roadmap for migrating to the standard Rust test harness while preserving existing feature files.

## Changes
- Adds docs/adr-001-replace-cucumber-with-rstest-bdd.md containing the architectural decision and migration context.
- References the rstest-bdd guidance and notes planned integration with the repository's testing guides.

## Rationale
- Align behavioural tests with the Rust cargo test harness, ensuring consistent test execution.
- Reuse existing rstest fixtures for dependency injection, reducing bespoke world scaffolding.
- Enable compile-time validation of step coverage and tighter integration with Rust tooling.
- Reduce maintenance overhead from a dedicated Cucumber runner and async runtime wiring.
- Centralize guidance by adopting an in-repo ADR that complements existing documentation.

## Approach
- Keep existing .feature files with minor edits where rstest-bdd syntax differs.
- Replace Cucumber World structs with rstest fixtures and, where needed, ScenarioState/Slot helpers.
- Convert step macros (given/when/then) to rstest-bdd equivalents using fixture injection rather than World arguments.
- Bind scenarios via #[scenario] macros that point at the same feature files so cargo test runs them alongside other tests.
- Enable rstest-bdd compile-time validation; tighten validation as step definitions become local to the workspace.
- Remove the Cucumber runner and dependencies once parity is established and coverage is represented in the new suite.

## Consequences
- Behavioural tests will run under cargo test, simplifying CI and local workflows.
- Step definitions move to synchronous functions; some async steps may require refactoring.
- Temporary parallel operation of two frameworks increases short-term maintenance.
- rstest-bdd limitations (e.g., wildcard steps) may require rewriting certain scenarios until upstream support exists.

## Roadmap
### Phase 1: Establish the rstest-bdd foundation
- Add the new toolchain and skeleton tests with rstest-bdd and rstest-bdd-macros v0.2.0, enabling compile-time validation.
- Create a tests/bdd/ module layout and a minimal smoke scenario under cargo test.
- Document the new test layout and invocation in the testing guides.

### Phase 2: Migrate existing scenarios
- Port core behavioural coverage from Cucumber to rstest-bdd by converting worlds to rstest fixtures or ScenarioState structures.
- Translate step definitions to #[given], #[when], #[then] while preserving feature file wording where possible.
- Validate that migrated scenarios pass under cargo test and that feature coverage matches.

### Phase 3: Retire Cucumber
- Remove the legacy runner and Cucumber-specific code and dependencies.
- Update CI pipelines to drop the Cucumber target and rely on cargo test for behavioural coverage.
- Update documentation to retire references to Cucumber.

## References
- See docs/rstest-bdd-users-guide.md for current guidance on rstest-bdd.


🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/8bda5c9b-873a-4c8c-adad-7ecc83bafc31

## Summary by Sourcery

Documentation:
- Add ADR-001 describing the migration of behavioural tests from Cucumber to rstest-bdd, including rationale, consequences, and a three-phase roadmap for implementation.