### PR TITLE
Implement WireframeError error integration (#513)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,7 +674,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2400,6 +2400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2575,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tempfile"
 version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2576,6 +2591,15 @@ dependencies = [
  "once_cell",
  "rustix 1.0.8",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2753,10 +2777,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae2a4cf385da23d1d53bc15cdfa5c2109e93d8d362393c801e87da2f72f0e201"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.12",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
@@ -2765,9 +2813,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
- "toml_datetime",
- "winnow",
+ "toml_datetime 0.6.11",
+ "winnow 0.7.12",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower-service"
@@ -2863,6 +2926,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.6",
+]
 
 [[package]]
 name = "type-map"
@@ -3436,6 +3514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+
+[[package]]
 name = "winx"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3485,6 +3569,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-test",
+ "trybuild",
  "wireframe",
  "wireframe_testing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ criterion = "0.5.1"
 cap-std = { version = "3.4.5", features = ["fs_utf8"] }
 camino = "1.2.2"
 serde_json = "1.0.141"
+trybuild = "1"
 
 tokio = { version = "1.47.1", default-features = false, features = [
     "macros",

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -218,6 +218,19 @@ describes one or more scenarios using the standard Given/When/Then syntax.
 Scenario functions are annotated with `#[scenario(path = "…", name = "…")]` and
 receive fixture parameters by name.
 
+### trybuild compile-time tests
+
+Compile-time API contracts live in
+[`tests/compile_error.rs`](../tests/compile_error.rs). That runner uses
+[`trybuild`](https://crates.io/crates/trybuild) to execute small pass and
+compile-fail programs under [`tests/ui/`](../tests/ui/).
+
+Use these tests for public trait bounds, default generic parameters, and other
+contracts that must fail or succeed at type-check time rather than runtime.
+Place new snippets in `tests/ui/`, register them in `tests/compile_error.rs`,
+and commit the generated `.stderr` file for compile-fail cases after verifying
+that the diagnostics describe the intended contract.
+
 ### Feature files and step definitions
 
 Each `.feature` file under `tests/features/` has a corresponding

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -56,6 +56,21 @@ Use this checklist before merging API naming changes:
 - Label cross-layer terms (for example, `correlation_id`) explicitly as shared
   metadata.
 
+## Error surface conventions
+
+Library-facing errors should remain typed and inspectable. The root
+`WireframeError<E>` carries setup, transport, protocol, and codec failures, and
+the crate-level `Result<T>` aliases the default
+`WireframeError<NoProtocolError>` form. `NoProtocolError` is the marker for APIs
+that have no protocol-specific error payload.
+
+Implement `std::error::Error` for protocol error types that should appear in
+source chains. The blanket `WireframeError<E>` implementation exposes
+`Protocol(E)` as a source when `E: Error + 'static`; the
+`WireframeError<NoProtocolError>` specialization keeps the default error type
+usable with standard wrappers while returning `None` for
+`Protocol(NoProtocolError)`.
+
 ## Message sequence validation architecture
 
 Message continuation ordering lives in `src/message_assembler/series.rs`. The

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -58,18 +58,11 @@ Use this checklist before merging API naming changes:
 
 ## Error surface conventions
 
-Library-facing errors should remain typed and inspectable. The root
-`WireframeError<E>` carries setup, transport, protocol, and codec failures, and
-the crate-level `Result<T>` aliases the default
-`WireframeError<NoProtocolError>` form. `NoProtocolError` is the marker for APIs
-that have no protocol-specific error payload.
-
-Implement `std::error::Error` for protocol error types that should appear in
-source chains. The blanket `WireframeError<E>` implementation exposes
-`Protocol(E)` as a source when `E: Error + 'static`; the
-`WireframeError<NoProtocolError>` specialization keeps the default error type
-usable with standard wrappers while returning `None` for
-`Protocol(NoProtocolError)`.
+Library-facing errors should stay typed and inspectable by default. Use
+`NoProtocolError` when an API has no protocol-specific failure payload so the
+crate-level `Result<T>` still participates in standard error chaining; reserve
+`WireframeError<E>` for protocols with their own source-bearing error type. See
+the rustdoc for `wireframe::NoProtocolError` for the public API contract.
 
 ## Message sequence validation architecture
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -150,6 +150,15 @@ buffering caps for inbound assembly paths. Custom protocols implement
 settings, so call `enable_fragmentation()` (or `fragmentation(Some(cfg))`)
 again when transport fragmentation is required.
 
+`WireframeError` defaults to `WireframeError<NoProtocolError>`. The marker
+means an API does not carry protocol-defined error payloads, while still
+allowing the default `wireframe::Result<T>` to implement `std::error::Error`
+and work with `Box<dyn Error>` or other standard error wrappers. When a
+protocol does have its own typed failures, name the parameter explicitly, for
+example `WireframeError<MyProtocolError>`. Code that previously relied on the
+default accepting `WireframeError::Protocol(())` should annotate that case as
+`WireframeError<()>` instead.
+
 Once a stream is accepted—either from a manual accept loop or via
 `WireframeServer`—`handle_connection(stream)` builds (or reuses) the middleware
 chain, wraps the transport in the configured frame codec (length-delimited by

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -159,6 +159,22 @@ example `WireframeError<MyProtocolError>`. Code that previously relied on the
 default accepting `WireframeError::Protocol(())` should annotate that case as
 `WireframeError<()>` instead.
 
+The default error type works with standard error wrappers and source-chain
+inspection:
+
+```rust
+use std::error::Error;
+use wireframe::WireframeError;
+
+fn boxed_route_error() -> Box<dyn Error> {
+    Box::new(WireframeError::DuplicateRoute(7))
+}
+
+fn inspect_transport_source(error: &WireframeError) -> Option<&dyn Error> {
+    error.source()
+}
+```
+
 Once a stream is accepted—either from a manual accept loop or via
 `WireframeServer`—`handle_connection(stream)` builds (or reuses) the middleware
 chain, wraps the transport in the configured frame codec (length-delimited by
@@ -2098,24 +2114,30 @@ can be interleaved with push traffic. `WireframeError` distinguishes transport
 failures from protocol-level errors emitted by streaming
 responses.[^34][^35][^31]
 
+`Response<F>`, `FrameStream<F>`, and `ConnectionActor<F>` all use
+`NoProtocolError` by default. In ordinary no-protocol applications that means
+streaming code can name the frame type only, while still returning
+`WireframeError<NoProtocolError>` internally. Name the error parameter only when
+the stream or actor carries a protocol-specific failure payload.
+
 When constructing imperative streams, the `async-stream` crate integrates
 smoothly. The example below yields five frames and converts them into a
 `Response::Stream` value:[^36]
 
 ```rust
 use async_stream::try_stream;
-use wireframe::response::Response;
+use wireframe::response::{FrameStream, Response};
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug, PartialEq)]
 struct Frame(u32);
 
 fn stream_response() -> Response<Frame> {
-    let frames = try_stream! {
+    let frames: FrameStream<Frame> = Box::pin(try_stream! {
         for value in 0..5 {
             yield Frame(value);
         }
-    };
-    Response::Stream(Box::pin(frames))
+    });
+    Response::Stream(frames)
 }
 ```
 

--- a/docs/v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/v0-2-0-to-v0-3-0-migration-guide.md
@@ -235,6 +235,12 @@ protocol payload must name it explicitly, for example
 accepting `WireframeError::Protocol(())` should migrate to an explicit
 `WireframeError<()>` annotation.
 
+`WireframeError<E>` now implements `std::error::Error` when `E` is itself an
+error, preserving `Protocol(E)` as the source for protocol failures. The
+`NoProtocolError` specialization also implements `std::error::Error`, but its
+`Protocol(NoProtocolError)` variant has no source because the marker carries no
+underlying cause.
+
 ## Root re-exports removed
 
 The crate root now exposes only `wireframe::Result<T>` and

--- a/docs/v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/v0-2-0-to-v0-3-0-migration-guide.md
@@ -226,6 +226,15 @@ The unified `WireframeError<E>` carries four variants:
 - `Protocol(E)` – protocol-defined logical error.
 - `Codec(CodecError)` – codec-layer error with structured context.
 
+`WireframeError` defaults to `WireframeError<NoProtocolError>`, and
+`wireframe::Result<T>` aliases that default. This is the intended v0.3.0
+contract: APIs without protocol-specific error payloads use `NoProtocolError`,
+so `Result<T>` participates in standard error chaining. Code that needs a
+protocol payload must name it explicitly, for example
+`WireframeError<MyProtocolError>`. Code that previously relied on the default
+accepting `WireframeError::Protocol(())` should migrate to an explicit
+`WireframeError<()>` annotation.
+
 ## Root re-exports removed
 
 The crate root now exposes only `wireframe::Result<T>` and

--- a/docs/v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/v0-2-0-to-v0-3-0-migration-guide.md
@@ -243,12 +243,13 @@ underlying cause.
 
 ## Root re-exports removed
 
-The crate root now exposes only `wireframe::Result<T>` and
-`wireframe::WireframeError<E>`. Every other type is still available through its
-owning public module – those modules are all `pub mod` at the crate root and
-their contents have not been removed from the public API. What changed is that
-the convenience re-exports at the crate root are gone. Update import paths to
-reference the module directly rather than the root shorthand.
+The crate root now exposes only `wireframe::Result<T>`,
+`wireframe::WireframeError<E>`, and `wireframe::NoProtocolError` from the error
+surface. Every other type is still available through its owning public module –
+those modules are all `pub mod` at the crate root and their contents have not
+been removed from the public API. What changed is that the convenience
+re-exports at the crate root are gone. Update import paths to reference the
+module directly rather than the root shorthand.
 
 The most common moves:
 

--- a/docs/v0-2-0-to-v0-3-0-migration-guide.md
+++ b/docs/v0-2-0-to-v0-3-0-migration-guide.md
@@ -246,7 +246,7 @@ underlying cause.
 The crate root now exposes only `wireframe::Result<T>`,
 `wireframe::WireframeError<E>`, and `wireframe::NoProtocolError` from the error
 surface. Every other type is still available through its owning public module –
-those modules are all `pub mod` at the crate root and their contents have not
+those modules are all `pub mod` at the crate root, and their contents have not
 been removed from the public API. What changed is that the convenience
 re-exports at the crate root are gone. Update import paths to reference the
 module directly rather than the root shorthand.

--- a/examples/multi_packet.rs
+++ b/examples/multi_packet.rs
@@ -96,7 +96,7 @@ fn log_frame(frame: &Frame) {
     info!("{frame}");
 }
 
-async fn run() -> Result<(), WireframeError<()>> {
+async fn run() -> Result<(), WireframeError> {
     let _ = tracing_subscriber::fmt::try_init();
     let response = multi_packet_response();
     let mut stream = response.into_stream();

--- a/src/client/tests/streaming_parity.rs
+++ b/src/client/tests/streaming_parity.rs
@@ -35,7 +35,7 @@ fn stream_terminator() -> TestStreamEnvelope {
     }
 }
 
-fn hooks_with_stream_end() -> ProtocolHooks<TestStreamEnvelope, ()> {
+fn hooks_with_stream_end() -> ProtocolHooks<TestStreamEnvelope, crate::NoProtocolError> {
     ProtocolHooks {
         stream_end: Some(Box::new(|_ctx: &mut ConnectionContext| {
             Some(stream_terminator())
@@ -60,7 +60,7 @@ impl Drop for PausedTimeGuard {
 fn setup_fairness_actor(
     queues: PushQueues<TestStreamEnvelope>,
     handle: crate::push::PushHandle<TestStreamEnvelope>,
-) -> ConnectionActor<TestStreamEnvelope, ()> {
+) -> ConnectionActor<TestStreamEnvelope, crate::NoProtocolError> {
     let mut actor = ConnectionActor::with_hooks(
         ConnectionChannels::new(queues, handle),
         None,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -34,6 +34,7 @@ use tokio_util::sync::CancellationToken;
 
 pub use crate::fairness::FairnessConfig;
 use crate::{
+    NoProtocolError,
     app::Packet,
     correlation::CorrelatableFrame,
     fairness::FairnessTracker,
@@ -72,10 +73,10 @@ pub enum ConnectionStateError {
 ///     .build()
 ///     .expect("failed to build PushQueues");
 /// let shutdown = CancellationToken::new();
-/// let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+/// let mut actor: ConnectionActor<_> = ConnectionActor::new(queues, handle, None, shutdown);
 /// # drop(actor);
 /// ```
-pub struct ConnectionActor<F, E> {
+pub struct ConnectionActor<F, E = NoProtocolError> {
     high_rx: Option<mpsc::Receiver<F>>,
     low_rx: Option<mpsc::Receiver<F>>,
     /// Active output source: either a streaming response or a multi-packet channel.
@@ -113,7 +114,7 @@ where
     ///     .build()
     ///     .expect("failed to build PushQueues");
     /// let token = CancellationToken::new();
-    /// let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, token);
+    /// let mut actor: ConnectionActor<_> = ConnectionActor::new(queues, handle, None, token);
     /// # drop(actor);
     /// ```
     #[must_use]
@@ -237,7 +238,7 @@ where
     /// #     .build()
     /// #     .expect("failed to build PushQueues");
     /// # let shutdown = CancellationToken::new();
-    /// # let mut actor: ConnectionActor<u8, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+    /// # let mut actor: ConnectionActor<u8> = ConnectionActor::new(queues, handle, None, shutdown);
     /// # let (_tx, rx) = mpsc::channel(4);
     /// actor.set_multi_packet_with_correlation(Some(rx), Some(7))?;
     /// # Ok::<(), wireframe::connection::ConnectionStateError>(())

--- a/src/connection/test_support.rs
+++ b/src/connection/test_support.rs
@@ -14,6 +14,7 @@ use super::{
     state::ActorState,
 };
 use crate::{
+    NoProtocolError,
     app::{Packet, PacketParts},
     hooks::ProtocolHooks,
     push::{PushConfigError, PushQueues},
@@ -45,8 +46,8 @@ impl Packet for Vec<u8> {
 ///
 /// Returns an error if the push queues cannot be constructed.
 pub fn create_test_actor_with_hooks(
-    hooks: ProtocolHooks<u8, ()>,
-) -> Result<ConnectionActor<u8, ()>, PushConfigError> {
+    hooks: ProtocolHooks<u8, NoProtocolError>,
+) -> Result<ConnectionActor<u8>, PushConfigError> {
     let (queues, handle) = PushQueues::<u8>::builder()
         .high_capacity(4)
         .low_capacity(4)
@@ -61,7 +62,7 @@ pub fn create_test_actor_with_hooks(
 
 /// Convenience harness wrapping an actor, its state, and buffered output.
 pub struct ActorHarness {
-    actor: ConnectionActor<u8, ()>,
+    actor: ConnectionActor<u8>,
     state: ActorState,
     /// Frames emitted by the actor during tests, preserved for assertions.
     pub out: Vec<u8>,
@@ -74,7 +75,7 @@ impl ActorHarness {
     ///
     /// Returns an error if the push queues cannot be constructed.
     pub fn new_with_state(
-        hooks: ProtocolHooks<u8, ()>,
+        hooks: ProtocolHooks<u8, NoProtocolError>,
         has_response: bool,
         has_multi_packet: bool,
     ) -> Result<Self, PushConfigError> {
@@ -92,7 +93,11 @@ impl ActorHarness {
     ///
     /// Returns an error if the push queues cannot be constructed.
     pub fn new() -> Result<Self, PushConfigError> {
-        Self::new_with_state(ProtocolHooks::<u8, ()>::default(), false, false)
+        Self::new_with_state(
+            ProtocolHooks::<u8, NoProtocolError>::default(),
+            false,
+            false,
+        )
     }
 
     /// Snapshot the internal actor state.
@@ -173,7 +178,7 @@ impl ActorHarness {
     }
 
     /// Access the underlying actor mutably.
-    pub fn actor_mut(&mut self) -> &mut ConnectionActor<u8, ()> { &mut self.actor }
+    pub fn actor_mut(&mut self) -> &mut ConnectionActor<u8> { &mut self.actor }
 }
 
 /// Snapshot of the actor lifecycle flags and counters.

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,26 +63,39 @@ impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
     }
 }
 
+fn transport_or_codec_source<E>(
+    error: &WireframeError<E>,
+) -> Option<&(dyn std::error::Error + 'static)> {
+    match error {
+        WireframeError::Io(error) => Some(error),
+        WireframeError::Codec(error) => Some(error),
+        WireframeError::DuplicateRoute(_) | WireframeError::Protocol(_) => None,
+    }
+}
+
 impl<E> std::error::Error for WireframeError<E>
 where
     E: std::fmt::Debug + std::error::Error + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(error) => Some(error),
-            Self::Codec(error) => Some(error),
-            Self::Protocol(error) => Some(error),
-            Self::DuplicateRoute(_) => None,
-        }
+        transport_or_codec_source(self).or_else(|| protocol_error_source(self))
     }
 }
 
 impl std::error::Error for WireframeError<NoProtocolError> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            Self::Io(error) => Some(error),
-            Self::Codec(error) => Some(error),
-            Self::DuplicateRoute(_) | Self::Protocol(_) => None,
+        transport_or_codec_source(self)
+    }
+}
+
+fn protocol_error_source<E>(error: &WireframeError<E>) -> Option<&(dyn std::error::Error + 'static)>
+where
+    E: std::error::Error + 'static,
+{
+    match error {
+        WireframeError::Protocol(error) => Some(error),
+        WireframeError::DuplicateRoute(_) | WireframeError::Io(_) | WireframeError::Codec(_) => {
+            None
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@
 /// `WireframeError` distinguishes setup-time route conflicts from runtime
 /// transport, protocol, and codec failures.
 #[derive(Debug)]
-pub enum WireframeError<E = ()> {
+pub enum WireframeError<E = NoProtocolError> {
     /// A route with the provided identifier was already registered.
     DuplicateRoute(u32),
     /// An error in the underlying transport (for example, a socket close).
@@ -18,6 +18,14 @@ pub enum WireframeError<E = ()> {
     /// A codec-layer error with structured context.
     Codec(crate::codec::CodecError),
 }
+
+/// Default protocol-error marker for APIs that do not carry protocol errors.
+///
+/// This marker is deliberately not an [`std::error::Error`]. That keeps the
+/// default `WireframeError` implementation separate from the blanket
+/// implementation for protocol-error types that do expose a source.
+#[derive(Debug)]
+pub enum NoProtocolError {}
 
 impl<E> From<E> for WireframeError<E> {
     fn from(error: E) -> Self { Self::Protocol(error) }
@@ -52,8 +60,19 @@ impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
 
 impl<E> std::error::Error for WireframeError<E>
 where
-    E: std::fmt::Debug,
+    E: std::fmt::Debug + std::error::Error + 'static,
 {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Codec(error) => Some(error),
+            Self::Protocol(error) => Some(error),
+            Self::DuplicateRoute(_) => None,
+        }
+    }
+}
+
+impl std::error::Error for WireframeError<NoProtocolError> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(error) => Some(error),
@@ -64,4 +83,4 @@ where
 }
 
 /// Canonical result alias used by `wireframe` public APIs.
-pub type Result<T> = std::result::Result<T, WireframeError<()>>;
+pub type Result<T> = std::result::Result<T, WireframeError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub enum WireframeError<E = NoProtocolError> {
 /// default `WireframeError` implementation separate from the blanket
 /// implementation for protocol-error types that do expose a source.
 #[derive(Debug)]
-pub enum NoProtocolError {}
+pub struct NoProtocolError;
 
 impl<E> From<E> for WireframeError<E> {
     fn from(error: E) -> Self { Self::Protocol(error) }

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,11 @@
 ///
 /// `WireframeError` distinguishes setup-time route conflicts from runtime
 /// transport, protocol, and codec failures.
+///
+/// The default `E = NoProtocolError` is used by [`crate::Result`] for APIs
+/// that do not carry protocol-specific failures. Specify `WireframeError<E>`
+/// explicitly when the `Protocol` variant should contain a real protocol
+/// error type.
 #[derive(Debug)]
 pub enum WireframeError<E = NoProtocolError> {
     /// A route with the provided identifier was already registered.

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,6 +29,11 @@ pub enum WireframeError<E = NoProtocolError> {
 /// This marker is deliberately not an [`std::error::Error`]. That keeps the
 /// default `WireframeError` implementation separate from the blanket
 /// implementation for protocol-error types that do expose a source.
+/// `Protocol(())` is constructible but semantically empty; a named marker makes
+/// "no protocol error" an explicit API state. Because `()` does not implement
+/// [`std::error::Error`], defaulting to `()` would silently strip the
+/// [`std::error::Error`] implementation from `WireframeError`; that is the
+/// #513 regression this marker prevents.
 #[derive(Debug)]
 pub struct NoProtocolError;
 
@@ -82,6 +87,7 @@ where
     }
 }
 
+// See #513: `NoProtocolError` is intentionally not `Error`, so the blanket impl cannot cover it.
 impl std::error::Error for WireframeError<NoProtocolError> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         transport_or_codec_source(self)

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,14 +52,13 @@ impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
 
 impl<E> std::error::Error for WireframeError<E>
 where
-    E: std::fmt::Debug + std::error::Error + 'static,
+    E: std::fmt::Debug + 'static,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Io(error) => Some(error),
-            Self::Protocol(error) => Some(error),
             Self::Codec(error) => Some(error),
-            Self::DuplicateRoute(_) => None,
+            Self::DuplicateRoute(_) | Self::Protocol(_) => None,
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -52,7 +52,7 @@ impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
 
 impl<E> std::error::Error for WireframeError<E>
 where
-    E: std::fmt::Debug + 'static,
+    E: std::fmt::Debug,
 {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod byte_order;
 pub mod client;
 pub mod codec;
 pub mod error;
-pub use error::{Result, WireframeError};
+pub use error::{NoProtocolError, Result, WireframeError};
 pub mod connection;
 pub mod correlation;
 #[cfg(not(loom))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,12 @@
 //! - Root exports stay intentionally small and stable.
 //! - Domain modules hold detailed APIs (`app`, `server`, `client`, and so on).
 //! - [`prelude`] offers optional convenience imports for common workflows.
+//!
+//! The root [`Result`] alias uses [`WireframeError`] with the default
+//! [`NoProtocolError`] protocol marker. This keeps `Result<T>` usable as a
+//! standard error type when an API has no protocol-specific error payload.
+//! Use `WireframeError<E>` explicitly when a protocol supplies its own error
+//! type.
 
 extern crate self as wireframe;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -15,7 +15,7 @@
 pub use crate::message::serde_bridge::{IntoSerdeMessage, SerdeMessage};
 pub use crate::{
     app::{Envelope, Handler, Middleware, WireframeApp},
-    error::{Result, WireframeError},
+    error::{NoProtocolError, Result, WireframeError},
     message::{DecodeWith, DeserializeContext, EncodeWith, Message},
     response::Response,
     serializer::{BincodeSerializer, MessageCompatibilitySerializer, Serializer},

--- a/src/response.rs
+++ b/src/response.rs
@@ -35,17 +35,17 @@ use futures::{Stream, StreamExt, stream};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
-pub use crate::WireframeError;
+pub use crate::{NoProtocolError, WireframeError};
 
 /// A type alias for a type-erased, dynamically dispatched stream of frames.
 ///
 /// Each yielded item is a `Result` containing either a frame `F` or a
 /// [`WireframeError`] describing why the stream failed.
-pub type FrameStream<F, E = ()> =
+pub type FrameStream<F, E = NoProtocolError> =
     Pin<Box<dyn Stream<Item = Result<F, WireframeError<E>>> + Send + 'static>>;
 
 /// Represents the full response to a request.
-pub enum Response<F, E = ()> {
+pub enum Response<F, E = NoProtocolError> {
     /// A single frame reply.
     Single(F),
     /// An optimized list of frames.

--- a/src/testkit/result.rs
+++ b/src/testkit/result.rs
@@ -21,7 +21,7 @@ pub enum TestError {
     #[error("{0}")]
     Msg(String),
     /// Root crate error surfaced while exercising a helper.
-    #[error(transparent)]
+    #[error("wireframe error: {0}")]
     Wireframe(#[from] WireframeError),
     /// Client-side error surfaced while exercising a helper.
     #[cfg(not(loom))]

--- a/src/testkit/result.rs
+++ b/src/testkit/result.rs
@@ -1,4 +1,14 @@
 //! Shared result and error types for `wireframe::testkit`.
+//!
+//! The testkit pulls together helpers from the root crate, client runtime,
+//! server runtime, push queues, codecs, fragmentation, and observability
+//! support. Those helpers need one error surface so downstream protocol tests
+//! can use `?` freely without losing the original failure category.
+//!
+//! `TestError` is that boundary type: it preserves typed conversions for
+//! inspectable Wireframe errors and converts ad-hoc harness failures into a
+//! message variant. `TestResult` is the companion alias used throughout
+//! `wireframe::testkit` and the `wireframe_testing` crate.
 
 use thiserror::Error;
 

--- a/src/testkit/result.rs
+++ b/src/testkit/result.rs
@@ -21,8 +21,8 @@ pub enum TestError {
     #[error("{0}")]
     Msg(String),
     /// Root crate error surfaced while exercising a helper.
-    #[error("wireframe error: {0}")]
-    Wireframe(WireframeError),
+    #[error(transparent)]
+    Wireframe(#[from] WireframeError),
     /// Client-side error surfaced while exercising a helper.
     #[cfg(not(loom))]
     #[error(transparent)]
@@ -93,10 +93,6 @@ impl From<String> for TestError {
 
 impl From<&str> for TestError {
     fn from(value: &str) -> Self { Self::Msg(value.to_string()) }
-}
-
-impl From<WireframeError> for TestError {
-    fn from(value: WireframeError) -> Self { Self::Wireframe(value) }
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for TestError {

--- a/tests/advanced/interaction_fuzz.rs
+++ b/tests/advanced/interaction_fuzz.rs
@@ -37,7 +37,7 @@ async fn run_actions(actions: &[Action]) -> Vec<u8> {
         .expect("failed to build PushQueues");
     let shutdown = CancellationToken::new();
 
-    let mut resp_stream: Option<FrameStream<u8, ()>> = None;
+    let mut resp_stream: Option<FrameStream<u8>> = None;
     for act in actions {
         match act {
             Action::High(f) => handle
@@ -55,7 +55,7 @@ async fn run_actions(actions: &[Action]) -> Vec<u8> {
         }
     }
 
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, resp_stream, shutdown);
     let mut out = Vec::new();
     actor

--- a/tests/advanced/interaction_fuzz.rs
+++ b/tests/advanced/interaction_fuzz.rs
@@ -10,6 +10,8 @@ use proptest::prelude::*;
 use rstest::rstest;
 use tokio_util::sync::CancellationToken;
 use wireframe::{
+    NoProtocolError,
+    WireframeError,
     connection::ConnectionActor,
     response::FrameStream,
 };
@@ -49,13 +51,18 @@ async fn run_actions(actions: &[Action]) -> Vec<u8> {
                 .await
                 .expect("failed to push low priority frame"),
             Action::Stream(frames) => {
-                let s = stream::iter(frames.clone().into_iter().map(Ok::<u8, ()>));
+                let s = stream::iter(
+                    frames
+                        .clone()
+                        .into_iter()
+                        .map(Ok::<u8, WireframeError<NoProtocolError>>),
+                );
                 resp_stream = Some(Box::pin(s));
             }
         }
     }
 
-    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+    let mut actor: ConnectionActor<_, NoProtocolError> =
         ConnectionActor::new(queues, handle, resp_stream, shutdown);
     let mut out = Vec::new();
     actor

--- a/tests/common/interleaved_push_helpers.rs
+++ b/tests/common/interleaved_push_helpers.rs
@@ -33,7 +33,8 @@ where
     setup(handle.clone()).await?;
 
     let shutdown = CancellationToken::new();
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+        ConnectionActor::new(queues, handle, None, shutdown);
     actor.set_fairness(fairness);
     let mut out = Vec::new();
     actor

--- a/tests/common/terminator.rs
+++ b/tests/common/terminator.rs
@@ -2,14 +2,17 @@
 //!
 //! Used across integration and behavioural tests verifying the stream
 //! termination mechanism.
-use wireframe::hooks::{ConnectionContext, WireframeProtocol};
+use wireframe::{
+    NoProtocolError,
+    hooks::{ConnectionContext, WireframeProtocol},
+};
 
 /// Protocol that produces `0` as an explicit end-of-stream marker.
 pub struct Terminator;
 
 impl WireframeProtocol for Terminator {
     type Frame = u8;
-    type ProtocolError = ();
+    type ProtocolError = NoProtocolError;
 
     fn stream_end_frame(&self, _ctx: &mut ConnectionContext) -> Option<Self::Frame> { Some(0) }
 }

--- a/tests/compile_error.rs
+++ b/tests/compile_error.rs
@@ -1,0 +1,8 @@
+//! Compile-time trait-bound and public-default tests.
+
+#[test]
+fn compile_tests() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/ui/wireframe_result_default_no_protocol.rs");
+    t.compile_fail("tests/ui/wireframe_result_default_rejects_unit_protocol.rs");
+}

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -54,7 +54,7 @@ impl HookCounters {
         &self,
         increment: u8,
         stream_end_value: impl Fn(&mut ConnectionContext) -> Option<u8> + Send + Sync + 'static,
-    ) -> ProtocolHooks<u8, ()> {
+    ) -> ProtocolHooks<u8, wireframe::NoProtocolError> {
         let before_clone = Arc::clone(&self.before_calls);
         let end_clone = Arc::clone(&self.end_calls);
 
@@ -70,7 +70,7 @@ impl HookCounters {
             })
                 as Box<dyn FnMut(&mut ConnectionContext) + Send + 'static>),
             stream_end: Some(Box::new(stream_end_value)),
-            ..ProtocolHooks::<u8, ()>::default()
+            ..ProtocolHooks::<u8, wireframe::NoProtocolError>::default()
         }
     }
 

--- a/tests/connection_actor_errors.rs
+++ b/tests/connection_actor_errors.rs
@@ -53,10 +53,10 @@ async fn before_send_hook_modifies_frames(
     let stream = stream::iter(vec![Ok(2u8)]);
     let hooks = ProtocolHooks {
         before_send: Some(Box::new(|f: &mut u8, _ctx: &mut ConnectionContext| *f += 1)),
-        ..ProtocolHooks::<u8, ()>::default()
+        ..ProtocolHooks::<u8, wireframe::NoProtocolError>::default()
     };
 
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::with_hooks(
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> = ConnectionActor::with_hooks(
         ConnectionChannels::new(queues, handle),
         Some(Box::pin(stream)),
         shutdown_token,
@@ -90,10 +90,10 @@ async fn on_command_end_hook_runs(
         on_command_end: Some(Box::new(move |_ctx: &mut ConnectionContext| {
             c.fetch_add(1, Ordering::SeqCst);
         })),
-        ..ProtocolHooks::<u8, ()>::default()
+        ..ProtocolHooks::<u8, wireframe::NoProtocolError>::default()
     };
 
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::with_hooks(
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> = ConnectionActor::with_hooks(
         ConnectionChannels::new(queues, handle),
         Some(Box::pin(stream)),
         shutdown_token,
@@ -202,7 +202,7 @@ async fn io_error_terminates_connection(
         Ok(1u8),
         Err(WireframeError::Io(std::io::Error::other("fail"))),
     ]);
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
     let result = actor.run(&mut out).await;

--- a/tests/connection_actor_fairness.rs
+++ b/tests/connection_actor_fairness.rs
@@ -42,7 +42,7 @@ async fn strict_priority_order(
     push_expect!(handle.push_high_priority(1), "push high-priority")?;
 
     let stream = stream::iter(vec![Ok(3u8)]);
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
     actor
@@ -71,7 +71,7 @@ async fn fairness_yields_low_after_burst(
     }
     push_expect!(handle.push_low_priority(99), "push low-priority")?;
 
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, None, shutdown_token);
     actor.set_fairness(fairness);
     let mut out = Vec::new();
@@ -179,7 +179,7 @@ async fn processes_all_priorities_in_order(
     let high_count = order.iter().filter(|p| matches!(p, Priority::High)).count();
     let expected = queue_frames(&order, &handle, high_count).await?;
 
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, None, shutdown_token);
     actor.set_fairness(fairness);
     let mut out = Vec::new();
@@ -209,7 +209,7 @@ async fn fairness_yields_low_with_time_slice(
         time_slice: Some(Duration::from_millis(10)),
     };
 
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle.clone(), None, shutdown_token);
     actor.set_fairness(fairness);
 

--- a/tests/connection_actor_shutdown.rs
+++ b/tests/connection_actor_shutdown.rs
@@ -37,7 +37,7 @@ async fn shutdown_signal_precedence(
 ) {
     let (queues, handle) = queues.expect("fixture should build queues");
     shutdown_token.cancel();
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, None, shutdown_token);
     // drop the handle after actor creation to mimic early disconnection
     let mut out = Vec::new();
@@ -59,7 +59,7 @@ async fn complete_draining_of_sources(
     push_expect!(handle.push_high_priority(1), "push high-priority")?;
 
     let stream = stream::iter(vec![Ok(2u8), Ok(3u8)]);
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     // drop handle after actor setup
     let mut out = Vec::new();
@@ -93,7 +93,7 @@ async fn interleaved_shutdown_during_stream(
             None
         }
     });
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let mut out = Vec::new();
     actor.run(&mut out).await.expect("actor run failed");
@@ -132,7 +132,7 @@ async fn graceful_shutdown_waits_for_tasks() -> TestResult {
             .high_capacity(1)
             .low_capacity(1)
             .build()?;
-        let mut actor: ConnectionActor<_, ()> =
+        let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
             ConnectionActor::new(queues, handle.clone(), None, token.clone());
         handles.push(handle);
         tracker.spawn(async move {
@@ -166,7 +166,8 @@ async fn connection_count_decrements_on_abort(
     token.cancel();
 
     let before = wireframe::connection::active_connection_count();
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, token);
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+        ConnectionActor::new(queues, handle, None, token);
     let during = wireframe::connection::active_connection_count();
     assert_eq!(during, before + 1);
 
@@ -189,7 +190,7 @@ async fn connection_count_decrements_on_close(
     let (queues, handle) = queues.expect("fixture should build queues");
     let before = wireframe::connection::active_connection_count();
     let stream = stream::iter(vec![Ok(1u8)]);
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle, Some(Box::pin(stream)), shutdown_token);
     let during = wireframe::connection::active_connection_count();
     assert_eq!(during, before + 1);

--- a/tests/connection_fragmentation.rs
+++ b/tests/connection_fragmentation.rs
@@ -19,7 +19,7 @@ const ROUTE_ID: u32 = 7;
 use wireframe_testing::TestResult;
 
 fn setup_fragmented_actor() -> TestResult<(
-    ConnectionActor<Envelope, ()>,
+    ConnectionActor<Envelope, wireframe::NoProtocolError>,
     PushHandle<Envelope>,
     FragmentationConfig,
 )> {
@@ -28,7 +28,7 @@ fn setup_fragmented_actor() -> TestResult<(
         .low_capacity(4)
         .build()?;
     let shutdown = CancellationToken::new();
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle.clone(), None, shutdown);
 
     let message_cap = NonZeroUsize::new(256).ok_or("message cap must be non-zero")?;

--- a/tests/correlation_id.rs
+++ b/tests/correlation_id.rs
@@ -49,7 +49,7 @@ async fn stream_frames_carry_request_correlation_id() -> TestResult {
 async fn run_multi_packet_channel(
     request_correlation: Option<u64>,
     frame_correlations: &[Option<u64>],
-    hooks: ProtocolHooks<Envelope, ()>,
+    hooks: ProtocolHooks<Envelope, wireframe::NoProtocolError>,
 ) -> TestResult<Vec<Envelope>> {
     let capacity = frame_correlations.len().max(1);
     let (tx, rx) = mpsc::channel(capacity);
@@ -71,12 +71,13 @@ async fn run_multi_packet_channel(
         .unlimited()
         .build()?;
     let shutdown = CancellationToken::new();
-    let mut actor: ConnectionActor<Envelope, ()> = ConnectionActor::with_hooks(
-        ConnectionChannels::new(queues, handle),
-        None,
-        shutdown,
-        hooks,
-    );
+    let mut actor: ConnectionActor<Envelope, wireframe::NoProtocolError> =
+        ConnectionActor::with_hooks(
+            ConnectionChannels::new(queues, handle),
+            None,
+            shutdown,
+            hooks,
+        );
     actor
         .set_multi_packet_with_correlation(Some(rx), request_correlation)
         .map_err(|e| io::Error::other(format!("set_multi_packet_with_correlation: {e}")))?;

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -33,6 +33,7 @@ impl std::fmt::Display for ProtoErr {
 
 impl std::error::Error for ProtoErr {}
 
+#[derive(Debug)]
 enum ExpectedSource {
     Io {
         message: &'static str,
@@ -41,25 +42,76 @@ enum ExpectedSource {
     Codec(FramingError),
 }
 
-fn assert_source_matches(source: &(dyn Error + 'static), expected: ExpectedSource) {
-    match expected {
-        ExpectedSource::Io { message, kind } => {
-            let Some(io_source) = source.downcast_ref::<io::Error>() else {
-                panic!("io source should be std::io::Error");
-            };
-            assert_eq!(io_source.kind(), kind);
-            assert_eq!(io_source.to_string(), message);
-        }
-        ExpectedSource::Codec(expected_error) => {
-            let Some(codec_source) = source.downcast_ref::<CodecError>() else {
-                panic!("codec source should be wireframe::codec::CodecError");
-            };
-            assert!(
-                matches!(codec_source, CodecError::Framing(error) if error == &expected_error),
-                "codec source should preserve the original framing error"
-            );
-        }
+#[derive(Debug, PartialEq, Eq)]
+enum ActualSource<'a> {
+    Io {
+        message: String,
+        kind: io::ErrorKind,
+    },
+    Codec {
+        error: &'a FramingError,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum SourceExtractionError {
+    UnexpectedType,
+    UnexpectedCodecVariant,
+}
+
+fn extract_source<'a>(
+    source: &'a (dyn Error + 'static),
+) -> Result<ActualSource<'a>, SourceExtractionError> {
+    if let Some(io_source) = source.downcast_ref::<io::Error>() {
+        return Ok(ActualSource::Io {
+            message: io_source.to_string(),
+            kind: io_source.kind(),
+        });
     }
+
+    if let Some(codec_source) = source.downcast_ref::<CodecError>() {
+        return match codec_source {
+            CodecError::Framing(error) => Ok(ActualSource::Codec { error }),
+            _ => Err(SourceExtractionError::UnexpectedCodecVariant),
+        };
+    }
+
+    Err(SourceExtractionError::UnexpectedType)
+}
+
+fn source_matches(actual: &ActualSource<'_>, expected: &ExpectedSource) -> bool {
+    match (actual, expected) {
+        (
+            ActualSource::Io {
+                message: actual_message,
+                kind: actual_kind,
+            },
+            ExpectedSource::Io {
+                message: expected_message,
+                kind: expected_kind,
+            },
+        ) => actual_kind == expected_kind && actual_message == expected_message,
+        (
+            ActualSource::Codec {
+                error: actual_error,
+            },
+            ExpectedSource::Codec(expected_error),
+        ) => *actual_error == expected_error,
+        _ => false,
+    }
+}
+
+fn assert_source_matches(source: &(dyn Error + 'static), expected: ExpectedSource) {
+    let expected = std::convert::identity(expected);
+    let actual = match extract_source(source) {
+        Ok(actual) => actual,
+        Err(error) => panic!("source should be a supported error source: {error:?}"),
+    };
+
+    assert!(
+        source_matches(&actual, &expected),
+        "source should match expected source\nactual: {actual:?}\nexpected: {expected:?}",
+    );
 }
 
 #[test]

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -34,16 +34,50 @@ impl std::error::Error for ProtoErr {}
 fn wireframe_error_messages() {
     let proto = WireframeError::Protocol(ProtoErr);
     assert_eq!(proto.to_string(), "protocol error: ProtoErr");
-    let proto_source = proto
-        .source()
-        .expect("protocol variant must expose its underlying source");
-    assert_eq!(proto_source.to_string(), "boom");
+    assert!(
+        proto.source().is_none(),
+        "Protocol variants should not expose a source without specialization"
+    );
 
     let duplicate_route = WireframeError::<ProtoErr>::DuplicateRoute(7);
     assert_eq!(
         duplicate_route.to_string(),
         "route id 7 was already registered"
     );
+    assert!(
+        duplicate_route.source().is_none(),
+        "DuplicateRoute should not expose an error source"
+    );
+}
+
+#[test]
+fn wireframe_error_unit_implements_error() {
+    let io = WireframeError::<()>::from_io(io::Error::other("socket closed"));
+    let io_source = io
+        .source()
+        .expect("io variant must expose its underlying source")
+        .downcast_ref::<io::Error>()
+        .expect("io source should be std::io::Error");
+    assert_eq!(io_source.to_string(), "socket closed");
+
+    let codec = WireframeError::<()>::from_codec(CodecError::from(FramingError::EmptyFrame));
+    let codec_source = codec
+        .source()
+        .expect("codec variant must expose its underlying source")
+        .downcast_ref::<CodecError>()
+        .expect("codec source should be wireframe::codec::CodecError");
+    assert!(
+        matches!(codec_source, CodecError::Framing(FramingError::EmptyFrame)),
+        "codec source should preserve the original framing error"
+    );
+
+    let protocol = WireframeError::<()>::Protocol(());
+    assert!(
+        protocol.source().is_none(),
+        "unit protocol errors should not expose an error source"
+    );
+
+    let duplicate_route = WireframeError::<()>::DuplicateRoute(7);
     assert!(
         duplicate_route.source().is_none(),
         "DuplicateRoute should not expose an error source"

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -9,7 +9,9 @@
 use std::{error::Error, io};
 
 use wireframe::{
+    NoProtocolError,
     WireframeError,
+    client::ClientProtocolError,
     codec::{CodecError, FramingError},
     push::PushError,
     testkit::TestError,
@@ -35,10 +37,10 @@ impl std::error::Error for ProtoErr {}
 fn wireframe_error_messages() {
     let proto = WireframeError::Protocol(ProtoErr);
     assert_eq!(proto.to_string(), "protocol error: ProtoErr");
-    assert!(
-        proto.source().is_none(),
-        "Protocol variants should not expose a source without specialization"
-    );
+    let proto_source = proto
+        .source()
+        .expect("protocol variant must expose its underlying source");
+    assert_eq!(proto_source.to_string(), "boom");
 
     let duplicate_route = WireframeError::<ProtoErr>::DuplicateRoute(7);
     assert_eq!(
@@ -49,6 +51,26 @@ fn wireframe_error_messages() {
         duplicate_route.source().is_none(),
         "DuplicateRoute should not expose an error source"
     );
+}
+
+#[test]
+fn wireframe_error_preserves_client_protocol_source_chain() {
+    let protocol = ClientProtocolError::Deserialize(Box::new(io::Error::other("decode failed")));
+    let wireframe = WireframeError::Protocol(protocol);
+    let protocol_source = wireframe
+        .source()
+        .expect("protocol errors implementing Error should be exposed");
+
+    assert!(
+        protocol_source
+            .downcast_ref::<ClientProtocolError>()
+            .is_some(),
+        "protocol source should retain its concrete client error type"
+    );
+    let decode_source = protocol_source
+        .source()
+        .expect("client protocol error should expose the decode source");
+    assert_eq!(decode_source.to_string(), "decode failed");
 }
 
 #[test]
@@ -73,8 +95,8 @@ fn wireframe_error_unit_messages() {
 }
 
 #[test]
-fn wireframe_error_unit_sources() {
-    let io = WireframeError::<()>::from_io(io::Error::other("socket closed"));
+fn wireframe_error_default_sources() {
+    let io = WireframeError::<NoProtocolError>::from_io(io::Error::other("socket closed"));
     let io_source = io
         .source()
         .expect("io variant must expose its underlying source")
@@ -82,7 +104,8 @@ fn wireframe_error_unit_sources() {
         .expect("io source should be std::io::Error");
     assert_eq!(io_source.to_string(), "socket closed");
 
-    let codec = WireframeError::<()>::from_codec(CodecError::from(FramingError::EmptyFrame));
+    let codec =
+        WireframeError::<NoProtocolError>::from_codec(CodecError::from(FramingError::EmptyFrame));
     let codec_source = codec
         .source()
         .expect("codec variant must expose its underlying source")
@@ -93,13 +116,7 @@ fn wireframe_error_unit_sources() {
         "codec source should preserve the original framing error"
     );
 
-    let protocol = WireframeError::<()>::Protocol(());
-    assert!(
-        protocol.source().is_none(),
-        "unit protocol errors should not expose an error source"
-    );
-
-    let duplicate_route = WireframeError::<()>::DuplicateRoute(7);
+    let duplicate_route = WireframeError::<NoProtocolError>::DuplicateRoute(7);
     assert!(
         duplicate_route.source().is_none(),
         "DuplicateRoute should not expose an error source"
@@ -107,7 +124,7 @@ fn wireframe_error_unit_sources() {
 }
 
 #[test]
-fn wireframe_error_bound_allows_non_static_protocol_type() {
+fn wireframe_error_display_allows_non_static_protocol_type() {
     struct BorrowedProtocolError<'a>(&'a str);
 
     impl std::fmt::Debug for BorrowedProtocolError<'_> {
@@ -118,15 +135,10 @@ fn wireframe_error_bound_allows_non_static_protocol_type() {
 
     let message = String::from("borrowed");
     let error = WireframeError::Protocol(BorrowedProtocolError(&message));
-    let as_error = &error as &dyn Error;
 
     assert_eq!(
-        as_error.to_string(),
+        error.to_string(),
         "protocol error: BorrowedProtocolError(\"borrowed\")"
-    );
-    assert!(
-        as_error.source().is_none(),
-        "borrowed protocol errors should not be exposed as static sources"
     );
 }
 

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -207,6 +207,36 @@ fn wireframe_error_default_duplicate_route_has_no_source() {
 }
 
 #[test]
+fn wireframe_error_default_protocol_has_no_source() {
+    let protocol = WireframeError::<NoProtocolError>::Protocol(NoProtocolError);
+    assert!(
+        protocol.source().is_none(),
+        "Protocol(NoProtocolError) should not expose an error source"
+    );
+}
+
+#[test]
+fn wireframe_error_default_can_be_boxed_as_error() {
+    let error: Box<dyn Error> = Box::new(WireframeError::<NoProtocolError>::DuplicateRoute(7));
+
+    assert_eq!(error.to_string(), "route id 7 was already registered");
+}
+
+#[tokio::test]
+async fn wireframe_error_default_propagates_through_async_result() {
+    async fn duplicate_route() -> wireframe::Result<()> {
+        tokio::task::yield_now().await;
+        Err(WireframeError::DuplicateRoute(7))
+    }
+
+    let error = duplicate_route()
+        .await
+        .expect_err("async result should propagate WireframeError");
+
+    assert_eq!(error.to_string(), "route id 7 was already registered");
+}
+
+#[test]
 fn wireframe_error_display_allows_non_static_protocol_type() {
     struct BorrowedProtocolError<'a>(&'a str);
 

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -33,6 +33,35 @@ impl std::fmt::Display for ProtoErr {
 
 impl std::error::Error for ProtoErr {}
 
+enum ExpectedSource {
+    Io {
+        message: &'static str,
+        kind: io::ErrorKind,
+    },
+    Codec(FramingError),
+}
+
+fn assert_source_matches(source: &(dyn Error + 'static), expected: ExpectedSource) {
+    match expected {
+        ExpectedSource::Io { message, kind } => {
+            let Some(io_source) = source.downcast_ref::<io::Error>() else {
+                panic!("io source should be std::io::Error");
+            };
+            assert_eq!(io_source.kind(), kind);
+            assert_eq!(io_source.to_string(), message);
+        }
+        ExpectedSource::Codec(expected_error) => {
+            let Some(codec_source) = source.downcast_ref::<CodecError>() else {
+                panic!("codec source should be wireframe::codec::CodecError");
+            };
+            assert!(
+                matches!(codec_source, CodecError::Framing(error) if error == &expected_error),
+                "codec source should preserve the original framing error"
+            );
+        }
+    }
+}
+
 #[test]
 fn wireframe_error_messages() {
     let proto = WireframeError::Protocol(ProtoErr);
@@ -94,28 +123,30 @@ fn wireframe_error_unit_messages() {
     );
 }
 
+#[rstest::rstest]
+#[case(
+    WireframeError::<NoProtocolError>::from_io(io::Error::other("socket closed")),
+    ExpectedSource::Io {
+        message: "socket closed",
+        kind: io::ErrorKind::Other,
+    }
+)]
+#[case(
+    WireframeError::<NoProtocolError>::from_codec(CodecError::from(FramingError::EmptyFrame)),
+    ExpectedSource::Codec(FramingError::EmptyFrame)
+)]
+fn wireframe_error_default_exposes_sources(
+    #[case] error: WireframeError<NoProtocolError>,
+    #[case] expected: ExpectedSource,
+) {
+    let source = error
+        .source()
+        .expect("variant must expose its underlying source");
+    assert_source_matches(source, expected);
+}
+
 #[test]
-fn wireframe_error_default_sources() {
-    let io = WireframeError::<NoProtocolError>::from_io(io::Error::other("socket closed"));
-    let io_source = io
-        .source()
-        .expect("io variant must expose its underlying source")
-        .downcast_ref::<io::Error>()
-        .expect("io source should be std::io::Error");
-    assert_eq!(io_source.to_string(), "socket closed");
-
-    let codec =
-        WireframeError::<NoProtocolError>::from_codec(CodecError::from(FramingError::EmptyFrame));
-    let codec_source = codec
-        .source()
-        .expect("codec variant must expose its underlying source")
-        .downcast_ref::<CodecError>()
-        .expect("codec source should be wireframe::codec::CodecError");
-    assert!(
-        matches!(codec_source, CodecError::Framing(FramingError::EmptyFrame)),
-        "codec source should preserve the original framing error"
-    );
-
+fn wireframe_error_default_duplicate_route_has_no_source() {
     let duplicate_route = WireframeError::<NoProtocolError>::DuplicateRoute(7);
     assert!(
         duplicate_route.source().is_none(),
@@ -152,30 +183,26 @@ fn test_error_wireframe_from_preserves_display_prefix() {
     );
 }
 
-#[test]
-fn wireframe_error_exposes_sources_for_io_and_codec() {
-    let io = WireframeError::<ProtoErr>::from_io(io::Error::other("socket closed"));
-    assert_eq!(io.to_string(), "transport error: socket closed");
-    let source = io.source().expect("io variant must have source");
-    let io_source = source
-        .downcast_ref::<io::Error>()
-        .expect("io source should be std::io::Error");
-    assert_eq!(io_source.kind(), io::ErrorKind::Other);
-    assert_eq!(io_source.to_string(), "socket closed");
-
-    let wireframe_codec =
-        WireframeError::<ProtoErr>::from_codec(CodecError::from(FramingError::EmptyFrame));
-    let codec_source = wireframe_codec
-        .source()
-        .expect("Codec variant should expose an error source");
-    let typed_codec_source = codec_source
-        .downcast_ref::<CodecError>()
-        .expect("codec source should be wireframe::codec::CodecError");
-    assert!(
-        matches!(
-            typed_codec_source,
-            CodecError::Framing(FramingError::EmptyFrame)
-        ),
-        "codec source should preserve the original framing error"
-    );
+#[rstest::rstest]
+#[case(
+    WireframeError::<ProtoErr>::from_io(io::Error::other("socket closed")),
+    "transport error: socket closed",
+    ExpectedSource::Io {
+        message: "socket closed",
+        kind: io::ErrorKind::Other,
+    }
+)]
+#[case(
+    WireframeError::<ProtoErr>::from_codec(CodecError::from(FramingError::EmptyFrame)),
+    "codec error: framing error: empty frame not permitted",
+    ExpectedSource::Codec(FramingError::EmptyFrame)
+)]
+fn wireframe_error_exposes_sources_for_io_and_codec(
+    #[case] error: WireframeError<ProtoErr>,
+    #[case] display: &str,
+    #[case] expected: ExpectedSource,
+) {
+    assert_eq!(error.to_string(), display);
+    let source = error.source().expect("variant must expose an error source");
+    assert_source_matches(source, expected);
 }

--- a/tests/error_display.rs
+++ b/tests/error_display.rs
@@ -12,6 +12,7 @@ use wireframe::{
     WireframeError,
     codec::{CodecError, FramingError},
     push::PushError,
+    testkit::TestError,
 };
 
 #[rstest::rstest]
@@ -51,7 +52,28 @@ fn wireframe_error_messages() {
 }
 
 #[test]
-fn wireframe_error_unit_implements_error() {
+fn wireframe_error_unit_messages() {
+    let io = WireframeError::<()>::from_io(io::Error::other("socket closed"));
+    assert_eq!(io.to_string(), "transport error: socket closed");
+
+    let codec = WireframeError::<()>::from_codec(CodecError::from(FramingError::EmptyFrame));
+    assert_eq!(
+        codec.to_string(),
+        "codec error: framing error: empty frame not permitted"
+    );
+
+    let protocol = WireframeError::<()>::Protocol(());
+    assert_eq!(protocol.to_string(), "protocol error: ()");
+
+    let duplicate_route = WireframeError::<()>::DuplicateRoute(7);
+    assert_eq!(
+        duplicate_route.to_string(),
+        "route id 7 was already registered"
+    );
+}
+
+#[test]
+fn wireframe_error_unit_sources() {
     let io = WireframeError::<()>::from_io(io::Error::other("socket closed"));
     let io_source = io
         .source()
@@ -81,6 +103,40 @@ fn wireframe_error_unit_implements_error() {
     assert!(
         duplicate_route.source().is_none(),
         "DuplicateRoute should not expose an error source"
+    );
+}
+
+#[test]
+fn wireframe_error_bound_allows_non_static_protocol_type() {
+    struct BorrowedProtocolError<'a>(&'a str);
+
+    impl std::fmt::Debug for BorrowedProtocolError<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "BorrowedProtocolError({:?})", self.0)
+        }
+    }
+
+    let message = String::from("borrowed");
+    let error = WireframeError::Protocol(BorrowedProtocolError(&message));
+    let as_error = &error as &dyn Error;
+
+    assert_eq!(
+        as_error.to_string(),
+        "protocol error: BorrowedProtocolError(\"borrowed\")"
+    );
+    assert!(
+        as_error.source().is_none(),
+        "borrowed protocol errors should not be exposed as static sources"
+    );
+}
+
+#[test]
+fn test_error_wireframe_from_preserves_display_prefix() {
+    let error = TestError::from(WireframeError::DuplicateRoute(7));
+
+    assert_eq!(
+        error.to_string(),
+        "wireframe error: route id 7 was already registered"
     );
 }
 

--- a/tests/fixtures/correlation.rs
+++ b/tests/fixtures/correlation.rs
@@ -78,7 +78,7 @@ impl CorrelationWorld {
 
         let (queues, handle) = build_small_queues::<Envelope>()?;
         let shutdown = CancellationToken::new();
-        let mut actor: ConnectionActor<Envelope, ()> =
+        let mut actor: ConnectionActor<Envelope, wireframe::NoProtocolError> =
             ConnectionActor::new(queues, handle, None, shutdown);
         actor
             .set_multi_packet_with_correlation(Some(rx), expected)

--- a/tests/fixtures/multi_packet.rs
+++ b/tests/fixtures/multi_packet.rs
@@ -41,7 +41,7 @@ impl MultiPacketWorld {
     async fn collect_frames_from(rx: mpsc::Receiver<u8>) -> TestResult<Vec<u8>> {
         let (queues, handle) = build_small_queues::<u8>()?;
         let shutdown = CancellationToken::new();
-        let mut actor: ConnectionActor<_, ()> =
+        let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
             ConnectionActor::new(queues, handle, None, shutdown);
         actor
             .set_multi_packet(Some(rx))

--- a/tests/fixtures/multi_packet.rs
+++ b/tests/fixtures/multi_packet.rs
@@ -70,7 +70,7 @@ impl MultiPacketWorld {
     /// Returns an error if the response cannot be converted to a multi-packet
     /// stream or if producer tasks fail.
     async fn process_messages(&mut self, messages: &[u8]) -> TestResult {
-        let (sender, response): (mpsc::Sender<u8>, Response<u8, ()>) = Response::with_channel(4);
+        let (sender, response): (mpsc::Sender<u8>, Response<u8>) = Response::with_channel(4);
         let Response::MultiPacket(rx) = response else {
             return Err("helper did not return a MultiPacket response".into());
         };
@@ -116,7 +116,7 @@ impl MultiPacketWorld {
     /// Returns an error if sending to the channel fails unexpectedly or the
     /// producer task returns an error.
     pub async fn process_overflow(&mut self) -> TestResult {
-        let (sender, response): (mpsc::Sender<u8>, Response<u8, ()>) = Response::with_channel(1);
+        let (sender, response): (mpsc::Sender<u8>, Response<u8>) = Response::with_channel(1);
         let Response::MultiPacket(rx) = response else {
             return Err("helper did not return a MultiPacket response".into());
         };

--- a/tests/fixtures/stream_end.rs
+++ b/tests/fixtures/stream_end.rs
@@ -60,7 +60,7 @@ impl StreamEndWorld {
 
         match mode {
             ActorMode::Stream => {
-                let stream: FrameStream<u8, ()> = Box::pin(try_stream! {
+                let stream: FrameStream<u8> = Box::pin(try_stream! {
                     yield 1u8;
                     yield 2u8;
                 });

--- a/tests/fixtures/stream_end.rs
+++ b/tests/fixtures/stream_end.rs
@@ -60,7 +60,7 @@ impl StreamEndWorld {
 
         match mode {
             ActorMode::Stream => {
-                let stream: FrameStream<u8> = Box::pin(try_stream! {
+                let stream: FrameStream<u8, ()> = Box::pin(try_stream! {
                     yield 1u8;
                     yield 2u8;
                 });

--- a/tests/interleaved_push_queues.rs
+++ b/tests/interleaved_push_queues.rs
@@ -227,7 +227,7 @@ async fn interleaved_time_slice_fairness(shutdown_token: CancellationToken) -> T
         time_slice: Some(Duration::from_millis(10)),
     };
 
-    let mut actor: ConnectionActor<_, ()> =
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
         ConnectionActor::new(queues, handle.clone(), None, shutdown_token);
     actor.set_fairness(fairness);
 

--- a/tests/multi_packet.rs
+++ b/tests/multi_packet.rs
@@ -91,7 +91,8 @@ async fn connection_actor_drains_multi_packet_channel(
     drop(tx);
 
     let (queues, handle, shutdown) = actor_components?;
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+        ConnectionActor::new(queues, handle, None, shutdown);
     actor
         .set_multi_packet(Some(rx))
         .map_err(|e| boxed_err("set_multi_packet error", e))?;
@@ -124,7 +125,8 @@ async fn connection_actor_interleaves_multi_packet_and_priority_frames(
     handle.push_low_priority(100).await?;
     handle.push_low_priority(101).await?;
 
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+        ConnectionActor::new(queues, handle, None, shutdown);
     actor.set_fairness(FairnessConfig {
         max_high_before_low: 1,
         time_slice: None,
@@ -150,7 +152,8 @@ async fn shutdown_completes_multi_packet_channel(
 ) -> TestResult {
     let (queues, handle, shutdown) = actor_components?;
     let (tx, rx) = mpsc::channel(1);
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+        ConnectionActor::new(queues, handle, None, shutdown);
     actor
         .set_multi_packet(Some(rx))
         .map_err(|e| boxed_err("set_multi_packet error", e))?;
@@ -186,7 +189,8 @@ async fn shutdown_during_active_multi_packet_send(
 ) -> TestResult {
     let (queues, handle, shutdown) = actor_components?;
     let (tx, rx) = mpsc::channel(4);
-    let mut actor: ConnectionActor<_, ()> = ConnectionActor::new(queues, handle, None, shutdown);
+    let mut actor: ConnectionActor<_, wireframe::NoProtocolError> =
+        ConnectionActor::new(queues, handle, None, shutdown);
     actor
         .set_multi_packet(Some(rx))
         .map_err(|e| boxed_err("set_multi_packet error", e))?;

--- a/tests/multi_packet_streaming.rs
+++ b/tests/multi_packet_streaming.rs
@@ -36,7 +36,7 @@ fn envelope_with_payload(id: u32, correlation: Option<u64>, payload: &[u8]) -> E
 }
 
 struct ActorHarness {
-    actor: ConnectionActor<Envelope, ()>,
+    actor: ConnectionActor<Envelope, wireframe::NoProtocolError>,
     handle: Option<PushHandle<Envelope>>,
 }
 

--- a/tests/stream_end.rs
+++ b/tests/stream_end.rs
@@ -21,6 +21,7 @@ use rstest::{fixture, rstest};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use wireframe::{
+    NoProtocolError,
     connection::{ConnectionActor, ConnectionChannels},
     hooks::{ConnectionContext, ProtocolHooks, WireframeProtocol},
     push::{PushHandle, PushQueues},
@@ -44,7 +45,7 @@ async fn emits_end_frame(
 ) -> TestResult<()> {
     let (queues, handle) = queues?;
     // fixture injected above
-    let stream: FrameStream<u8, ()> = Box::pin(try_stream! {
+    let stream: FrameStream<u8> = Box::pin(try_stream! {
         yield 1;
         yield 2;
     });
@@ -113,7 +114,7 @@ async fn multi_packet_respects_no_terminator(
 
     impl WireframeProtocol for NoTerminator {
         type Frame = u8;
-        type ProtocolError = ();
+        type ProtocolError = NoProtocolError;
 
         fn stream_end_frame(&self, _ctx: &mut ConnectionContext) -> Option<Self::Frame> { None }
     }
@@ -187,7 +188,7 @@ async fn multi_packet_empty_channel_no_terminator_emits_nothing(
 
     impl WireframeProtocol for NoTerminator {
         type Frame = u8;
-        type ProtocolError = ();
+        type ProtocolError = NoProtocolError;
 
         fn stream_end_frame(&self, _ctx: &mut ConnectionContext) -> Option<Self::Frame> { None }
     }
@@ -227,14 +228,14 @@ async fn emits_no_end_frame_when_none(
 
     impl WireframeProtocol for NoTerminator {
         type Frame = u8;
-        type ProtocolError = ();
+        type ProtocolError = NoProtocolError;
 
         fn stream_end_frame(&self, _ctx: &mut ConnectionContext) -> Option<Self::Frame> { None }
     }
 
     let (queues, handle) = queues?;
     // fixture injected above
-    let stream: FrameStream<u8, ()> = Box::pin(try_stream! {
+    let stream: FrameStream<u8> = Box::pin(try_stream! {
         yield 7;
         yield 8;
     });

--- a/tests/stream_end.rs
+++ b/tests/stream_end.rs
@@ -33,7 +33,7 @@ async fn emits_end_frame(
 ) -> TestResult<()> {
     let (queues, handle) = queues?;
     // fixture injected above
-    let stream: FrameStream<u8> = Box::pin(try_stream! {
+    let stream: FrameStream<u8, ()> = Box::pin(try_stream! {
         yield 1;
         yield 2;
     });
@@ -223,7 +223,7 @@ async fn emits_no_end_frame_when_none(
 
     let (queues, handle) = queues?;
     // fixture injected above
-    let stream: FrameStream<u8> = Box::pin(try_stream! {
+    let stream: FrameStream<u8, ()> = Box::pin(try_stream! {
         yield 7;
         yield 8;
     });

--- a/tests/stream_end.rs
+++ b/tests/stream_end.rs
@@ -1,4 +1,15 @@
 //! Tests for explicit end-of-stream signalling.
+//!
+//! These integration tests exercise the relationship between streaming
+//! responses, multi-packet channels, and protocol terminator hooks. The
+//! `ConnectionActor` is driven with both ordinary response streams and
+//! `Response::MultiPacket` channels so the test suite can verify where end
+//! frames are emitted, suppressed, or preserved during shutdown.
+//!
+//! The module uses shared queue fixtures and the `Terminator` test protocol to
+//! keep the assertions focused on response-stream behaviour rather than server
+//! setup. It complements the testkit helpers by checking the concrete actor
+//! wiring used by streaming response tests.
 #![cfg(not(loom))]
 
 mod support;

--- a/tests/ui/wireframe_result_default_no_protocol.rs
+++ b/tests/ui/wireframe_result_default_no_protocol.rs
@@ -1,0 +1,17 @@
+//! Verifies `Result` uses `WireframeError<NoProtocolError>` by default.
+
+use wireframe::{NoProtocolError, Result, WireframeError};
+
+fn accepts_error(_: &dyn std::error::Error) {}
+
+fn accepts_result(_: Result<()>) {}
+
+fn main() {
+    let default_error: WireframeError = WireframeError::DuplicateRoute(1);
+    accepts_error(&default_error);
+
+    let explicit_default: WireframeError<NoProtocolError> = WireframeError::DuplicateRoute(2);
+    accepts_error(&explicit_default);
+
+    accepts_result(Err(WireframeError::DuplicateRoute(3)));
+}

--- a/tests/ui/wireframe_result_default_rejects_unit_protocol.rs
+++ b/tests/ui/wireframe_result_default_rejects_unit_protocol.rs
@@ -1,4 +1,5 @@
 //! Verifies the `WireframeError` default is `NoProtocolError`, not `()`.
+//! This blocks regressions to `E = ()`; see #513 for the API rationale.
 
 use wireframe::{NoProtocolError, Result, WireframeError};
 

--- a/tests/ui/wireframe_result_default_rejects_unit_protocol.rs
+++ b/tests/ui/wireframe_result_default_rejects_unit_protocol.rs
@@ -1,0 +1,9 @@
+//! Verifies the `WireframeError` default is `NoProtocolError`, not `()`.
+
+use wireframe::{NoProtocolError, Result, WireframeError};
+
+fn main() {
+    let _: WireframeError = WireframeError::Protocol(());
+    let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
+    let _: Result<()> = Err(WireframeError::Protocol(()));
+}

--- a/tests/ui/wireframe_result_default_rejects_unit_protocol.stderr
+++ b/tests/ui/wireframe_result_default_rejects_unit_protocol.stderr
@@ -1,0 +1,62 @@
+error[E0308]: mismatched types
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:6:54
+  |
+6 |     let _: WireframeError = WireframeError::Protocol(());
+  |                             ------------------------ ^^ expected `NoProtocolError`, found `()`
+  |                             |
+  |                             arguments to this enum variant are incorrect
+  |
+help: the type constructed contains `()` due to the type of the argument passed
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:6:29
+  |
+6 |     let _: WireframeError = WireframeError::Protocol(());
+  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^--^
+  |                                                      |
+  |                                                      this argument influences the type of `Protocol`
+note: tuple variant defined here
+ --> src/error.rs
+  |
+  |     Protocol(E),
+  |     ^^^^^^^^
+
+error[E0308]: mismatched types
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:7:71
+  |
+7 |     let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
+  |                                              ------------------------ ^^ expected `NoProtocolError`, found `()`
+  |                                              |
+  |                                              arguments to this enum variant are incorrect
+  |
+help: the type constructed contains `()` due to the type of the argument passed
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:7:46
+  |
+7 |     let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
+  |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^--^
+  |                                                                       |
+  |                                                                       this argument influences the type of `Protocol`
+note: tuple variant defined here
+ --> src/error.rs
+  |
+  |     Protocol(E),
+  |     ^^^^^^^^
+
+error[E0308]: mismatched types
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:8:54
+  |
+8 |     let _: Result<()> = Err(WireframeError::Protocol(()));
+  |                             ------------------------ ^^ expected `NoProtocolError`, found `()`
+  |                             |
+  |                             arguments to this enum variant are incorrect
+  |
+help: the type constructed contains `()` due to the type of the argument passed
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:8:29
+  |
+8 |     let _: Result<()> = Err(WireframeError::Protocol(()));
+  |                             ^^^^^^^^^^^^^^^^^^^^^^^^^--^
+  |                                                      |
+  |                                                      this argument influences the type of `Protocol`
+note: tuple variant defined here
+ --> src/error.rs
+  |
+  |     Protocol(E),
+  |     ^^^^^^^^

--- a/tests/ui/wireframe_result_default_rejects_unit_protocol.stderr
+++ b/tests/ui/wireframe_result_default_rejects_unit_protocol.stderr
@@ -1,15 +1,15 @@
 error[E0308]: mismatched types
- --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:6:54
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:7:54
   |
-6 |     let _: WireframeError = WireframeError::Protocol(());
+7 |     let _: WireframeError = WireframeError::Protocol(());
   |                             ------------------------ ^^ expected `NoProtocolError`, found `()`
   |                             |
   |                             arguments to this enum variant are incorrect
   |
 help: the type constructed contains `()` due to the type of the argument passed
- --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:6:29
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:7:29
   |
-6 |     let _: WireframeError = WireframeError::Protocol(());
+7 |     let _: WireframeError = WireframeError::Protocol(());
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^--^
   |                                                      |
   |                                                      this argument influences the type of `Protocol`
@@ -20,17 +20,17 @@ note: tuple variant defined here
   |     ^^^^^^^^
 
 error[E0308]: mismatched types
- --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:7:71
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:8:71
   |
-7 |     let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
+8 |     let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
   |                                              ------------------------ ^^ expected `NoProtocolError`, found `()`
   |                                              |
   |                                              arguments to this enum variant are incorrect
   |
 help: the type constructed contains `()` due to the type of the argument passed
- --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:7:46
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:8:46
   |
-7 |     let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
+8 |     let _: WireframeError<NoProtocolError> = WireframeError::Protocol(());
   |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^--^
   |                                                                       |
   |                                                                       this argument influences the type of `Protocol`
@@ -41,17 +41,17 @@ note: tuple variant defined here
   |     ^^^^^^^^
 
 error[E0308]: mismatched types
- --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:8:54
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:9:54
   |
-8 |     let _: Result<()> = Err(WireframeError::Protocol(()));
+9 |     let _: Result<()> = Err(WireframeError::Protocol(()));
   |                             ------------------------ ^^ expected `NoProtocolError`, found `()`
   |                             |
   |                             arguments to this enum variant are incorrect
   |
 help: the type constructed contains `()` due to the type of the argument passed
- --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:8:29
+ --> tests/ui/wireframe_result_default_rejects_unit_protocol.rs:9:29
   |
-8 |     let _: Result<()> = Err(WireframeError::Protocol(()));
+9 |     let _: Result<()> = Err(WireframeError::Protocol(()));
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^--^
   |                                                      |
   |                                                      this argument influences the type of `Protocol`


### PR DESCRIPTION
## Summary

This branch implements standard error integration for `WireframeError` in support of issue #513. It makes the default public error type usable through `std::error::Error`, preserves source chaining for transport and codec failures, and lets `TestError` use thiserror's transparent `#[from]` conversion.

Closes #513.

## Review walkthrough

- Start with [src/error.rs](https://github.com/leynos/wireframe/blob/issue-513-wireframeerror-e-should-derive-display-and-std-error-error/src/error.rs) to review the `std::error::Error` implementation and source chaining behaviour.
- Then review [src/testkit/result.rs](https://github.com/leynos/wireframe/blob/issue-513-wireframeerror-e-should-derive-display-and-std-error-error/src/testkit/result.rs) for the transparent `TestError::Wireframe` conversion.
- Finish with [tests/error_display.rs](https://github.com/leynos/wireframe/blob/issue-513-wireframeerror-e-should-derive-display-and-std-error-error/tests/error_display.rs) for the coverage around `WireframeError<()>` sources.

## Validation

- `make check-fmt`: passed
- `make lint`: passed
- `make test`: passed
- `coderabbit review --agent`: passed with zero findings after one rate-limit retry

## Notes

The originally suggested blanket `Display`/`Error` implementation plus a separate `WireframeError<()>` specialisation conflicts under Rust's coherence rules because upstream crates may add future trait implementations for `()`. This branch therefore uses a stable-compatible `Error` implementation for `WireframeError<E>` where `E: Debug + 'static`; `source()` exposes the nested `Io` and `Codec` errors that are always known to implement `Error`.

## Summary by Sourcery

Integrate WireframeError with std::error::Error while introducing a NoProtocolError default marker and tightening the public Result and response error surface.

New Features:
- Make WireframeError<E> implement std::error::Error when the protocol error type E is an Error, preserving protocol failures as sources.
- Introduce the NoProtocolError marker type and use WireframeError<NoProtocolError> as the crate-wide default error for Result<T> and response-related aliases.

Enhancements:
- Adjust Response and FrameStream aliases, examples, and fixtures to use the NoProtocolError-backed WireframeError default instead of unit.
- Allow TestError to use thiserror's transparent #[from] conversion for WireframeError while preserving its display prefix.
- Document the new error surface conventions, default protocol marker, and migration guidance in the library, user guide, and developer guide.

Build:
- Add the trybuild dev-dependency and wire up compile-time UI tests for the default WireframeError and Result<T> behavior.

Documentation:
- Update user, developer, migration, and crate root documentation to describe the NoProtocolError marker, the default WireframeError contract, and how protocol-specific error types participate in source chains.

Tests:
- Expand error_display tests to cover WireframeError source chaining, default/parameterized protocol types, async propagation, boxing as dyn Error, and TestError integration.
- Add trybuild-based UI tests to assert that the default Result<T> uses WireframeError<NoProtocolError> and does not accept unit protocol payloads by default.