### PR TITLE
ci: Update shared-actions SHAs in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@988ff278fcab48e8a932e2af88ce1aaaa78386a0
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
       - name: Format
         run: make check-fmt
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@988ff278fcab48e8a932e2af88ce1aaaa78386a0
+        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:
           output-path: lcov.info
           format: lcov
@@ -31,7 +31,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@988ff278fcab48e8a932e2af88ce1aaaa78386a0
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         
         with:
           format: lcov


### PR DESCRIPTION
## Summary
- Update shared-actions SHA references in CI workflow to latest commits

## Changes

### CI Workflows
- **ci.yml**: Bump shared-actions references:
  - setup-rust from 988ff278fcab48e8a932e2af88ce1aaaa78386a0 to aebb3f5b831102e2a10ef909c83d7d50ea86c332
  - generate-coverage from 988ff278fcab48e8a932e2af88ce1aaaa78386a0 to aebb3f5b831102e2a10ef909c83d7d50ea86c332
  - upload-codescene-coverage from 988ff278fcab48e8a932e2af88ce1aaaa78386a0 to aebb3f5b831102e2a10ef909c83d7d50ea86c332

## Rationale
- Ensures CI uses updated action versions and aligns with repository's shared-actions reference.

## Testing
- [x] Trigger CI workflow and confirm steps run and pass
- [x] Confirm coverage generation and upload steps execute correctly

## Notes
- No functional changes to codebase; just workflow references.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/7da6b47f-534f-4f31-b691-1fe6cfb70a44

## Summary by Sourcery

CI:
- Bump shared-actions references in ci.yml to newer commit SHAs for setup-rust, generate-coverage, and upload-codescene-coverage.