### PR TITLE
Publish Frame Vec<u8> inventory docs and recover ExecPlan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .crush
 .grepai/
 *:Zone.Identifier
+.agents/mcp/context_pack/packs/

--- a/docs/adr-001-multi-packet-streaming-response-api.md
+++ b/docs/adr-001-multi-packet-streaming-response-api.md
@@ -35,11 +35,12 @@ existing connection actor and protocol hook lifecycle.
 
 - Documentation describing **server-side multi-packet response handlers** MUST
   reflect the tuple-based API and explain the helper constructors that prepare
-  the channel pair (`Response::with_channel`, `Response::with_channel_and_initial`).
-  This requirement is scoped to handler-authoring documentation; it does not
-  apply to client-side streaming consumption APIs (`ResponseStream`,
-  `call_streaming`, `receive_streaming`, `StreamingResponseExt`,
-  `TypedResponseStream`), which are governed by their own documentation.
+  the channel pair (`Response::with_channel`,
+  `Response::with_channel_and_initial`). This requirement is scoped to
+  handler-authoring documentation; it does not apply to client-side streaming
+  consumption APIs (`ResponseStream`, `call_streaming`, `receive_streaming`,
+  `StreamingResponseExt`, `TypedResponseStream`), which are governed by their
+  own documentation.
 - The development roadmap gains concrete tasks covering helper construction,
   handler ergonomics, and documentation updates so the work is tracked
   explicitly.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -57,6 +57,8 @@ the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
 
 - [Developers' guide](developers-guide.md) Canonical architectural vocabulary
   and naming invariants.
+- [Frame = `Vec<u8>` inventory](frame-vec-u8-inventory.md) Inventory of frame-
+  and payload-shaped APIs that still rely on owned byte vectors.
 - [Formal verification methods](formal-verification-methods-in-wireframe.md)
   Recommended use of Kani, Stateright, and Verus in Wireframe.
 - [Refactoring guide](complexity-antipatterns-and-refactoring-strategies.md)

--- a/docs/execplans/issue-287-inventory-trait-bounds-expecting-frame-vec-u8.md
+++ b/docs/execplans/issue-287-inventory-trait-bounds-expecting-frame-vec-u8.md
@@ -1,0 +1,209 @@
+# Inventory `Frame = Vec<u8>` trait bounds and APIs
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: COMPLETE
+
+No `PLANS.md` exists in this repository as of 2026-04-11.
+
+## Purpose / big picture
+
+Issue 287 supports epic 284 by producing a source-of-truth inventory of code
+paths, trait bounds, impls, and APIs that currently assume `Frame = Vec<u8>` or
+otherwise expose `Vec<u8>` as the de facto frame or payload representation.
+
+The goal is to bound migration scope without prescribing the migration itself.
+The published artefact for this work is `docs/frame-vec-u8-inventory.md`.
+
+## Constraints
+
+- This issue is an inventory and planning task, not the `Bytes` migration
+  itself.
+- The resulting document must distinguish between:
+  - true `Frame = Vec<u8>` constraints in traits, impls, and generic bounds;
+  - public APIs that expose raw payload bytes as `Vec<u8>` without literally
+    constraining `F::Frame = Vec<u8>`;
+  - internal-only usages that can likely change with lower compatibility risk;
+  - examples, tests, and documentation references that are illustrative but
+    not binding.
+- Every inventory entry must cite concrete evidence: file path, symbol, and
+  current signature or usage shape.
+- The work must reflect the current repository layout rather than historical
+  issue context.
+- The implementation must not invent roadmap completion where no local roadmap
+  item exists.
+
+## Tolerances (exception triggers)
+
+- Scope: if the inventory expands beyond roughly 40 runtime-significant files,
+  stop and group the findings before continuing.
+- Ambiguity: if more than a handful of surfaces cannot be classified as
+  `frame-bound`, `payload-bound`, `internal-only`, or `docs/tests-only`, stop
+  and define the taxonomy explicitly before proceeding.
+- Epic linkage: if GitHub cannot be edited from the local environment, record
+  the exact document path and link text so the follow-up is trivial.
+
+## Risks
+
+- Risk: the inventory may overstate migration scope by treating all
+  `Vec<u8>` payload APIs as equivalent to `Frame = Vec<u8>` generic bounds.
+  Severity: high. Likelihood: medium. Mitigation: classify each finding by
+  coupling type and call out false friends explicitly.
+
+- Risk: stale issue context may send the investigation toward files or types
+  that no longer exist. Severity: medium. Likelihood: high. Mitigation: drive
+  the inventory from the current repository state first, and record stale
+  references as discoveries rather than facts.
+
+- Risk: documentation-only findings may drown out public API breakpoints.
+  Severity: medium. Likelihood: medium. Mitigation: keep separate sections for
+  runtime surfaces, internal-only paths, and docs/tests-only follow-up.
+
+## Validation and acceptance
+
+Acceptance is based on observable artefacts:
+
+- `docs/frame-vec-u8-inventory.md` exists and inventories:
+  - true `Frame = Vec<u8>` surfaces;
+  - payload-bound public APIs;
+  - internal-only runtime coupling;
+  - tests, examples, and docs that would need follow-up during epic 284.
+- The inventory document includes non-prescriptive notes on generalization
+  paths, conceptual risks, and open questions.
+- The inventory records roadmap status explicitly rather than guessing.
+- Documentation quality gates pass.
+
+Validation commands for this documentation-only implementation:
+
+```sh
+set -o pipefail
+timeout 300 make fmt 2>&1 | tee /tmp/wireframe-fmt.log
+echo "fmt exit: $?"
+
+set -o pipefail
+timeout 300 make markdownlint 2>&1 | tee /tmp/wireframe-markdownlint.log
+echo "markdownlint exit: $?"
+```
+
+## Context and orientation
+
+The current repository already shows a split between generic transport frames
+and owned payload-byte APIs:
+
+- `src/codec.rs` defines `FrameCodec` generically over `Self::Frame`.
+- `src/hooks.rs` defines `WireframeProtocol` generically over
+  `type Frame: FrameLike`.
+- `src/app/envelope.rs`, `src/middleware.rs`, `src/client/hooks.rs`, and
+  `src/serializer.rs` still expose owned `Vec<u8>` payloads directly.
+- `src/connection/mod.rs` uses generic frame bounds
+  `FrameLike + CorrelatableFrame + Packet`, which is adjacent to the migration
+  but is not itself a literal `Vec<u8>` constraint.
+
+## Plan of work
+
+Stage A builds a taxonomy and evidence set from current source signatures.
+
+Stage B inventories runtime-significant public and internal surfaces, keeping
+true frame coupling separate from payload ownership APIs.
+
+Stage C records adjacent constraints, especially the actor/codec boundary,
+without collapsing them into false `Vec<u8>` findings.
+
+Stage D publishes the inventory document and records epic-link and roadmap
+status.
+
+## Concrete steps
+
+1. Locate the original issue-287 plan context and confirm the current
+   repository state.
+2. Scan source files for `Vec<u8>`-shaped frame and payload surfaces.
+3. Classify findings as `frame-bound`, `payload-bound`, `internal-only`, or
+   `docs/tests-only`.
+4. Publish `docs/frame-vec-u8-inventory.md`.
+5. Update the docs index and record roadmap and epic-link follow-up notes.
+6. Run documentation gates.
+
+## Idempotence and recovery
+
+The source scan, classification, and documentation steps are all re-runnable.
+If a first pass over-collects findings, keep the evidence and reclassify it
+rather than deleting it. If follow-up work later changes the coupling shape,
+publish a superseding inventory rather than silently mutating historical
+conclusions.
+
+## Progress
+
+- [x] (2026-04-10) Original issue-287 ExecPlan drafted in commit `c0cbc75`.
+- [x] (2026-04-11) Recovered the missing ExecPlan from repository history
+  because the file was absent from the current worktree.
+- [x] (2026-04-11) Re-scanned current runtime code and classified findings by
+  coupling type.
+- [x] (2026-04-11) Published `docs/frame-vec-u8-inventory.md`.
+- [x] (2026-04-11) Added the inventory to `docs/contents.md`.
+- [x] (2026-04-11) Recorded roadmap status and prepared epic-link text in the
+  inventory document.
+- [x] (2026-04-11) Ran documentation quality gates:
+  `make fmt` and `make markdownlint`.
+
+## Surprises & Discoveries
+
+- Observation: the exact issue-287 ExecPlan file was not present in the
+  current worktree. Evidence: direct file lookup failed, but `git log --all`
+  showed commit `c0cbc75` creating
+  `docs/execplans/issue-287-inventory-trait-bounds-expecting-frame-vec-u8.md`.
+  Impact: the implementation had to recover planning context from history
+  before proceeding.
+
+- Observation: the runtime no longer hard-codes `F::Frame = Vec<u8>` at the
+  codec or protocol trait layer. Evidence: `src/codec.rs` and `src/hooks.rs`.
+  Impact: the main migration scope is payload ownership and mutability, not a
+  blanket frame-type constraint.
+
+- Observation: the strongest remaining coupling is public payload-oriented API
+  shape. Evidence: `src/app/envelope.rs`, `src/middleware.rs`,
+  `src/client/hooks.rs`, and `src/serializer.rs`. Impact: epic 284 should
+  separate transport-frame work from payload-API work.
+
+- Observation: no matching roadmap item for this inventory work exists in the
+  local docs set. Evidence: repository-wide roadmap search on 2026-04-11.
+  Impact: nothing was marked done.
+
+## Decision Log
+
+- Decision: publish the final inventory as
+  `docs/frame-vec-u8-inventory.md`. Rationale: the path is explicit, stable,
+  and easy to link from epic 284. Date/Author: 2026-04-11 / Codex.
+
+- Decision: restore the missing issue-287 ExecPlan path in the worktree.
+  Rationale: the user explicitly referenced this path, and the historical plan
+  existed in commit history. Restoring it keeps the documentation trail intact.
+  Date/Author: 2026-04-11 / Codex.
+
+- Decision: classify findings by coupling type instead of flattening them into
+  a grep dump. Rationale: migration planning needs scope-ranked evidence, not
+  only a list of matches. Date/Author: 2026-04-11 / Codex.
+
+## Outcomes & Retrospective
+
+Completed implementation outcomes:
+
+- Published `docs/frame-vec-u8-inventory.md` as the issue-287 source of truth.
+- Distinguished true `Frame = Vec<u8>` surfaces from payload-bound APIs,
+  internal-only runtime coupling, and docs/tests-only follow-up.
+- Recorded the actor/codec boundary as adjacent context rather than a false
+  `Vec<u8>` finding.
+- Added the inventory to `docs/contents.md` for discoverability.
+- Recorded that no matching roadmap item was found locally and prepared
+  epic-link text for external follow-up.
+
+Validation outcomes:
+
+- `make fmt` passed.
+- `make markdownlint` passed.
+
+## Revision note
+
+This file was restored on 2026-04-11 from commit `c0cbc75` and updated to
+reflect completion of the documentation work in the current worktree.

--- a/docs/frame-vec-u8-inventory.md
+++ b/docs/frame-vec-u8-inventory.md
@@ -1,0 +1,274 @@
+# Inventory of `Frame = Vec<u8>` trait bounds and APIs
+
+This document records the current code paths, trait bounds, implementations,
+and documentation that still assume `Frame = Vec<u8>` or otherwise expose owned
+`Vec<u8>` values as the de facto frame or payload representation. Issue 287
+uses this inventory to support epic 284 by bounding the migration scope without
+prescribing a single implementation sequence.[^adr-004]
+
+## Scope and taxonomy
+
+This inventory distinguishes four kinds of coupling:
+
+| Category          | Meaning                                                                                              | Migration sensitivity                                 |
+| ----------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `frame-bound`     | A trait, impl, or test uses `Vec<u8>` as a concrete frame type.                                      | High when the transport frame type changes.           |
+| `payload-bound`   | A public API exposes owned payload bytes as `Vec<u8>` without literally fixing `F::Frame = Vec<u8>`. | High for API compatibility, lower for codec plumbing. |
+| `internal-only`   | Runtime code carries `Vec<u8>` internally without exposing it as a stable API.                       | Medium; usually easier to change behind shims.        |
+| `docs/tests-only` | Examples, tests, and design text that still teach `Vec<u8>`-shaped framing.                          | Low runtime risk, but high drift risk.                |
+
+Two important boundaries are out of scope for this inventory:
+
+- General `Vec<u8>` usage that is clearly about message bodies, fragment
+  payloads, or unrelated buffering rather than transport frames or payload
+  ownership hand-offs.
+- Selecting `Bytes`, `BytesMut`, or another abstraction as the replacement.
+  This document records coupling and trade-offs only.
+
+## Executive summary
+
+The codebase no longer hard-codes `F::Frame = Vec<u8>` at the top-level codec
+or protocol abstraction. `FrameCodec` is generic over `Self::Frame`, and
+`WireframeProtocol` is generic over `type Frame: FrameLike`.[^codec][^hooks]
+The main remaining migration scope is instead concentrated in public
+payload-owned APIs:
+
+- `PacketParts`, `Envelope`, `ServiceRequest`, and `ServiceResponse` all own
+  `Vec<u8>` payloads or frames.
+- Client request hooks and preamble replay APIs still expose mutable or owned
+  `Vec<u8>` buffers.
+- `Serializer::serialize` still returns `Vec<u8>`, which keeps outbound
+  serialization byte-owned even when codecs use `Bytes`.
+
+The main adjacent constraint is not a literal `Vec<u8>` bound. The
+`ConnectionActor` requires `F: FrameLike + CorrelatableFrame + Packet`, which
+the default codec frame type (`Bytes`) does not satisfy.[^unified-path] This is
+why the current server path routes actor output through `Envelope` and the
+codec driver rather than sending transport frames through the actor directly.
+
+## Inventory summary
+
+| Category          | Representative surfaces                                         | Primary files                                                                                          |
+| ----------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `frame-bound`     | `CorrelatableFrame for Vec<u8>`, test-only `Packet for Vec<u8>` | `src/correlation.rs`, `src/connection/test_support.rs`                                                 |
+| `payload-bound`   | Packets, middleware, client request hooks, serializer output    | `src/app/envelope.rs`, `src/middleware.rs`, `src/client/hooks.rs`, `src/serializer.rs`                 |
+| `internal-only`   | DLQ sender, response forwarding, preamble replay                | `src/app/builder/core.rs`, `src/app/frame_handling/response.rs`, `src/rewind_stream.rs`                |
+| `docs/tests-only` | Protocol tests, guide examples, design diagrams                 | `tests/wireframe_protocol.rs`, `docs/users-guide.md`, `docs/asynchronous-outbound-messaging-design.md` |
+
+## Confirmed runtime surfaces
+
+### True `frame-bound` surfaces
+
+- `src/correlation.rs` implements `CorrelatableFrame` for `Vec<u8>`.
+  This makes raw byte vectors participate directly in generic frame plumbing,
+  even though the implementation is a no-op correlation carrier.
+- `src/connection/test_support.rs` implements `Packet` for `Vec<u8>` in test
+  support. This is not production API, but it proves the connection actor stack
+  still treats `Vec<u8>` as a first-class frame type in its generic harnesses.
+
+These are the only confirmed runtime code paths where `Vec<u8>` is promoted to
+an actual frame type today. The public codec and protocol traits themselves do
+not require it.
+
+### Public `payload-bound` surfaces
+
+#### Packets and envelopes
+
+- `src/app/envelope.rs` defines `PacketParts` with
+  `payload: Vec<u8>`, `PacketParts::new(..., payload: Vec<u8>)`, and
+  `PacketParts::into_payload(self) -> Vec<u8>`.
+- The same file defines `Envelope` with `payload: Vec<u8>` and
+  `Envelope::new(id, correlation_id, payload: Vec<u8>)`.
+- `Packet` itself is payload-oriented through
+  `fn into_parts(self) -> PacketParts` and
+  `fn from_parts(parts: PacketParts) -> Self`.
+
+These are not transport-frame constraints, but they are high-sensitivity public
+APIs because routing, middleware reconstruction, and packet rebuilding all
+depend on owned payload bytes.
+
+#### Middleware request and response wrappers
+
+- `src/middleware.rs` fixes `ServiceRequest` to
+  `inner: FrameContainer<Vec<u8>>`.
+- `ServiceRequest::new(frame: Vec<u8>, correlation_id)` and
+  `ServiceRequest::frame_mut(&mut self) -> &mut Vec<u8>` expose owned, mutable
+  bytes directly to middleware.
+- `ServiceResponse` mirrors the same contract with
+  `inner: FrameContainer<Vec<u8>>`,
+  `ServiceResponse::new(frame: Vec<u8>, ...)`,
+  `frame_mut(&mut self) -> &mut Vec<u8>`, and `into_inner(self) -> Vec<u8>`.
+
+This is one of the clearest byte-ownership APIs in the crate. Any migration
+that changes the type here becomes a user-visible middleware API change.
+
+#### Client request hooks
+
+- `src/client/hooks.rs` exports
+  `BeforeSendHook = Arc<dyn Fn(&mut Vec<u8>) + Send + Sync>`.
+- `src/client/builder/request_hooks.rs` exposes the same shape through
+  `before_send<F>(...) where F: Fn(&mut Vec<u8>) + Send + Sync + 'static`.
+- `src/client/messaging.rs` applies these hooks via
+  `invoke_before_send_hooks(&self, bytes: &mut Vec<u8>)`.
+
+This is a payload-bound API rather than a literal `Frame = Vec<u8>` bound, but
+it is still a compatibility surface because the client promises mutable access
+to serialized outbound bytes before transport framing.
+
+#### Client preamble leftovers
+
+- `src/client/mod.rs` exports `ClientPreambleSuccessHandler<T>` as a callback
+  returning `io::Result<Vec<u8>>`.
+- `src/client/preamble_exchange.rs` stores and executes that callback through
+  `perform_preamble_exchange(...) -> Result<Vec<u8>, ClientError>` and
+  `run_preamble_exchange(...) -> Result<Vec<u8>, ClientError>`.
+- `src/rewind_stream.rs` then replays those leftover bytes through
+  `RewindStream::new(leftover: Vec<u8>, inner)`.
+
+This is another public owned-bytes contract. It is adjacent to transport
+framing because the leftover bytes are replayed before framed communication
+starts, but the surface is about preamble buffering rather than `F::Frame`.
+
+#### Serializer output
+
+- `src/serializer.rs` defines
+  `Serializer::serialize<M>(&self, value: &M) -> Result<Vec<u8>, ...>`.
+- `BincodeSerializer` preserves that same return type.
+
+This does not force transport frames to be `Vec<u8>`, because codecs can still
+wrap those bytes into `Bytes` or protocol-native frame structs. It does,
+however, keep outbound message serialization owned and mutable at the boundary
+where several other APIs also expect `Vec<u8>`.
+
+### `internal-only` runtime surfaces
+
+- `src/app/builder/core.rs` stores `push_dlq` as
+  `Option<mpsc::Sender<Vec<u8>>>`.
+- `src/app/builder/config.rs` exposes that internal channel through
+  `with_push_dlq(self, dlq: mpsc::Sender<Vec<u8>>) -> Self`.
+- `src/app/frame_handling/response.rs` shows the current payload flow
+  explicitly: `ServiceRequest::new(env.payload, env.correlation_id)` moves the
+  inbound envelope payload into middleware, and
+  `PacketParts::new(env.id, resp.correlation_id(), resp.into_inner())`
+  reconstructs an outbound envelope from `Vec<u8>`.
+
+These are lower-risk than the public packet and middleware APIs, but they are
+still part of the migration blast radius because they connect the public byte
+contracts to the internal send path.
+
+## Adjacent constraints that matter but do not name `Vec<u8>`
+
+These surfaces are essential migration context even though they are not
+themselves `Frame = Vec<u8>` bindings:
+
+- `src/connection/mod.rs` requires
+  `F: FrameLike + CorrelatableFrame + Packet` for the `ConnectionActor`.
+- `src/app/builder/protocol.rs` stores protocols as
+  `WireframeProtocol<Frame = F::Frame, ProtocolError = ()>`.
+- `src/codec.rs` defines the default `LengthDelimitedFrameCodec` with
+  `Bytes` frames, not `Vec<u8>`.
+
+Taken together, these show that the main frame-level tension is between generic
+actor requirements and codec frame capabilities, not between the actor and
+`Vec<u8>` specifically. The current unified server path therefore routes actor
+output through `Envelope` and lets the codec driver perform the final
+`wrap_payload` step.[^unified-path]
+
+For epic 284, this means transport-frame generalization and payload-API
+generalization should be tracked separately. A code path can be generic over
+`F::Frame` while still exposing `Vec<u8>` in middleware, packets, or hooks.
+
+## Tests, examples, and documentation that still teach `Vec<u8>`
+
+### Tests and harnesses
+
+- `tests/wireframe_protocol.rs` defines a test codec with `type Frame = Vec<u8>`
+  and a protocol implementation with `type Frame = Vec<u8>`.
+- `src/connection/test_support.rs` uses `Packet for Vec<u8>` to drive actor
+  tests.
+
+These are not runtime blockers, but they confirm that `Vec<u8>` remains the
+default teaching and testing shape for protocol hooks.
+
+### User and design documentation
+
+- `docs/users-guide.md` still includes protocol examples with
+  `type Frame = Vec<u8>` and client hook examples using `&mut Vec<u8>`.
+- `docs/asynchronous-outbound-messaging-design.md` still contains diagrams and
+  narrative that show `WireframeProtocol<Frame = Vec<u8>, ProtocolError = ()>`.
+- `docs/wireframe-client-design.md` describes `before_send` as operating on
+  `&mut Vec<u8>`.
+
+These documents need follow-up whenever the public byte-oriented APIs change,
+otherwise the written guidance will drift from the implementation.
+
+## What is already generic today
+
+Several prominent abstractions already distinguish transport frames from owned
+payload bytes:
+
+- `FrameCodec` is generic over `Self::Frame` and already supports `Bytes` and
+  protocol-native frame structs.[^codec]
+- `WireframeProtocol` is generic over `type Frame: FrameLike`, so the protocol
+  trait itself is not coupled to `Vec<u8>`.[^hooks]
+- `ProtocolHooks<F, E>` is also generic over `F`.
+
+This means epic 284 does not start from a codebase that hard-codes `Vec<u8>`
+everywhere. The remaining work is concentrated in the payload-owned surfaces
+listed above and in the actor/codec boundary described by the unified
+codec-path work.[^unified-path]
+
+## Generalization paths and conceptual risks
+
+The inventory suggests several non-prescriptive workstreams:
+
+- Separate transport-frame work from payload-ownership work. Changing
+  `FrameCodec::Frame` does not automatically solve middleware, packet, or
+  serializer APIs that still promise owned `Vec<u8>` values.
+- Decide whether client hooks should continue to promise mutable owned bytes,
+  or whether a future API should distinguish read-only shared bytes from
+  editable outbound buffers.
+- Treat preamble leftovers as their own compatibility surface. They are not
+  regular framed payloads, but the API still exposes owned byte vectors.
+- Keep the actor-boundary problem separate from the `Vec<u8>` inventory. The
+  `ConnectionActor` currently wants `Packet + CorrelatableFrame`; changing only
+  byte container types will not remove that constraint.
+
+The main conceptual risk is overstating the migration scope by treating every
+`Vec<u8>` as a frame problem. In practice, most runtime-sensitive surfaces are
+about payload ownership and mutability, while true frame-level `Vec<u8>`
+coupling is now limited.
+
+## Open questions for epic 284
+
+- Should epic 284 cover only transport-frame substitution, or also public
+  payload-owned APIs such as `PacketParts`, middleware, and client hooks?
+- Is `Serializer::serialize -> Vec<u8>` still the desired boundary if codecs
+  move further toward zero-copy `Bytes` usage?
+- Does `CorrelatableFrame for Vec<u8>` still need to exist outside tests once
+  protocol and actor examples stop using raw byte vectors?
+- Should client preamble leftovers remain owned `Vec<u8>` values, or be
+  treated as another buffer abstraction entirely?
+
+## Coordination notes
+
+No matching roadmap item for this inventory work was found in the local docs
+set on 2026-04-11, so nothing was marked done. If epic 284 is updated outside
+the repository, the prepared link text is:
+
+```plaintext
+Add inventory reference: docs/frame-vec-u8-inventory.md
+Link label: Frame = Vec<u8> inventory
+```
+
+[^adr-004]: See [ADR 004](adr-004-pluggable-protocol-codecs.md) for the
+    generic codec decision and the current `Bytes` default frame type.
+[^codec]: See
+          [Pluggable protocol codecs](execplans/pluggable-protocol-codecs.md)
+    and `src/codec.rs`.
+[^hooks]: See `src/hooks.rs` and the hook overview in
+    [users-guide.md](users-guide.md).
+[^unified-path]: See
+    [docs/execplans/9-3-1-fragment-adapter-trait.md](execplans/9-3-1-fragment-adapter-trait.md)
+    for the actor/codec-driver boundary and why `Bytes` does not flow through
+    `ConnectionActor` directly today.

--- a/docs/frame-vec-u8-inventory.md
+++ b/docs/frame-vec-u8-inventory.md
@@ -12,12 +12,12 @@ allocations.[^adr-004][^issue-286]
 
 This inventory distinguishes four kinds of coupling:
 
-| Category          | Meaning                                                                                              | Migration sensitivity                                 |
-| ----------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `frame-bound`     | A trait, impl, or test uses `Vec<u8>` as a concrete frame type.                                      | High when the transport frame type changes.           |
-| `payload-bound`   | A public API exposes owned payload bytes as `Vec<u8>` without literally fixing `F::Frame = Vec<u8>`. | High for API compatibility, lower for codec plumbing. |
-| `internal-only`   | Runtime code carries `Vec<u8>` internally without exposing it as a stable API.                       | Medium; usually easier to change behind shims.        |
-| `docs/tests-only` | Examples, tests, and design text that still teach `Vec<u8>`-shaped framing.                          | Low runtime risk, but high drift risk.                |
+| Category          | Meaning                                                                                                                                  | Migration sensitivity                                 |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `frame-bound`     | A trait, impl, or test uses `Vec<u8>` as a concrete frame type.                                                                          | High when the transport frame type changes.           |
+| `payload-bound`   | A public application programming interface (API) exposes owned payload bytes as `Vec<u8>` without literally fixing `F::Frame = Vec<u8>`. | High for API compatibility, lower for codec plumbing. |
+| `internal-only`   | Runtime code carries `Vec<u8>` internally without exposing it as a stable API.                                                           | Medium; usually easier to change behind shims.        |
+| `docs/tests-only` | Examples, tests, and design text that still teach `Vec<u8>`-shaped framing.                                                              | Low runtime risk, but high drift risk.                |
 
 Two important boundaries are out of scope for this inventory:
 
@@ -235,8 +235,8 @@ where several other APIs also expect `Vec<u8>`.
 
 ### `internal-only` runtime surfaces
 
-- `src/app/builder/core.rs` stores `push_dlq` as
-  `Option<mpsc::Sender<Vec<u8>>>`.
+- `src/app/builder/core.rs` stores `push_dlq` as a dead-letter queue (DLQ)
+  sender: `Option<mpsc::Sender<Vec<u8>>>`.
 - `src/app/builder/config.rs` exposes that internal channel through
   `with_push_dlq(self, dlq: mpsc::Sender<Vec<u8>>) -> Self`.
 - `src/app/frame_handling/response.rs` shows the current payload flow
@@ -374,8 +374,9 @@ Epic 284 workstreams:
    byte APIs justify standardization.
 ```
 
-[^adr-004]: See [ADR 004](adr-004-pluggable-protocol-codecs.md) for the
-    generic codec decision and the current `Bytes` default frame type.
+[^adr-004]: See
+            [Architecture Decision Record (ADR) 004](adr-004-pluggable-protocol-codecs.md)
+    for the generic codec decision and the current `Bytes` default frame type.
 [^issue-286]: Middleware follow-up requested by
     [@leynos](https://github.com/leynos), with context from
     [issue #286](https://github.com/leynos/wireframe/issues/286),
@@ -387,6 +388,6 @@ Epic 284 workstreams:
 [^hooks]: See `src/hooks.rs` and the hook overview in
     [users-guide.md](users-guide.md).
 [^unified-path]: See
-    [docs/execplans/9-3-1-fragment-adapter-trait.md](execplans/9-3-1-fragment-adapter-trait.md)
+    [docs/execplans/9-3-1-fragment-adapter-trait.md](./execplans/9-3-1-fragment-adapter-trait.md)
     for the actor/codec-driver boundary and why `Bytes` does not flow through
     `ConnectionActor` directly today.

--- a/docs/frame-vec-u8-inventory.md
+++ b/docs/frame-vec-u8-inventory.md
@@ -4,7 +4,9 @@ This document records the current code paths, trait bounds, implementations,
 and documentation that still assume `Frame = Vec<u8>` or otherwise expose owned
 `Vec<u8>` values as the de facto frame or payload representation. Issue 287
 uses this inventory to support epic 284 by bounding the migration scope without
-prescribing a single implementation sequence.[^adr-004]
+prescribing a single implementation sequence. Issue 286 extends that work with
+a middleware-specific analysis after PR #283 reduced frame-processing
+allocations.[^adr-004][^issue-286]
 
 ## Scope and taxonomy
 
@@ -39,6 +41,10 @@ payload-owned APIs:
   `Vec<u8>` buffers.
 - `Serializer::serialize` still returns `Vec<u8>`, which keeps outbound
   serialization byte-owned even when codecs use `Bytes`.
+- Epic 284 should cover both transport-frame substitution and public
+  payload-owned APIs, but those should be tracked as separate workstreams under
+  one umbrella so consuming developers do not have to write avoidable adapter
+  boilerplate.
 
 The main adjacent constraint is not a literal `Vec<u8>` bound. The
 `ConnectionActor` requires `F: FrameLike + CorrelatableFrame + Packet`, which
@@ -101,6 +107,93 @@ depend on owned payload bytes.
 
 This is one of the clearest byte-ownership APIs in the crate. Any migration
 that changes the type here becomes a user-visible middleware API change.
+
+#### Middleware boundary analysis (issue 286)
+
+Issue 286 asks for a focused read on the middleware layer, including its data
+flow, impacted integration points, and conceptual adaptation strategies after
+PR #283 moved more of the codec path toward `Bytes`.[^issue-286]
+
+##### Middleware data flow
+
+The middleware layer currently sits entirely inside an owned-`Vec<u8>` segment
+of the request/response pipeline:
+
+1. `src/app/inbound_handler.rs` builds or reuses the middleware chain through
+   `WireframeApp::build_chains()`, wrapping each route handler inside
+   `HandlerService<E>`.
+2. `src/app/frame_handling/decode.rs` and `src/app/inbound_handler.rs` decode
+   an inbound codec frame into an `Envelope`.
+3. `src/app/frame_handling/response.rs` crosses the middleware boundary by
+   calling `ServiceRequest::new(env.payload, env.correlation_id)`.
+4. `src/middleware.rs` exposes that payload to middleware as
+   `ServiceRequest`, with `frame()`, `frame_mut()`, `set_correlation_id()`, and
+   `into_inner()`.
+5. The terminal bridge in `src/middleware.rs` (`RouteService::call`) converts
+   the request back into a packet with
+   `E::from_parts(PacketParts::new(self.id, req.correlation_id(), req.into_inner()))`,
+    invokes the registered handler, then returns
+   `ServiceResponse::new(payload, correlation_id)`.
+6. `src/app/frame_handling/response.rs` crosses back out of middleware by
+   rebuilding `PacketParts` and `Envelope` from `resp.into_inner()`.
+7. `src/app/codec_driver.rs` serializes that envelope to bytes via
+   `Serializer::serialize`, converts the `Vec<u8>` into `Bytes`, and finally
+   hands it to `FrameCodec::wrap_payload`.
+
+The practical consequence is that middleware currently forms a hard
+`Vec<u8>`-owned island between generic codec frames on the wire and the
+`Bytes`-friendly codec boundary on the way back out.
+
+##### Middleware integration points affected by a frame-type change
+
+- `src/middleware.rs` is the primary public API surface:
+  `ServiceRequest`, `ServiceResponse`, `Service`, `Transform`, `Next`,
+  `from_fn`, `HandlerService::from_service`, and the `frame_mut()` /
+  `into_inner()` editing model all currently depend on `Vec<u8>`.
+- `src/app/frame_handling/response.rs` is the request/response bridge into and
+  out of middleware. Any type change has to preserve correlation handling and
+  packet reconstruction here.
+- `src/app/inbound_handler.rs` owns middleware-chain construction and therefore
+  any staging or compatibility story for mixed old/new middleware types.
+- `tests/middleware.rs` and `tests/middleware_order.rs` demonstrate the current
+  mutation semantics directly through `push`, `clear`, and `extend_from_slice`
+  on `frame_mut()`.
+- `docs/users-guide.md` teaches middleware authors to decode requests from
+  `req.frame()` and rewrite replies through `response.frame_mut()`.
+- `wireframe_testing/src/helpers/drive.rs` is an adjacent test surface: it
+  still feeds raw `Vec<u8>` wire frames into apps, which matters for end-to-end
+  middleware tests even though it is not itself the middleware API.
+
+##### Middleware-specific risks
+
+- Blast radius is high because every request passes through the middleware
+  wrappers, and external middleware implementations are written against
+  `Vec<u8>` constructors and mutation helpers today.
+- Switching directly to immutable `Bytes` would break the current editing model
+  around `frame_mut()`.
+- Switching directly to another mutable buffer type could still impose
+  widespread boilerplate if consumers have to manually convert between
+  `Vec<u8>`, `Bytes`, and `BytesMut`.
+
+##### Conceptual adaptation strategies
+
+The following strategies are intentionally non-prescriptive, but they bound the
+design space:
+
+- Track middleware payload APIs as a separate epic-284 workstream from
+  transport-frame substitution. The two interact, but they do not need to land
+  in a single breaking change.
+- Prefer developer ergonomics over exposing raw buffer taxonomy. Middleware
+  authors should not have to hand-write repetitive conversions between byte
+  container types to achieve routine inspection and mutation.
+- If middleware internals move toward a `Bytes`-compatible representation, keep
+  mutation opt-in and edit-oriented. A copy-on-write or edit-on-demand surface
+  is conceptually safer than forcing every middleware author to manage shared
+  byte ownership directly.
+- Preserve the bounded special case for client preamble leftovers. That path is
+  one-shot and replay-only, so it does not need to be pulled into the
+  middleware or transport-frame redesign unless the broader public byte APIs
+  standardize on a new shared abstraction.
 
 #### Client request hooks
 
@@ -223,46 +316,71 @@ codec-path work.[^unified-path]
 The inventory suggests several non-prescriptive workstreams:
 
 - Separate transport-frame work from payload-ownership work. Changing
-  `FrameCodec::Frame` does not automatically solve middleware, packet, or
-  serializer APIs that still promise owned `Vec<u8>` values.
-- Decide whether client hooks should continue to promise mutable owned bytes,
-  or whether a future API should distinguish read-only shared bytes from
-  editable outbound buffers.
-- Treat preamble leftovers as their own compatibility surface. They are not
-  regular framed payloads, but the API still exposes owned byte vectors.
+  `FrameCodec::Frame` does not automatically solve middleware, packet,
+  serializer, or client-hook APIs that still promise owned `Vec<u8>` values.
 - Keep the actor-boundary problem separate from the `Vec<u8>` inventory. The
   `ConnectionActor` currently wants `Packet + CorrelatableFrame`; changing only
   byte container types will not remove that constraint.
+- Plan for a long-term outbound boundary that is `Bytes`-compatible rather than
+  `Vec<u8>`-centric, while retaining `Vec<u8>` compatibility adapters for as
+  long as public mutation hooks still require owned mutable bytes.
+- Remove `CorrelatableFrame for Vec<u8>` from the core surface once raw
+  `Vec<u8>` stops being a documented or production frame shape. If a bridge is
+  still useful, keep it in docs, `test-support`, or a feature-gated
+  compatibility shim.
+- Keep client preamble leftovers as owned `Vec<u8>` values for now. Revisit
+  that path only if the broader public byte APIs converge on a shared buffer
+  abstraction.
 
 The main conceptual risk is overstating the migration scope by treating every
 `Vec<u8>` as a frame problem. In practice, most runtime-sensitive surfaces are
 about payload ownership and mutability, while true frame-level `Vec<u8>`
 coupling is now limited.
 
-## Open questions for epic 284
+## Resolved direction for epic 284
 
-- Should epic 284 cover only transport-frame substitution, or also public
-  payload-owned APIs such as `PacketParts`, middleware, and client hooks?
-- Is `Serializer::serialize -> Vec<u8>` still the desired boundary if codecs
-  move further toward zero-copy `Bytes` usage?
-- Does `CorrelatableFrame for Vec<u8>` still need to exist outside tests once
-  protocol and actor examples stop using raw byte vectors?
-- Should client preamble leftovers remain owned `Vec<u8>` values, or be
-  treated as another buffer abstraction entirely?
+The current direction is now explicit:
+
+- Epic 284 covers both transport-frame substitution and public payload-owned
+  APIs such as `PacketParts`, middleware, and client hooks.
+- Those changes should be tracked as separate workstreams under the same
+  umbrella so the migration can preserve developer ergonomics and minimize
+  boilerplate.
+- The long-term outbound boundary should be `Bytes`-compatible rather than
+  `Vec<u8>`-centric, with `Vec<u8>` retained only as a compatibility adapter
+  while mutable byte-edit hooks still require it.
+- `CorrelatableFrame for Vec<u8>` should leave the core surface once raw
+  `Vec<u8>` stops serving as a documented or production frame shape.
+- Client preamble leftovers remain a separate compatibility surface and should
+  stay as owned `Vec<u8>` for now.
 
 ## Coordination notes
 
 No matching roadmap item for this inventory work was found in the local docs
 set on 2026-04-11, so nothing was marked done. If epic 284 is updated outside
-the repository, the prepared link text is:
+the repository, the prepared link text and next-step summary are:
 
 ```plaintext
 Add inventory reference: docs/frame-vec-u8-inventory.md
 Link label: Frame = Vec<u8> inventory
+
+Epic 284 workstreams:
+1. Transport-frame substitution and actor/codec boundary work.
+2. Public payload-owned API work: PacketParts, Envelope, middleware, and
+   client byte hooks, with minimal consumer boilerplate.
+3. Compatibility cleanup: move Vec<u8>-only bridges such as
+   CorrelatableFrame for Vec<u8> out of the core surface once no longer needed.
+4. Deferred: keep client preamble leftovers on Vec<u8> until broader public
+   byte APIs justify standardization.
 ```
 
 [^adr-004]: See [ADR 004](adr-004-pluggable-protocol-codecs.md) for the
     generic codec decision and the current `Bytes` default frame type.
+[^issue-286]: Middleware follow-up requested by
+    [@leynos](https://github.com/leynos), with context from
+    [issue #286](https://github.com/leynos/wireframe/issues/286),
+    [PR #283](https://github.com/leynos/wireframe/pull/283), and the linked
+    [comment](https://github.com/leynos/wireframe/pull/283#issuecomment-3167997856).
 [^codec]: See
           [Pluggable protocol codecs](execplans/pluggable-protocol-codecs.md)
     and `src/codec.rs`.

--- a/docs/v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/v0-2-0-to-v0-3-0-migration-guide.md
@@ -703,7 +703,7 @@ assert_eq!(
 
 `obs_handle()` is an `rstest` fixture that constructs a handle directly.
 `Labels` provides a builder for label pairs used with
-`ObservabilityHandle:: counter`.
+`ObservabilityHandle::counter`.
 
 The handle's `snapshot()` method drains counters atomically. Query after
 `snapshot()`; earlier values are not retained.
@@ -892,9 +892,10 @@ yielding a `SendStreamingOutcome`.*
   inbound frame against that identifier.
 
 `ResponseStream` implements `futures::Stream` with
-`Item = Result<P, ClientError>`. It holds an exclusive borrow of the client for
-the duration of the stream, preventing concurrent sends. The terminator frame
-is consumed internally and the stream returns `None` once it arrives.
+`Item = Result<Frame, ClientError>`. It holds an exclusive borrow of the
+client for the duration of the stream, preventing concurrent sends. The
+terminator frame is consumed internally and the stream returns `None` once it
+arrives.
 
 ```rust
 use std::net::SocketAddr;

--- a/docs/v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/v0-2-0-to-v0-3-0-migration-guide.md
@@ -200,8 +200,9 @@ wireframe = { version = "0.3.0", features = ["testkit"] }
 
 ## Unified error surface
 
-`wireframe` now exposes one canonical error type: `wireframe::WireframeError<E>`,
-defined in `wireframe::error`. The two previous error types are gone.
+`wireframe` now exposes one canonical error type:
+`wireframe::WireframeError<E>`, defined in `wireframe::error`. The two previous
+error types are gone.
 
 - `wireframe::app::error::WireframeError` is removed.
 - `wireframe::response::WireframeError` is removed.
@@ -236,21 +237,21 @@ reference the module directly rather than the root shorthand.
 
 The most common moves:
 
-| Removed root path | New path |
-| --- | --- |
-| `wireframe::BincodeSerializer`, `wireframe::Serializer` | `wireframe::serializer::{BincodeSerializer, Serializer}` |
-| `wireframe::ConnectionActor` | `wireframe::connection::ConnectionActor` |
-| `wireframe::CorrelatableFrame` | `wireframe::correlation::CorrelatableFrame` |
+| Removed root path                                                                          | New path                                                                  |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `wireframe::BincodeSerializer`, `wireframe::Serializer`                                    | `wireframe::serializer::{BincodeSerializer, Serializer}`                  |
+| `wireframe::ConnectionActor`                                                               | `wireframe::connection::ConnectionActor`                                  |
+| `wireframe::CorrelatableFrame`                                                             | `wireframe::correlation::CorrelatableFrame`                               |
 | `wireframe::ConnectionContext`, `wireframe::ProtocolHooks`, `wireframe::WireframeProtocol` | `wireframe::hooks::{ConnectionContext, ProtocolHooks, WireframeProtocol}` |
-| `wireframe::ClientCodecConfig`, `wireframe::ClientError`, `wireframe::WireframeClient` | `wireframe::client::{...}` |
-| `wireframe::CodecError`, `wireframe::DefaultRecoveryPolicy`, `wireframe::RecoveryConfig` | `wireframe::codec::{...}` |
-| `wireframe::FrameStream`, `wireframe::Response` | `wireframe::response::{FrameStream, Response}` |
-| `wireframe::ConnectionId`, `wireframe::SessionRegistry` | `wireframe::session::{ConnectionId, SessionRegistry}` |
-| `wireframe::RequestParts`, `wireframe::RequestBodyStream` | `wireframe::request::{RequestParts, RequestBodyStream}` |
+| `wireframe::ClientCodecConfig`, `wireframe::ClientError`, `wireframe::WireframeClient`     | `wireframe::client::{...}`                                                |
+| `wireframe::CodecError`, `wireframe::DefaultRecoveryPolicy`, `wireframe::RecoveryConfig`   | `wireframe::codec::{...}`                                                 |
+| `wireframe::FrameStream`, `wireframe::Response`                                            | `wireframe::response::{FrameStream, Response}`                            |
+| `wireframe::ConnectionId`, `wireframe::SessionRegistry`                                    | `wireframe::session::{ConnectionId, SessionRegistry}`                     |
+| `wireframe::RequestParts`, `wireframe::RequestBodyStream`                                  | `wireframe::request::{RequestParts, RequestBodyStream}`                   |
 
 The full list of moved types is in the
-[v0.1.0 → v0.2.0 migration guide](v0-1-0-to-v0-2-0-migration-guide.md).
-That list now takes effect.
+[v0.1.0 → v0.2.0 migration guide](v0-1-0-to-v0-2-0-migration-guide.md). That
+list now takes effect.
 
 `wireframe::prelude::*` provides an optional convenience import for
 high-frequency types. It is intentionally small; prefer direct module imports
@@ -336,14 +337,14 @@ impl EncodeWith<MySerializer> for MyMessage {
 }
 ```
 
-A `SerdeSerializerBridge` trait (behind the `serializer-serde` feature) and
-the `SerdeMessage<T>` wrapper provide a path for Serde-derived types without
+A `SerdeSerializerBridge` trait (behind the `serializer-serde` feature) and the
+`SerdeMessage<T>` wrapper provide a path for Serde-derived types without
 implementing `bincode::Encode`.
 
 ## WireframeApp construction
 
-`WireframeApp::new()` now returns `Result<Self>` for forward compatibility.
-The call currently always succeeds, but the return type must be handled.
+`WireframeApp::new()` now returns `Result<Self>` for forward compatibility. The
+call currently always succeeds, but the return type must be handled.
 
 ```rust
 // Before
@@ -611,7 +612,8 @@ partial frames, fragments, and slow I/O, plus `TestSerializer`, `TestResult`,
 `TestError`, and assembly snapshot assertion helpers. The `wireframe_testing`
 companion crate provides `WireframePair` (real loopback server–client pair),
 `ObservabilityHandle` (log + metrics capture with atomic snapshot semantics),
-`Labels`, and `HotlineFixtures` (codec regression fixtures and `new_test_codec`).*
+`Labels`, and `HotlineFixtures` (codec regression fixtures and
+`new_test_codec`).*
 
 `wireframe::testkit` (behind the `testkit` Cargo feature) provides optional
 test utilities for downstream protocol crates. The module is not available in
@@ -627,8 +629,8 @@ Capabilities include:
   real network delay.
 - Assembly assertion helpers (`assert_message_assembly_completed`,
   `assert_fragment_reassembly_error`, and the full `MessageAssemblySnapshot` /
-  `FragmentReassemblySnapshot` families) for verifying assembly and
-  reassembly outcomes without panicking.
+  `FragmentReassemblySnapshot` families) for verifying assembly and reassembly
+  outcomes without panicking.
 - `TestSerializer` – a minimal serializer for use in tests.
 - `TestResult` and `TestError` – ergonomic result types for test functions.
 
@@ -700,8 +702,8 @@ assert_eq!(
 ```
 
 `obs_handle()` is an `rstest` fixture that constructs a handle directly.
-`Labels` provides a builder for label pairs used with `ObservabilityHandle::
-counter`.
+`Labels` provides a builder for label pairs used with
+`ObservabilityHandle:: counter`.
 
 The handle's `snapshot()` method drains counters atomically. Query after
 `snapshot()`; earlier values are not retained.
@@ -885,14 +887,14 @@ yielding a `SendStreamingOutcome`.*
   request, and returns a `ResponseStream` that yields typed frames until the
   server sends a stream terminator.
 - `receive_streaming(correlation_id)` – the lower-level variant for callers
-  that have already sent the request via `send` or `send_envelope` and hold
-  the correlation identifier. Returns a `ResponseStream` that validates every
+  that have already sent the request via `send` or `send_envelope` and hold the
+  correlation identifier. Returns a `ResponseStream` that validates every
   inbound frame against that identifier.
 
-`ResponseStream` implements `futures::Stream` with `Item = Result<P,
-ClientError>`. It holds an exclusive borrow of the client for the duration of
-the stream, preventing concurrent sends. The terminator frame is consumed
-internally and the stream returns `None` once it arrives.
+`ResponseStream` implements `futures::Stream` with
+`Item = Result<P, ClientError>`. It holds an exclusive borrow of the client for
+the duration of the stream, preventing concurrent sends. The terminator frame
+is consumed internally and the stream returns `None` once it arrives.
 
 ```rust
 use std::net::SocketAddr;
@@ -945,16 +947,16 @@ sequenceDiagram
 ```
 
 *Sequence diagram: `call_streaming` sends the request and returns a
-`ResponseStream` that holds an exclusive borrow of the client. Each `try_next()`
-call polls the client for the next server frame; the loop continues until the
-server sends a terminator, at which point the stream returns `None`. Dropping
-the `ResponseStream` releases the borrow, making the client available for
-further calls.*
+`ResponseStream` that holds an exclusive borrow of the client. Each
+`try_next()` call polls the client for the next server frame; the loop
+continues until the server sends a terminator, at which point the stream
+returns `None`. Dropping the `ResponseStream` releases the borrow, making the
+client available for further calls.*
 
 `StreamingResponseExt` is a trait on any `Stream` of response frames. It
-provides `typed_with(mapper)`, which produces a `TypedResponseStream<S, Mapper,
-P, Item>` that translates raw frames into domain values and skips control
-frames where the mapper returns `Ok(None)`.
+provides `typed_with(mapper)`, which produces a
+`TypedResponseStream<S, Mapper, P, Item>` that translates raw frames into
+domain values and skips control frames where the mapper returns `Ok(None)`.
 
 ```rust
 use wireframe::client::StreamingResponseExt;
@@ -973,8 +975,8 @@ let typed_stream = raw_stream.typed_with(|frame| {
 `WireframeClient::send_streaming` sends a large body as a sequence of
 protocol-framed chunks, reading from any `AsyncRead` source.
 
-`SendStreamingConfig` controls chunk sizing and timeout. When chunk size is
-not set, it is derived from `max_frame_length - frame_header.len()`.
+`SendStreamingConfig` controls chunk sizing and timeout. When chunk size is not
+set, it is derived from `max_frame_length - frame_header.len()`.
 
 ```rust
 use std::time::Duration;
@@ -1086,11 +1088,11 @@ classDiagram
     ClientPoolConfig --> PoolFairnessPolicy
 ```
 
-*Class diagram: `WireframeClientBuilder` creates a `WireframeClientPool` using a
-`ClientPoolConfig` (which selects a `PoolFairnessPolicy`). The pool vends
-`PoolHandle` instances; each handle yields a `PooledClientLease` on `acquire()`.
-`PooledClientLease` derefs to `WireframeClient`, exposing `call`, `send`, and
-`receive` for individual requests.*
+*Class diagram: `WireframeClientBuilder` creates a `WireframeClientPool` using
+a `ClientPoolConfig` (which selects a `PoolFairnessPolicy`). The pool vends
+`PoolHandle` instances; each handle yields a `PooledClientLease` on
+`acquire()`. `PooledClientLease` derefs to `WireframeClient`, exposing `call`,
+`send`, and `receive` for individual requests.*
 
 Sequence diagram showing the connection pool usage flow: building the pool,
 acquiring a PoolHandle, checking out a PooledClientLease, making a request, and
@@ -1171,9 +1173,9 @@ let client = WireframeClientBuilder::new()
 `TracingConfig` controls which client operations emit tracing spans, at what
 level, and whether per-operation elapsed-time events are recorded.
 
-The default configuration emits `INFO` spans for lifecycle operations (`connect`,
-`close`) and `DEBUG` spans for data operations (`send`, `receive`, `call`,
-`call_streaming`). Timing is disabled by default.
+The default configuration emits `INFO` spans for lifecycle operations
+(`connect`, `close`) and `DEBUG` spans for data operations (`send`, `receive`,
+`call`, `call_streaming`). Timing is disabled by default.
 
 ```rust
 use tracing::Level;


### PR DESCRIPTION
## Summary
- Compile and publish the inventory trait bounds documentation for Frame = Vec<u8>, including recovering Issue 287 ExecPlan context to bound the migration scope for frame/payload ownership.
- This is a docs-only change focused on inventory, planning artifacts, and cross-links.

## Changes
### Documentation
- Added docs/execplans/issue-287-inventory-trait-bounds-expecting-frame-vec-u8.md — ExecPlan for Issue 287 detailing constraints, taxonomy, risks, validation, and plan of work.
- Added docs/frame-vec-u8-inventory.md — Inventory of Frame = Vec<u8> trait bounds and APIs, including taxonomy (frame-bound, payload-bound, internal-only, docs/tests-only) and confirmed runtime surfaces.
- Updated docs/contents.md — linked the new frame-vec-u8 inventory to improve discoverability.
- Updated docs/adr-001-multi-packet-streaming-response-api.md — clarified wording around channel constructors in the server-side multi-packet API documentation.
- Updated docs/v0-2-0-to-v0-3-0-migration-guide.md — refined table formatting and wrapping for better readability; adjusted several root-path migration entries and notes.

## Rationale
- The repository previously recovered the missing Issue 287 ExecPlan from history and published the final inventory document (frame-vec-u8-inventory.md). This PR formalizes that work, providing:
  - A stable reference for what constitutes a frame-bound vs. payload-bound surface.
  - A clear plan for how to generalize transport frames without prematurely constraining payload APIs.
  - Documentation gates that help coordinate epic 284/284-era migration efforts.
- Making these docs explicit helps maintainers and downstream users align on scope, risk, and next steps without introducing code changes.

## Validation and checks
- This is a docs-only PR; no code changes.
- Local validation performed:
  - Ran formatting and markdown lint gates as part of the docs quality checks (e.g., make fmt, make markdownlint). All gates pass for the included files.
- Cross-link checks: new ExecPlan references the frame-u8 inventory; inventory doc references the runtime surfaces and categories described in the ExecPlan.

## Testing plan
- Review the new ExecPlan to ensure it matches the inventory document and does not introduce conflicting claims.
- Confirm cross-links in contents.md and migration guide are accurate and navigable.
- Ensure formatting conforms to project conventions (tables, headings, code blocks).

## Notes for reviewers
- No code changes were made; please focus on:
  - Accuracy and completeness of the ExecPlan and inventory taxonomy.
  - Consistency of terminology (frame-bound vs. payload-bound vs. internal-only).
  - Clarity of the plan of work and validation steps.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/7afce1d8-b015-472e-b74a-57696a4c91ee

## Summary by Sourcery

Add and publish documentation inventorying all remaining `Frame = Vec<u8>` trait bounds and APIs, restore the Issue 287 ExecPlan describing that inventory and migration context, and hook these docs into the existing documentation index while making minor readability tweaks to related guides.

Documentation:
- Publish a detailed inventory of `Frame = Vec<u8>`-related trait bounds and payload APIs, including taxonomy, risks, and migration considerations.
- Restore and finalize the Issue 287 ExecPlan document describing constraints, validation, and plan of work for the frame/payload migration scope.
- Link the new inventory into the docs contents index and clarify wording/formatting in the multi-packet streaming ADR and v0.2.0→v0.3.0 migration guide for better readability.
