### PR TITLE
Refactor fragmentation: move fragment_packet to fragment crate

### DIFF
--- a/src/app/envelope.rs
+++ b/src/app/envelope.rs
@@ -6,7 +6,11 @@
 //! [`crate::app::builder::WireframeApp`] for how envelopes are used when
 //! registering routes.
 
-use crate::{correlation::CorrelatableFrame, message::Message};
+use crate::{
+    correlation::CorrelatableFrame,
+    fragment::{FragmentParts, Fragmentable},
+    message::Message,
+};
 
 /// Envelope-like type used to wrap incoming and outgoing messages.
 ///
@@ -241,5 +245,21 @@ impl From<PacketParts> for Envelope {
         let correlation_id = p.correlation_id();
         let payload = p.payload();
         Envelope::new(id, correlation_id, payload)
+    }
+}
+
+// Blanket implementation: any Packet is automatically Fragmentable.
+impl<T: Packet> Fragmentable for T {
+    fn into_fragment_parts(self) -> FragmentParts {
+        let parts = self.into_parts();
+        FragmentParts::new(parts.id(), parts.correlation_id(), parts.payload())
+    }
+
+    fn from_fragment_parts(parts: FragmentParts) -> Self {
+        T::from_parts(PacketParts::new(
+            parts.id(),
+            parts.correlation_id(),
+            parts.payload(),
+        ))
     }
 }

--- a/src/app/fragment_utils.rs
+++ b/src/app/fragment_utils.rs
@@ -1,7 +1,12 @@
 //! Shared helpers for applying transport-level fragmentation to packets.
 //!
-//! This module re-exports [`fragment_packet`] from the canonical location in
-//! [`crate::fragment::packet`] to preserve backward compatibility.
+//! **Deprecated:** This module re-exports [`fragment_packet`] from its
+//! canonical location in [`crate::fragment`]. New code should import directly
+//! from [`crate::fragment::fragment_packet`] instead.
 
 // Re-export from canonical location for backward compatibility.
+#[deprecated(
+    since = "0.3.0",
+    note = "use `crate::fragment::fragment_packet` instead"
+)]
 pub use crate::fragment::fragment_packet;

--- a/src/app/fragmentation_state.rs
+++ b/src/app/fragmentation_state.rs
@@ -8,6 +8,7 @@ use thiserror::Error;
 
 use super::{Packet, PacketParts};
 use crate::fragment::{
+    Fragmentable,
     FragmentationError,
     Fragmenter,
     MessageId,
@@ -39,7 +40,10 @@ impl FragmentationState {
         }
     }
 
-    pub(crate) fn fragment<E: Packet>(&self, packet: E) -> Result<Vec<E>, FragmentationError> {
+    pub(crate) fn fragment<E: Fragmentable>(
+        &self,
+        packet: E,
+    ) -> Result<Vec<E>, FragmentationError> {
         crate::fragment::fragment_packet(&self.fragmenter, packet)
     }
 

--- a/src/fragment/mod.rs
+++ b/src/fragment/mod.rs
@@ -22,7 +22,7 @@ pub use fragmenter::{FragmentBatch, FragmentFrame, Fragmenter};
 pub use header::FragmentHeader;
 pub use id::MessageId;
 pub use index::FragmentIndex;
-pub use packet::fragment_packet;
+pub use packet::{FragmentParts, Fragmentable, fragment_packet};
 pub use payload::{
     FRAGMENT_MAGIC,
     decode_fragment_payload,

--- a/src/fragment/packet.rs
+++ b/src/fragment/packet.rs
@@ -1,11 +1,63 @@
 //! Shared helpers for applying transport-level fragmentation to packets.
 //!
-//! This module provides the [`fragment_packet`] function used by both the
-//! connection actor and the application layer to split oversized payloads
-//! into transport-safe fragment frames.
+//! This module provides the [`Fragmentable`] trait and [`fragment_packet`]
+//! function used by both the connection actor and the application layer to
+//! split oversized payloads into transport-safe fragment frames.
 
 use super::{FragmentationError, Fragmenter, encode_fragment_payload};
-use crate::app::{Packet, PacketParts};
+
+/// Component values extracted from or used to build a [`Fragmentable`] packet.
+///
+/// This type mirrors [`crate::app::PacketParts`] but lives in the fragment
+/// module to avoid a layering violation where fragmentation depends on app
+/// types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FragmentParts {
+    id: u32,
+    correlation_id: Option<u64>,
+    payload: Vec<u8>,
+}
+
+impl FragmentParts {
+    /// Construct a new set of fragment parts.
+    #[must_use]
+    pub fn new(id: u32, correlation_id: Option<u64>, payload: Vec<u8>) -> Self {
+        Self {
+            id,
+            correlation_id,
+            payload,
+        }
+    }
+
+    /// Return the message identifier.
+    #[must_use]
+    pub const fn id(&self) -> u32 { self.id }
+
+    /// Retrieve the correlation identifier, if present.
+    #[must_use]
+    pub const fn correlation_id(&self) -> Option<u64> { self.correlation_id }
+
+    /// Consume the parts and return the raw payload bytes.
+    #[must_use]
+    pub fn payload(self) -> Vec<u8> { self.payload }
+}
+
+/// A packet that can be decomposed into parts and reconstructed for fragmentation.
+///
+/// This trait captures the minimal interface required by the fragmentation layer
+/// to split oversized packets into smaller frames and reassemble them. It
+/// intentionally avoids depending on application-layer types like
+/// [`crate::app::Packet`].
+///
+/// Types implementing [`crate::app::Packet`] automatically implement this trait
+/// via a blanket implementation in the `app` module.
+pub trait Fragmentable: Send + Sync + 'static + Sized {
+    /// Consume the packet and return its identifier, correlation id and payload bytes.
+    fn into_fragment_parts(self) -> FragmentParts;
+
+    /// Construct a new packet from raw parts.
+    fn from_fragment_parts(parts: FragmentParts) -> Self;
+}
 
 /// Fragment a packet using the provided fragmenter, returning one or more frames.
 ///
@@ -15,18 +67,18 @@ use crate::app::{Packet, PacketParts};
 ///
 /// Returns [`FragmentationError`] if fragmenting the payload fails or if
 /// encoding the fragment header and payload into an on-wire frame fails.
-pub fn fragment_packet<E: Packet>(
+pub fn fragment_packet<E: Fragmentable>(
     fragmenter: &Fragmenter,
     packet: E,
 ) -> Result<Vec<E>, FragmentationError> {
-    let parts = packet.into_parts();
+    let parts = packet.into_fragment_parts();
     let id = parts.id();
     let correlation = parts.correlation_id();
     let payload = parts.payload();
 
     let batch = fragmenter.fragment_bytes(&payload)?;
     if !batch.is_fragmented() {
-        return Ok(vec![E::from_parts(PacketParts::new(
+        return Ok(vec![E::from_fragment_parts(FragmentParts::new(
             id,
             correlation,
             payload,
@@ -37,7 +89,11 @@ pub fn fragment_packet<E: Packet>(
     for fragment in batch {
         let (header, payload) = fragment.into_parts();
         let encoded = encode_fragment_payload(header, &payload)?;
-        frames.push(E::from_parts(PacketParts::new(id, correlation, encoded)));
+        frames.push(E::from_fragment_parts(FragmentParts::new(
+            id,
+            correlation,
+            encoded,
+        )));
     }
     Ok(frames)
 }


### PR DESCRIPTION
## Summary
- Refactors fragmentation: centralizes fragment_packet in the fragment crate and adds Fragmentable/FragmentParts
- Keeps backward compatibility via re-exports and canonical path changes
- Improves layering by consolidating fragmentation logic in the fragment module
- Adds envelope blanket Fragmentable implementation for all Packet types

## Changes

### Core changes
- Added new module: `src/fragment/packet.rs` implementing `fragment_packet` along with `FragmentParts` and `Fragmentable`
- Created `pub mod packet` in `src/fragment/mod.rs` and exposed `fragment_packet`, `FragmentParts`, and `Fragmentable` publicly
- Exported `FragmentParts` and `Fragmentable` from `crate::fragment` for convenient access
- Updated `src/app/envelope.rs` to provide a blanket implementation: any `Packet` now implements `Fragmentable`
- Updated `src/app/fragmentation_state.rs` to accept `E: Fragmentable` and call `crate::fragment::fragment_packet` instead of app-layer path
- Updated `src/app/fragment_utils.rs` to re-export the canonical `fragment_packet` from `crate::fragment`, preserving existing imports

### Compatibility
- Re-export ensures existing code paths continue to compile without changes

### Behavior
- Fragmentation behavior remains unchanged: oversized payloads are split into frames with preserved IDs and correlation IDs

### Why
- Improves layering by moving fragmentation logic into the fragment crate, avoiding cross-layer dependencies

### Test plan
- `cargo test`
- Build and run tests to ensure no regressions
- Optionally test with an oversized payload to verify fragmentation frames are produced as before

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---
ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/58637d28-099d-4210-84c7-3b4d55874cd5

📝 Closes #431

## Summary by Sourcery

Centralize packet fragmentation logic in the fragment module while preserving existing public APIs.

Enhancements:
- Move the packet fragmentation helper into a new fragment::packet module and expose it via the fragment crate API.
- Update app-layer fragmentation state to depend on the fragment-layer fragment_packet function instead of an app-local helper.
- Re-export fragment_packet from the existing app::fragment_utils module to maintain backward-compatible imports.