### PR TITLE
Rename BackoffConfig.normalised to normalized (US spelling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
   instead.
 - Breaking: Marked `ServerError` as `#[non_exhaustive]`. Downstream consumers
   must add a wildcard arm when matching it.
+- Breaking: Renamed `BackoffConfig::normalised` to `BackoffConfig::normalized`
+  to align the public API spelling with American English.
 - Exposed `MAX_PUSH_RATE` for configuring push queue rate limits.
 - Added a `Fragmenter` helper that slices oversized messages into sequential
   fragments, stamping each piece with a `FragmentHeader` for transparent

--- a/docs/execplans/migrate-from-cucumber-to-rstest-bdd.md
+++ b/docs/execplans/migrate-from-cucumber-to-rstest-bdd.md
@@ -523,8 +523,8 @@ Phase 2 with `PanicWorld`.
 
 ### Risk 3: Fragment.feature Complexity (11 scenarios)
 
-**Mitigation**: Migrate in Phase 4 after patterns are proven. Can use `scenarios!`
-macro if individual tests become verbose.
+**Mitigation**: Migrate in Phase 4 after patterns are proven. Can use
+`scenarios!` macro if individual tests become verbose.
 
 ### Risk 4: Compile-Time Validation False Positives
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -55,7 +55,7 @@ src/server/runtime.rs:221), immediately before the accept loop begins.
 
 The accept loop retries failed `accept()` calls using exponential backoff.
 `accept_backoff(cfg)` sets both bounds using a `BackoffConfig` value. The
-builder normalises the supplied configuration via `BackoffConfig::normalised`,
+builder normalises the supplied configuration via `BackoffConfig::normalized`,
 so out-of-range values are adjusted rather than preserved:
 
 - `initial_delay` – starting delay for the first retry, clamped to at least 1

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -139,17 +139,17 @@ where
         /// Configure accept-loop backoff behaviour.
         ///
         /// The supplied configuration is passed to
-        /// [`BackoffConfig::normalised`] (`cfg.normalised()`) before being
+        /// [`BackoffConfig::normalized`] (`cfg.normalized()`) before being
         /// stored. Normalisation clamps `initial_delay` to at least 1 ms and no
         /// greater than `max_delay`. If `initial_delay` exceeds `max_delay`,
         /// the values are swapped. Normalisation applies any other adjustments
-        /// `BackoffConfig::normalised` defines so out-of-range values are
+        /// `BackoffConfig::normalized` defines so out-of-range values are
         /// corrected rather than preserved.
         ///
         /// Invariants:
         /// - `initial_delay` must be >= 1 ms
         /// - `initial_delay` must be <= `max_delay`
-        accept_backoff, backoff_config, cfg: BackoffConfig => cfg.normalised()
+        accept_backoff, backoff_config, cfg: BackoffConfig => cfg.normalized()
     );
 
     /// Returns the configured number of worker tasks for the server.

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -335,7 +335,7 @@ pub(super) async fn accept_loop<F, T, L, App>(
         tracker,
         backoff,
     } = options;
-    let backoff = backoff.normalised();
+    let backoff = backoff.normalized();
     debug_assert!(
         backoff.initial_delay <= backoff.max_delay,
         "BackoffConfig invariant violated: initial_delay > max_delay"

--- a/src/server/runtime/backoff.rs
+++ b/src/server/runtime/backoff.rs
@@ -49,12 +49,12 @@ impl BackoffConfig {
     ///     max_delay: Duration::from_millis(1),
     /// };
     ///
-    /// let normalised = cfg.normalised();
-    /// assert_eq!(normalised.initial_delay, Duration::from_millis(1));
-    /// assert_eq!(normalised.max_delay, Duration::from_millis(5));
+    /// let normalized = cfg.normalized();
+    /// assert_eq!(normalized.initial_delay, Duration::from_millis(1));
+    /// assert_eq!(normalized.max_delay, Duration::from_millis(5));
     /// ```
     #[must_use]
-    pub fn normalised(mut self) -> Self {
+    pub fn normalized(mut self) -> Self {
         self.initial_delay = self.initial_delay.max(Duration::from_millis(1));
         self.max_delay = self.max_delay.max(Duration::from_millis(1));
         if self.initial_delay > self.max_delay {


### PR DESCRIPTION
## Summary
- Rename BackoffConfig.normalised to BackoffConfig::normalized across the codebase to adopt American English spelling.
- Update all internal usage, docs, and tests accordingly.
- This is a breaking change for downstream users; call sites must be updated.

## Changes
### Core changes
- Backoff API: replace `BackoffConfig::normalised()` with `BackoffConfig::normalized()`.
- Runtime:
  - In `src/server/runtime.rs`, use `backoff.normalized()` when preparing the backoff configuration.
- Server config:
  - In `src/server/config/mod.rs`, document and reference `cfg.normalized()` instead of `cfg.normalised()`.
- Documentation/comments:
  - Update examples and commentary to reference `normalized`.

### Documentation changes
- CHANGELOG.md: Add breaking change note for the API rename.
- docs/server/configuration.md: Update references to use `BackoffConfig::normalized`.
- Other docs/comments that mentioned `normalised` updated to `normalized`.
- Doc tests/examples in `src/server/runtime/backoff.rs` updated accordingly.

### Tests / Examples changes
- Doc tests and inline examples updated from `normalised()` to `normalized()`.

## Migration Guide
- Update all call sites from:
  - `cfg.normalised()` to `cfg.normalized()`
  - `backoff.normalised()` to `backoff.normalized()`
- Rebuild and run tests to ensure all references are updated.

## Test plan
- [x] Build succeeds with updated API.
- [x] Doc tests compile with new method name.
- [x] No remaining references to `normalised()` in code or docs.
- [x] Runtime acceptance loop uses the corrected `normalized()` backoff configuration.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/1bd3b44a-656f-416a-a9fd-f0b1c4073512

📝 Closes #441

## Summary by Sourcery

Rename the backoff configuration normalisation method to use American English spelling and update all references across code, configuration, and docs.

Enhancements:
- Rename `BackoffConfig::normalised` to `BackoffConfig::normalized` and update runtime usage and server configuration to match.

Documentation:
- Update configuration and changelog documentation to reference `BackoffConfig::normalized` and note the breaking API change.

Chores:
- Tidy a minor formatting issue in migration documentation.