### PR TITLE
Docs: rewrite user-guide to remove first-person pronouns

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -470,9 +470,9 @@ Available slow-I/O helper functions:
 - `drive_with_slow_codec_frames` — codec-aware frames, returns decoded
   `F::Frame` values.
 
-These helpers are designed for deterministic tests under paused Tokio time. Use
-small duplex capacities together with reader pacing when you need the app's
-outbound writes to hit back-pressure quickly.
+These helpers are designed for deterministic tests under paused Tokio time. Small
+duplex capacities should be used together with reader pacing when the app's
+outbound writes must hit back-pressure quickly.
 
 #### Zero-copy payload extraction
 
@@ -665,8 +665,8 @@ no change is required for bincode-compatible types.
 - Metadata-aware serializers can implement
   `Serializer::deserialize_with_context` to inspect `DeserializeContext`.
 - `Serializer` is not object-safe (`Self: Sized` on serializer entry points), so
-  using `dyn Serializer` directly is unsupported unless you provide concrete
-  wrappers. For migration, keep concrete serializer types in `EncodeWith` /
+  using `dyn Serializer` directly is unsupported unless concrete wrappers are
+  provided. For migration, keep concrete serializer types in `EncodeWith` /
   `DecodeWith` bounds, retain
   `wireframe::serializer::MessageCompatibilitySerializer` for legacy
   `Message`-based payloads, and use `SerdeMessage` with `SerdeSerializerBridge`


### PR DESCRIPTION
## Summary
- Rewrites sections of the user guide to remove first-person pronouns and adopt a neutral, instructional tone.
- Improves consistency in phrasing around deterministic tests and serializer guidance.

## Changes
- Documentation: Updated docs/users-guide.md to replace first-person phrasing with neutral, instructional language.
  - Reworded guidance about duplex capacities to use passive phrasing: from relying on the app to hit back-pressure quickly to assuring that small duplex capacities are used with reader pacing when outbound writes must hit back-pressure quickly.
  - Reworded serializer guidance to remove imperative you language and clarify the recommendation:
    - from: "using `dyn Serializer` directly is unsupported unless you provide concrete wrappers. For migration, keep concrete serializer types in `EncodeWith` / `DecodeWith` bounds, retain ... for legacy ... and use `SerdeMessage` with `SerdeSerializerBridge`" 
    - to: "using `dyn Serializer` directly is unsupported unless concrete wrappers are provided. For migration, keep concrete serializer types in `EncodeWith` / `DecodeWith` bounds, retain
      `wireframe::serializer::MessageCompatibilitySerializer` for legacy
      `Message`-based payloads, and use `SerdeMessage` with `SerdeSerializerBridge`." 

- No code changes; this is a documentation-only update.

## Testing plan
- [x] Build and review updated docs to ensure no first-person pronouns remain in touched sections.
- [x] Confirm the changes render correctly in the repository documentation site.

## Rationale
- Aligns the documentation with a neutral, instructional voice and avoids first-person pronouns for consistency across the project docs.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/7601fb7c-3f51-4058-80cd-1f5c76f21845

## Summary by Sourcery

Documentation:
- Rewrite user-guide sections to replace second-person, imperative phrasing with neutral instructional language for deterministic test helpers and serializer guidance.