### PR TITLE
Add ExecPlan docs for API cleanup critique

### DIFF
--- a/docs/execplans/enable-and-resolve-doctests.md
+++ b/docs/execplans/enable-and-resolve-doctests.md
@@ -1,0 +1,209 @@
+# Enable and resolve doctests
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+`PLANS.md` is not present in this repository at the time this plan was drafted.
+
+## Purpose / big picture
+
+Wireframe currently sets `doctest = false` in `Cargo.toml`, which means many
+Rustdoc examples are never compile-validated. This plan enables doctests and
+brings all public API examples to a compile-clean state. Success is observable
+when `cargo test --doc` passes, doctests are scoped to public API
+documentation, and the repository tracks a measurable runnable-vs-`no_run`
+benchmark.
+
+## Constraints
+
+- Doctests must be enabled for the library crate in `Cargo.toml`.
+- All doctest code blocks must compile under supported feature combinations.
+- Doctest examples must not be attached to private items or test-only helper
+  modules.
+- Doctest examples must not be attached to `#[cfg(test)]` test functions.
+- Behavioural integration tests and unit tests remain separate from doctests;
+  doctests document public API usage, not internal test scaffolding.
+- No new runtime-only external services (network/database) are required for
+  doctest execution.
+
+## Tolerances (exception triggers)
+
+- Scope: if enabling doctests requires changes in more than 40 files, stop and
+  escalate.
+- Interface: if this work requires public API signature changes, stop and
+  escalate.
+- Dependencies: if a new dependency is required only to make doctests pass,
+  stop and escalate.
+- Iterations: if `cargo test --doc --all-features` fails after 3 full fix
+  loops, stop and escalate with failure clusters.
+- Ambiguity: if runnable-vs-`no_run` policy cannot satisfy stakeholder intent,
+  stop and escalate with options.
+
+## Risks
+
+- Risk: examples that open sockets or spawn long-running tasks may hang under
+  doctest execution. Severity: medium Likelihood: high Mitigation: convert
+  those blocks to `no_run` while preserving compile checks.
+
+- Risk: examples in private modules may accidentally become doctests once
+  doctests are enabled. Severity: medium Likelihood: medium Mitigation: audit
+  private/test modules and strip runnable example blocks from non-public item
+  docs.
+
+- Risk: feature-gated API examples may fail when doctests run under default
+  features. Severity: medium Likelihood: medium Mitigation: annotate examples
+  with explicit feature guards and validate under both default and
+  `--all-features` runs.
+
+## Progress
+
+- [x] (2026-02-18) Drafted ExecPlan with success criteria and milestones.
+- [ ] Inventory all Rustdoc code blocks in `src/` and classify by item
+      visibility and runtime profile.
+- [ ] Enable doctests in `Cargo.toml` and add a dedicated command target for
+      doctest execution.
+- [ ] Resolve compile failures in all doctest blocks.
+- [ ] Enforce doctest scope rules (no private/test item doctest examples).
+- [ ] Compute and validate runnable-vs-`no_run` benchmark.
+- [ ] Run quality gates and update user documentation.
+
+## Surprises & Discoveries
+
+- Observation: None yet.
+  Evidence: Plan-only phase. Impact: None yet.
+
+## Decision Log
+
+- Decision: Use an explicit benchmark of at least 70% runnable doctests and no
+  more than 30% `no_run` doctests. Rationale: This preserves high executable
+  documentation coverage while keeping side-effect-heavy examples
+  compile-checked only. The wording request about `no_run` percentage is
+  ambiguous; this interpretation optimizes usefulness. Date/Author: 2026-02-18
+  / Codex.
+
+- Decision: Treat doctest ownership as public API documentation only.
+  Rationale: This prevents mixing testing concerns with user-facing docs and
+  aligns with Rustdoc guidance. Date/Author: 2026-02-18 / Codex.
+
+## Outcomes & Retrospective
+
+Not started. Populate after implementation milestones complete.
+
+## Context and orientation
+
+Current state relevant to this plan:
+
+- `Cargo.toml` disables doctests with `doctest = false` in `[lib]`.
+- Public docs are spread across module-level docs and item-level docs in
+  `src/`.
+- The repository already contains extensive integration and behavioural tests in
+  `tests/`; these are not doctest replacements.
+- `docs/rust-doctest-dry-guide.md` documents project expectations for doctests
+  and should be kept aligned with implementation reality.
+
+Key files expected to change:
+
+- `Cargo.toml`
+- `Makefile`
+- Rustdoc-bearing modules under `src/`
+- `docs/rust-doctest-dry-guide.md`
+- `docs/users-guide.md` (if guidance text requires updates)
+
+## Plan of work
+
+Stage A performs inventory and policy assignment before changing behaviour.
+Generate a report of all Rust code blocks in Rustdoc comments and classify each
+as `runnable`, `no_run`, `ignore`, or `compile_fail`, with item visibility
+(public/private/test-only) and module path.
+
+Stage B enables doctests and introduces a repeatable verification command path.
+Set `doctest = true` and add a dedicated Make target (`make test-doc`) that
+runs `cargo test --doc --all-features` with warnings denied.
+
+Stage C resolves compile failures and applies runtime policy. Pure examples
+should be runnable unless there is a concrete side effect risk. Examples that
+perform networking, rely on timing races, or represent non-deterministic flows
+should use `no_run` and still compile.
+
+Stage D enforces scope boundaries. Remove or rewrite example blocks attached to
+private items and `#[cfg(test)]` modules so doctest burden stays on public API
+surface only.
+
+Stage E locks observability and docs. Add benchmark reporting (runnable vs
+`no_run`) to a scriptable check, then update documentation with the policy and
+how to interpret exceptions.
+
+Each stage ends with validation before advancing.
+
+## Concrete steps
+
+Run all commands from repository root (`/home/user/project`).
+
+1. Inventory Rustdoc code blocks and classify candidates.
+
+   `rg -n "^\s*///|^\s*//!|```rust" src docs`
+
+2. Enable doctests and add an explicit Doctest Make target.
+
+   `make check-fmt`
+
+3. Execute doctests with all features.
+
+   `RUSTFLAGS="-D warnings" cargo test --doc --all-features`
+
+4. Execute standard Rust quality gates after fixes.
+
+   `make check-fmt` `make lint` `make test`
+
+5. Execute markdown quality gates if docs were changed.
+
+   `make fmt` `make markdownlint` `make nixie`
+
+Expected success indicators:
+
+- Doctest command exits 0.
+- No doctest compile errors remain.
+- Benchmark report confirms runnable ratio >= 70% and `no_run` ratio <= 30%.
+
+## Validation and acceptance
+
+Acceptance criteria:
+
+- `cargo test --doc --all-features` passes.
+- All public Rustdoc examples compile.
+- Runnable benchmark target is met: at least 70% runnable.
+- `no_run` benchmark bound is met: no more than 30% `no_run`.
+- No doctest-bearing code blocks remain on private functions or test-only
+  modules.
+- `make check-fmt`, `make lint`, and `make test` pass.
+- `make fmt`, `make markdownlint`, and `make nixie` pass if docs changed.
+
+## Idempotence and recovery
+
+All steps are idempotent. Re-running inventory and doctest commands is safe. If
+a doctest fix introduces regressions, revert only the affected file and re-run
+the stage-specific command before continuing.
+
+## Artifacts and notes
+
+Implementation should retain:
+
+- A short inventory summary of doctest blocks by class.
+- A benchmark summary with counts and percentages.
+- Failure cluster notes for any blocks converted to `no_run`.
+
+## Interfaces and dependencies
+
+No new external dependencies are planned.
+
+Expected interfaces at completion:
+
+- `Cargo.toml` `[lib]` no longer disables doctests.
+- `Makefile` includes a repeatable doctest command target.
+- Public Rustdoc examples compile under `cargo test --doc --all-features`.
+
+Revision note: Initial draft created on 2026-02-18 to plan doctest enablement,
+coverage policy, and validation workflow.

--- a/docs/execplans/error-surface-coherence.md
+++ b/docs/execplans/error-surface-coherence.md
@@ -1,0 +1,208 @@
+# Unify the public error surface
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+`PLANS.md` is not present in this repository at the time this plan was drafted.
+
+## Purpose / big picture
+
+Wireframe currently exposes multiple top-level error families, including two
+public `WireframeError` definitions and a root `Result` alias coupled to app
+setup. This plan consolidates user-facing errors into one canonical
+`wireframe::WireframeError` type and one canonical `wireframe::Result<T>`
+alias, so downstream users have a single error contract throughout the crate.
+
+## Constraints
+
+- End state must have exactly one public `WireframeError` type at crate level.
+- End state must have exactly one public `Result<T>` alias at crate level,
+  backed by the canonical `WireframeError`.
+- Subsystem-specific errors may remain, but they must convert into the single
+  `WireframeError` via `From` implementations.
+- Public error docs and examples in `docs/users-guide.md` must reflect the new
+  unified contract.
+- Keep `thiserror`-derived semantic variants; avoid introducing opaque
+  catch-all boxed error variants as the primary public surface.
+
+## Tolerances (exception triggers)
+
+- Scope: if unification requires edits in more than 50 files, stop and
+  escalate.
+- Interface: if consumer migration cannot be expressed clearly in one migration
+  guide section, stop and escalate.
+- Dependencies: if new error-handling crates are needed, stop and escalate.
+- Iterations: if `make test` fails after 3 full integration loops, stop and
+  escalate with categorized failures.
+- Ambiguity: if subsystem semantics force incompatible variant designs, stop
+  and escalate with explicit alternatives.
+
+## Risks
+
+- Risk: collapsing multiple error types may blur domain intent if variant
+  boundaries are vague. Severity: high Likelihood: medium Mitigation: define
+  subsystem-specific nested enums and preserve variant intent through clear
+  names and docs.
+
+- Risk: client/server/request APIs currently parameterized over protocol errors
+  may become difficult to model. Severity: high Likelihood: medium Mitigation:
+  settle on one canonical protocol variant strategy early and add regression
+  tests for typed protocol failure paths.
+
+- Risk: migration burden for existing users may be high due to type renames.
+  Severity: medium Likelihood: high Mitigation: provide explicit before/after
+  mapping in migration guide with compile-focused examples.
+
+## Progress
+
+- [x] (2026-02-18) Drafted ExecPlan for error surface unification.
+- [ ] Catalogue all public error types and all public `Result` aliases.
+- [ ] Define canonical `WireframeError` structure and conversion policy.
+- [ ] Refactor modules to use canonical error type.
+- [ ] Update docs and migration guide.
+- [ ] Run full quality gates.
+
+## Surprises & Discoveries
+
+- Observation: None yet.
+  Evidence: Plan-only phase. Impact: None yet.
+
+## Decision Log
+
+- Decision: Canonicalize on a dedicated error module (for example,
+  `src/error.rs`) and re-export only one `WireframeError` and one `Result<T>`
+  from `src/lib.rs`. Rationale: This enforces a single front-door contract and
+  removes naming collisions. Date/Author: 2026-02-18 / Codex.
+
+- Decision: Keep subsystem enums where they add semantic value, but make them
+  implementation detail or nested variants of canonical error. Rationale:
+  Preserves meaning without fragmenting top-level API. Date/Author: 2026-02-18
+  / Codex.
+
+## Outcomes & Retrospective
+
+Not started. Populate after implementation milestones complete.
+
+## Context and orientation
+
+Current public error-related surface includes:
+
+- `src/app/error.rs` with `WireframeError`, `SendError`, and `Result<T>`.
+- `src/response.rs` with generic `WireframeError<E>`.
+- `src/lib.rs` re-exporting `app::error::Result` while also re-exporting
+  response `WireframeError`.
+- Additional public subsystem errors in client, codec, server, fragment,
+  message assembler, and extractor modules.
+
+The objective is not to remove domain information. The objective is to ensure
+all public failure paths resolve through one top-level error type that users
+can reliably match and log.
+
+Likely touched files:
+
+- `src/lib.rs`
+- `src/app/error.rs`
+- `src/response.rs`
+- `src/client/error.rs`
+- `src/server/error.rs`
+- `src/codec/error.rs`
+- `src/fragment/error.rs`
+- `docs/users-guide.md`
+- `docs/v0-1-0-to-v0-2-0-migration-guide.md`
+
+## Plan of work
+
+Stage A performs an error inventory. Build a source-of-truth list of all public
+error enums and aliases, plus where each appears in public signatures.
+
+Stage B defines the canonical model. Introduce one top-level `WireframeError`
+enum with semantically grouped variants (for example: app configuration,
+transport I/O, codec, protocol, client, server, fragmentation, extractor, and
+send path failures). Include strict conversion rules.
+
+Stage C migrates module signatures. Replace local top-level `WireframeError`
+exports with either internal domain errors or aliases that resolve to canonical
+`WireframeError`. Eliminate duplicate top-level names.
+
+Stage D refreshes docs and migration guidance. Update user guide examples and
+publish explicit migration mappings for renamed or removed variants/types.
+
+Stage E validates behaviour through compile and test gates.
+
+## Concrete steps
+
+Run all commands from repository root (`/home/user/project`).
+
+1. Inventory error types and aliases.
+
+   `rg -n "pub enum .*Error|pub type Result<|WireframeError" src`
+
+2. Introduce canonical error module and integrate conversions.
+
+   `make check-fmt`
+
+3. Compile and run tests.
+
+   `make lint` `make test`
+
+4. Validate docs after migration updates.
+
+   `make fmt` `make markdownlint` `make nixie`
+
+Expected success indicators:
+
+- One public `WireframeError` remains.
+- One public `Result<T>` alias remains.
+- All previously public error paths convert into canonical error.
+
+## Validation and acceptance
+
+Acceptance criteria:
+
+- `wireframe::WireframeError` is the only public top-level error type named
+  `WireframeError`.
+- `wireframe::Result<T>` is the only public crate-level result alias.
+- Public signatures that previously returned alternative top-level error types
+  now return `WireframeError` (directly or via alias).
+- Migration guide contains before/after mapping snippets.
+- `make check-fmt`, `make lint`, and `make test` pass.
+- `make fmt`, `make markdownlint`, and `make nixie` pass for doc changes.
+
+## Idempotence and recovery
+
+The migration is refactor-oriented and re-runnable in slices. If a migration
+step causes broad breakage, restore the last coherent module boundary and
+re-run inventory before continuing.
+
+## Artifacts and notes
+
+Implementation should capture:
+
+- Error type inventory (before and after).
+- Variant mapping table used for migration docs.
+- Representative downstream callsite updates.
+
+## Interfaces and dependencies
+
+No new dependencies are planned.
+
+Target interface sketch at completion:
+
+    pub enum WireframeError {
+        App(AppError),
+        Transport(std::io::Error),
+        Codec(CodecError),
+        Protocol(ProtocolError),
+        Client(ClientError),
+        Server(ServerError),
+        Fragment(FragmentError),
+        // Additional semantic variants as required.
+    }
+
+    pub type Result<T> = std::result::Result<T, WireframeError>;
+
+Revision note: Initial draft created on 2026-02-18 to plan consolidation of all
+public error paths into one canonical type.

--- a/docs/execplans/public-api-surface.md
+++ b/docs/execplans/public-api-surface.md
@@ -1,0 +1,193 @@
+# Reshape the public API surface
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+`PLANS.md` is not present in this repository at the time this plan was drafted.
+
+## Purpose / big picture
+
+Wireframe exposes a very wide root API, which makes discovery and maintenance
+harder and increases accidental coupling. This plan defines a tiered,
+progressive-discovery API shape: a small root, focused domain modules, and
+optional convenience prelude. Test-only helpers become private to tests (or to
+`wireframe_testing`) rather than regular public API.
+
+## Constraints
+
+- Keep crate root intentionally small and stable in shape.
+- Organize exports so users can discover core workflows from root, then drill
+  into module-specific detail.
+- Test-only modules and helpers must not be publicly reachable in normal builds.
+- Backwards compatibility is not required for this work.
+- `docs/v0-1-0-to-v0-2-0-migration-guide.md` must be updated with all breaking
+  API surface changes introduced by this plan.
+
+## Tolerances (exception triggers)
+
+- Scope: if API reshaping requires edits in more than 60 files, stop and
+  escalate.
+- Interface: if root simplification breaks internal integration tests in ways
+  that cannot be addressed with straightforward import updates, stop and
+  escalate.
+- Dependencies: if new dependencies are required solely for re-export hygiene,
+  stop and escalate.
+- Iterations: if `make test` fails after 3 complete repair loops, stop and
+  escalate with grouped import/signature issues.
+- Ambiguity: if two valid root layouts exist with materially different user
+  ergonomics, stop and escalate with both options.
+
+## Risks
+
+- Risk: aggressive root pruning may reduce short-term ergonomics for existing
+  users. Severity: medium Likelihood: high Mitigation: provide
+  `wireframe::prelude` and a migration guide with concrete import mappings.
+
+- Risk: hiding test helpers may disrupt internal or companion-crate tests.
+  Severity: medium Likelihood: medium Mitigation: move needed helpers to
+  `wireframe_testing` or `#[cfg(test)]` local modules with explicit ownership.
+
+- Risk: module boundary edits may produce circular dependencies.
+  Severity: high Likelihood: low Mitigation: perform export-surface changes
+  first, then internal visibility tightening, with compile checks at each stage.
+
+## Progress
+
+- [x] (2026-02-18) Drafted ExecPlan for public API surface cleanup.
+- [ ] Define target root API map and progressive discovery tiers.
+- [ ] Refactor `src/lib.rs` exports to the target map.
+- [ ] Tighten module visibility (`pub` to `pub(crate)` where applicable).
+- [ ] Remove public test-only reachability from production builds.
+- [ ] Update migration guide and user docs.
+- [ ] Run full quality gates.
+
+## Surprises & Discoveries
+
+- Observation: None yet.
+  Evidence: Plan-only phase. Impact: None yet.
+
+## Decision Log
+
+- Decision: Use three discovery tiers.
+  Rationale: Tiered discovery keeps root simple while preserving depth.
+  Date/Author: 2026-02-18 / Codex.
+
+- Decision: Prefer module-based access over broad root re-export lists.
+  Rationale: Module paths communicate conceptual ownership and reduce root
+  clutter. Date/Author: 2026-02-18 / Codex.
+
+## Outcomes & Retrospective
+
+Not started. Populate after implementation milestones complete.
+
+## Context and orientation
+
+Current state:
+
+- `src/lib.rs` exports many modules and large re-export groups directly from
+  root.
+- Some test-oriented helpers are conditionally exported with cargo features.
+- `src/connection/mod.rs` exposes a `test_support` module under
+  `cfg(not(loom))`, which is broader than test-only scope.
+
+Target state:
+
+- Root surfaces only the primary concepts and canonical errors/results.
+- Detailed APIs live under clearly owned modules (`app`, `server`, `client`,
+  `codec`, `fragment`, `message_assembler`, and similar).
+- Optional `prelude` includes high-frequency traits/types only.
+- Test support is private to tests or externalized to `wireframe_testing`.
+
+Likely touched files:
+
+- `src/lib.rs`
+- module `mod.rs` files across `src/`
+- `src/connection/mod.rs`
+- `docs/users-guide.md`
+- `docs/v0-1-0-to-v0-2-0-migration-guide.md`
+
+## Plan of work
+
+Stage A designs the target API map. Create a before/after inventory of root
+exports, each tagged with tier (`root`, `module`, `prelude`, `internal`).
+
+Stage B applies root simplification. Remove or relocate broad re-exports from
+`src/lib.rs`, retaining only the smallest coherent front door.
+
+Stage C enforces visibility boundaries. Convert internal modules and helpers to
+`pub(crate)` or `#[cfg(test)]` as appropriate. Ensure test support no longer
+appears in normal builds.
+
+Stage D adds ergonomics. Introduce or refine a curated `prelude` for common
+imports and update docs so examples use intended discovery paths.
+
+Stage E ships migration documentation and validates the full build/test matrix.
+
+## Concrete steps
+
+Run all commands from repository root (`/home/user/project`).
+
+1. Capture current public API map.
+
+   `rg -n "^pub mod |^pub use " src/lib.rs src/*/mod.rs`
+
+2. Apply root export and visibility changes.
+
+   `make check-fmt`
+
+3. Verify crate compiles and tests pass.
+
+   `make lint` `make test`
+
+4. Validate migration and user docs.
+
+   `make fmt` `make markdownlint` `make nixie`
+
+Expected success indicators:
+
+- Root export list is materially smaller and conceptually grouped.
+- Test-only helpers are no longer reachable in normal builds.
+- Migration guide includes import-path before/after mappings.
+
+## Validation and acceptance
+
+Acceptance criteria:
+
+- Root API is intentionally small and documented.
+- Progressive discovery path exists and is documented (`root` -> `module` ->
+  optional `prelude`).
+- Test-only modules are inaccessible in non-test builds.
+- `docs/v0-1-0-to-v0-2-0-migration-guide.md` is updated for all breaking
+  import/path changes.
+- `make check-fmt`, `make lint`, and `make test` pass.
+- `make fmt`, `make markdownlint`, and `make nixie` pass for doc changes.
+
+## Idempotence and recovery
+
+API map generation and compile checks are re-runnable. If a visibility change
+causes excessive breakage, revert that module boundary only, then reapply with
+smaller steps and immediate compile validation.
+
+## Artifacts and notes
+
+Implementation should preserve:
+
+- Before/after root export inventory.
+- Migration mapping list for renamed or relocated paths.
+- Notes on any moved test helpers and their new ownership.
+
+## Interfaces and dependencies
+
+No new external dependencies are planned.
+
+Expected interface shape:
+
+- `wireframe::` root exposes only canonical high-level entry points.
+- `wireframe::<module>::...` is the default path for specialized APIs.
+- `wireframe::prelude::*` is optional convenience, not mandatory coupling.
+
+Revision note: Initial draft created on 2026-02-18 to plan public API surface
+simplification, test-surface privacy, and migration documentation.

--- a/docs/execplans/vocabulary-normalization.md
+++ b/docs/execplans/vocabulary-normalization.md
@@ -1,0 +1,195 @@
+# Normalize API vocabulary by layer
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+`PLANS.md` is not present in this repository at the time this plan was drafted.
+
+## Purpose / big picture
+
+Wireframe naming currently mixes layer-specific concepts in ways that can blur
+mental models (for example, frame/packet/envelope/message boundaries). This
+plan executes a layer-aware naming audit, normalizes terminology without
+blanket renaming, and updates conceptual documentation so API language and
+architectural model match.
+
+## Constraints
+
+- Naming normalization must be layer-specific, not global search/replace.
+- Terms must remain semantically distinct across transport, routing, and domain
+  payload layers.
+- Public docs must explicitly define the conceptual model and term boundaries.
+- `docs/users-guide.md` must be updated to match final vocabulary.
+- `docs/developers-guide.md` must be created or updated to encode architectural
+  vocabulary and invariants.
+- Migration guidance must be updated for any renamed public items.
+
+## Tolerances (exception triggers)
+
+- Scope: if vocabulary normalization touches more than 70 files, stop and
+  escalate.
+- Interface: if term normalization forces redesign of protocol behaviour rather
+  than naming alignment, stop and escalate.
+- Dependencies: if a new tooling dependency is needed for term auditing, stop
+  and escalate.
+- Iterations: if lint/test gates fail after 3 complete correction loops, stop
+  and escalate with failure clusters.
+- Ambiguity: if one term is used with two incompatible meanings in the same
+  layer, stop and escalate with proposed canonical definitions.
+
+## Risks
+
+- Risk: seemingly simple renames can break conceptual compatibility between docs
+  and code. Severity: high Likelihood: high Mitigation: define canonical
+  glossary first, then map every rename to that glossary before code edits.
+
+- Risk: cross-layer types (for example, correlation metadata) may not fit one
+  term cleanly. Severity: medium Likelihood: medium Mitigation: document
+  cross-layer terms explicitly and constrain where each alias is permitted.
+
+- Risk: migration churn may be large if names are changed aggressively.
+  Severity: medium Likelihood: medium Mitigation: normalize only where
+  ambiguity or inconsistency is user-visible.
+
+## Progress
+
+- [x] (2026-02-18) Drafted ExecPlan for vocabulary normalization.
+- [ ] Create canonical glossary by architectural layer.
+- [ ] Inventory API symbols and docs text against glossary.
+- [ ] Propose targeted rename set and update map.
+- [ ] Apply code and doc renames.
+- [ ] Create/update developers guide conceptual model section.
+- [ ] Update migration guide and run quality gates.
+
+## Surprises & Discoveries
+
+- Observation: `docs/developers-guide.md` is currently absent.
+  Evidence: repository file inventory under `docs/`. Impact: this plan must
+  include creating the developers guide.
+
+## Decision Log
+
+- Decision: Use a glossary-first approach before any renaming.
+  Rationale: This avoids ad hoc renames and keeps layer semantics stable.
+  Date/Author: 2026-02-18 / Codex.
+
+- Decision: Define and document at least these layers: transport frame,
+  routing packet/envelope, domain message payload, and fragmentation artifact.
+  Rationale: These are the recurring conceptual boundaries in Wireframe APIs.
+  Date/Author: 2026-02-18 / Codex.
+
+## Outcomes & Retrospective
+
+Not started. Populate after implementation milestones complete.
+
+## Context and orientation
+
+Primary conceptual terms currently appear across:
+
+- `src/frame/` and frame-related exports.
+- `src/app/` packet and envelope abstractions.
+- `src/message.rs`, `src/message_assembler/`, and request/response surfaces.
+- `src/fragment/` transport fragmentation terminology.
+- `README.md`, `docs/users-guide.md`, and design docs.
+
+The work should align term definitions with where the model actually lives:
+
+- Frame: transport unit processed by codec boundaries.
+- Packet/Envelope: routable wrapper carrying message metadata plus payload.
+- Message: typed domain payload after (de)serialization.
+- Fragment: transport-level subdivision of a frame/message for size limits.
+
+Potentially touched files:
+
+- `src/lib.rs` and affected modules exposing renamed symbols.
+- `README.md`
+- `docs/users-guide.md`
+- `docs/developers-guide.md` (new file expected)
+- `docs/v0-1-0-to-v0-2-0-migration-guide.md`
+
+## Plan of work
+
+Stage A defines the glossary and naming invariants. Capture canonical terms,
+layer definitions, and disallowed synonyms per layer.
+
+Stage B audits code and docs. Build an inventory of user-visible symbols and
+documentation passages that diverge from canonical vocabulary.
+
+Stage C proposes targeted renames. Limit changes to inconsistent or ambiguous
+symbols; avoid blanket renaming where semantics are already clear.
+
+Stage D applies updates with synchronized docs. Ensure code, user guide, and
+new developers guide describe the same conceptual model.
+
+Stage E updates migration guidance and validates compile/lint/test/doc gates.
+
+## Concrete steps
+
+Run all commands from repository root (`/home/user/project`).
+
+1. Build vocabulary inventory from code and docs.
+
+   `rg -n -e Frame -e Packet -e Envelope -e Message -e Fragment \
+   -e Route -e Handler -e Session -e Connection src docs README.md`
+
+2. Define glossary and target rename map in docs.
+
+   `make fmt`
+
+3. Apply symbol and doc updates.
+
+   `make check-fmt` `make lint` `make test`
+
+4. Validate markdown and diagram quality.
+
+   `make markdownlint` `make nixie`
+
+Expected success indicators:
+
+- Conceptual glossary is explicit in users and developers guides.
+- User-visible symbol names align to layer definitions.
+- Migration guide captures all renamed public items.
+
+## Validation and acceptance
+
+Acceptance criteria:
+
+- `docs/users-guide.md` clearly defines Wireframe conceptual model terms and
+  layer boundaries.
+- `docs/developers-guide.md` exists and documents model invariants plus naming
+  rules.
+- API naming is consistent within each layer and across shared cross-layer
+  concepts.
+- `docs/v0-1-0-to-v0-2-0-migration-guide.md` includes rename mappings.
+- `make check-fmt`, `make lint`, and `make test` pass.
+- `make fmt`, `make markdownlint`, and `make nixie` pass.
+
+## Idempotence and recovery
+
+The glossary and inventory steps are re-runnable and safe. If a rename proves
+semantically incorrect, revert that rename set only, update glossary mapping,
+and re-run validation.
+
+## Artifacts and notes
+
+Implementation should retain:
+
+- Canonical glossary table or section in documentation.
+- Symbol rename inventory with before/after names.
+- Cross-layer term usage notes where dual representation is intentional.
+
+## Interfaces and dependencies
+
+No new external dependencies are planned.
+
+Expected interface effects:
+
+- Public symbol names reflect one vocabulary per layer.
+- Cross-layer models are documented explicitly where names are shared.
+- Developers have a stable naming contract in `docs/developers-guide.md`.
+
+Revision note: Initial draft created on 2026-02-18 to plan layer-specific
+vocabulary normalization and conceptual model documentation.


### PR DESCRIPTION
## Summary
- Add living ExecPlan documents to guide and evaluate Wireframe API cleanup efforts, focusing on doctest enablement, error surface unification, public API shaping, and vocabulary normalization.
- Introduces structured planning artifacts to help track constraints, risks, progress, and acceptance criteria for upcoming work.

## Changes
- Added four new ExecPlan documents:
  - docs/execplans/enable-and-resolve-doctests.md
  - docs/execplans/error-surface-coherence.md
  - docs/execplans/public-api-surface.md
  - docs/execplans/vocabulary-normalization.md
- These are living documents intended to evolve with the project and reflect current planning and decision making around API cleanup tasks.

## Rationale
- Provides a formal, centralized plan for evaluating and guiding API cleanup efforts.
- Aligns doctest enablement, error contract unification, API surface shaping, and vocabulary normalization under consistent planning disciplines.
- Helps multidisciplinary teams (API, docs, tests) share a common understanding of goals, constraints, risks, and milestones.

## How to review
- Read each ExecPlan to understand the proposed approach and criteria:
  - enable-and-resolve-doctests.md: plan to turn on doctests, classify Rustdoc blocks, and establish runnable/no_run benchmarks.
  - error-surface-coherence.md: unify public error surface into a canonical WireframeError and Result<T> alias.
  - public-api-surface.md: simplify root API surface, favor module-based exports, and hide test-only helpers.
  - vocabulary-normalization.md: introduce layer-aware vocabulary with canonical terms and migration guidance.
- Check for alignment with current project goals and any potential breaking-change implications.
- Provide feedback on any missing sections (e.g., success criteria, validation steps, migration notes).

## Impact
- No code changes in this PR; changes are documentation artifacts only.
- Sets expectations and a roadmap for future implementation work and migration guidance.

## Validation plan
- Build docs locally to ensure they render cleanly (when doc tooling is available).
- Confirm cross-references and file paths are correct for future integration into PR reviews.

## Follow-ups
- Incorporate feedback into the ExecPlan documents.
- Use these plans to drive concrete tasks, milestones, and acceptance criteria in subsequent PRs.

## Artifacts
- New files under docs/execplans:
  - enable-and-resolve-doctests.md
  - error-surface-coherence.md
  - public-api-surface.md
  - vocabulary-normalization.md



◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/3c1c40c5-07ee-4766-a528-6a3d3c15c187

## Summary by Sourcery

Add living ExecPlan documents to guide upcoming Wireframe API cleanup around doctests, error modeling, public API shaping, and vocabulary alignment.

Documentation:
- Document a staged plan to enable and stabilize Rust doctests across the public API surface.
- Document a consolidation plan for unifying public error types into a single canonical WireframeError and Result<T> alias.
- Document a restructuring plan for simplifying and tiering the crate’s public API surface while hiding test-only helpers.
- Document a vocabulary-normalization plan to align API naming and documentation with a clear, layer-aware conceptual model.