### PR TITLE
Adopt cargo-mutants workflow

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -10,6 +10,13 @@ on:
         required: false
         default: "main"
 
+# Serialize runs per target branch: a dispatch during a scheduled run
+# (or vice versa) queues rather than racing on runner usage. Runs are
+# informational, so queued runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.event.inputs.branch || 'main' }}
+  cancel-in-progress: false
+
 jobs:
   mutants:
     runs-on: ubuntu-latest
@@ -19,7 +26,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.inputs.branch || 'main' }}
           fetch-depth: 0
@@ -101,6 +108,16 @@ jobs:
             *) exit "$status" ;;
           esac
 
+      - name: Reset working tree
+        # Belt-and-braces: `--in-place` restores mutated sources itself,
+        # but a restore bug or unclean tool exit must not poison the
+        # wireframe_testing run that reuses this checkout.
+        if: >-
+          steps.detect.outputs.has_changes == 'true'
+          && (steps.detect.outputs.wt_files != ''
+              || steps.detect.outputs.dispatch == 'true')
+        run: git checkout -- .
+
       - name: Run mutation testing (wireframe_testing)
         if: >-
           steps.detect.outputs.has_changes == 'true'
@@ -130,7 +147,7 @@ jobs:
           always()
           && (steps.detect.outputs.root_files != ''
               || steps.detect.outputs.dispatch == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutation-report-root
           path: mutants.out/
@@ -140,7 +157,7 @@ jobs:
           always()
           && (steps.detect.outputs.wt_files != ''
               || steps.detect.outputs.dispatch == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutation-report-wireframe-testing
           path: wireframe_testing/mutants.out/

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,194 @@
+name: Mutation testing
+
+on:
+  schedule:
+    - cron: "30 4 * * *" # Daily, 04:30 UTC
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: false
+        default: "main"
+
+jobs:
+  mutants:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.branch || 'main' }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect changed Rust files
+        id: detect
+        run: |
+          # Manual dispatch bypasses change detection — always run.
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "root_files=" >> "$GITHUB_OUTPUT"
+            echo "wt_files=" >> "$GITHUB_OUTPUT"
+            echo "dispatch=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Use commit timestamps (not reflog) — safe in fresh CI clones.
+          # The 25-hour window absorbs GitHub cron start-time drift.
+          # git log already filters to *.rs; case below matches prefixes
+          # including nested directories (e.g. src/foo/bar.rs). Files
+          # deleted or renamed since the change are skipped.
+          root_files=""
+          wt_files=""
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            case "$f" in
+              src/*|examples/*|benches/*)
+                root_files="${root_files:+$root_files }$f" ;;
+              wireframe_testing/src/*)
+                wt_files="${wt_files:+$wt_files }$f" ;;
+            esac
+          done < <(git log --since="25 hours ago" --name-only \
+            --format="" origin/main -- '*.rs' | sort -u)
+
+          if [ -z "$root_files" ] && [ -z "$wt_files" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "## Mutation testing skipped" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No Rust source changes on \`main\` in the last" \
+              "25 hours." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "root_files=$root_files" >> "$GITHUB_OUTPUT"
+            echo "wt_files=$wt_files" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Rust
+        if: steps.detect.outputs.has_changes == 'true'
+        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+
+      - name: Install cargo-mutants
+        if: steps.detect.outputs.has_changes == 'true'
+        # Unpinned for the initial rollout; pin once the first successful
+        # run confirms a known-good version (see ADR-007).
+        run: cargo binstall --no-confirm cargo-mutants
+
+      - name: Run mutation testing (root crate)
+        if: >-
+          steps.detect.outputs.has_changes == 'true'
+          && (steps.detect.outputs.root_files != ''
+              || steps.detect.outputs.dispatch == 'true')
+        env:
+          ROOT_FILES: ${{ steps.detect.outputs.root_files }}
+        run: |
+          args=""
+          for f in $ROOT_FILES; do
+            args="$args --file $f"
+          done
+          # Exit 2 (missed mutants) and 3 (timeouts) are informative
+          # outcomes, not failures; 1, 4, and 70 are genuine faults.
+          set +e
+          # shellcheck disable=SC2086
+          cargo mutants --in-place --timeout-multiplier 3 $args
+          status=$?
+          set -e
+          case "$status" in
+            0|2|3) exit 0 ;;
+            *) exit "$status" ;;
+          esac
+
+      - name: Run mutation testing (wireframe_testing)
+        if: >-
+          steps.detect.outputs.has_changes == 'true'
+          && (steps.detect.outputs.wt_files != ''
+              || steps.detect.outputs.dispatch == 'true')
+        env:
+          WT_FILES: ${{ steps.detect.outputs.wt_files }}
+        run: |
+          args=""
+          for f in $WT_FILES; do
+            # Strip the wireframe_testing/ prefix for --file.
+            args="$args --file ${f#wireframe_testing/}"
+          done
+          set +e
+          # shellcheck disable=SC2086
+          cargo mutants --in-place --timeout-multiplier 3 \
+            --dir wireframe_testing $args
+          status=$?
+          set -e
+          case "$status" in
+            0|2|3) exit 0 ;;
+            *) exit "$status" ;;
+          esac
+
+      - name: Upload mutation report (root)
+        if: >-
+          always()
+          && (steps.detect.outputs.root_files != ''
+              || steps.detect.outputs.dispatch == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report-root
+          path: mutants.out/
+
+      - name: Upload mutation report (wireframe_testing)
+        if: >-
+          always()
+          && (steps.detect.outputs.wt_files != ''
+              || steps.detect.outputs.dispatch == 'true')
+        uses: actions/upload-artifact@v4
+        with:
+          name: mutation-report-wireframe-testing
+          path: wireframe_testing/mutants.out/
+
+      - name: Post summary
+        if: >-
+          always()
+          && steps.detect.outputs.has_changes == 'true'
+        run: |
+          post_results() {
+            local label="$1" dir="$2"
+            if [ ! -f "$dir/outcomes.json" ]; then return; fi
+            echo "## Mutation testing results ($label)" \
+              >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            caught=$(jq '[.outcomes[]
+              | select(.scenario != "Baseline"
+                       and .summary == "CaughtMutant")]
+              | length' "$dir/outcomes.json")
+            missed=$(jq '[.outcomes[]
+              | select(.scenario != "Baseline"
+                       and .summary == "MissedMutant")]
+              | length' "$dir/outcomes.json")
+            timeout=$(jq '[.outcomes[]
+              | select(.scenario != "Baseline"
+                       and .summary == "Timeout")]
+              | length' "$dir/outcomes.json")
+            echo "- **Caught:** ${caught}" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Missed (survived):** ${missed}" \
+              >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Timeout:** ${timeout}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            if [ "$missed" -gt 0 ]; then
+              echo "### Surviving mutants" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+              echo "| File | Line | Mutation |" \
+                >> "$GITHUB_STEP_SUMMARY"
+              echo "| ---- | ---- | ------- |" \
+                >> "$GITHUB_STEP_SUMMARY"
+              jq -r '
+                .outcomes[]
+                | select(.scenario != "Baseline"
+                         and .summary == "MissedMutant")
+                | .scenario.Mutant as $m
+                | "| \($m.file) | \($m.span.start.line) | \($m.name) |"
+              ' "$dir/outcomes.json" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
+          post_results "root crate" "mutants.out"
+          post_results "wireframe_testing" "wireframe_testing/mutants.out"

--- a/docs/adr-007-mutation-testing-with-cargo-mutants.md
+++ b/docs/adr-007-mutation-testing-with-cargo-mutants.md
@@ -85,18 +85,24 @@ files changed on `main` in the preceding 24 hours.
    dispatchable on any branch via `workflow_dispatch` with a configurable
    branch input (defaulting to `main`).
 2. **Change detection:** After checkout (with full history), compute the set of
-   Rust source files changed on `origin/main` in the last 24 hours using commit
+   Rust source files changed on `origin/main` in the last 25 hours using commit
    timestamps:
 
    ```sh
-   git log --since="24 hours ago" --name-only --format="" \
+   git log --since="25 hours ago" --name-only --format="" \
      origin/main -- '*.rs'
    ```
 
-   This is preferred over `origin/main@{24.hours.ago}` because that syntax
+   This is preferred over `origin/main@{25.hours.ago}` because that syntax
    relies on reflog state, which is not available in fresh CI clones. The
-   result is stored as a step output (`has_changes=true|false`) and the heavy
-   mutation step is gated with
+   window is 25 hours rather than 24 because GitHub cron start times drift
+   (runs routinely begin 15–60 minutes late); the extra hour means a commit
+   landing just after one run still falls inside the next run's window, at
+   the cost of occasionally re-testing a file. Files that no longer exist at
+   the checked-out tip (deleted or renamed within the window) are filtered
+   out before being passed to `--file`. The result is stored as a step
+   output (`has_changes=true|false`) and the heavy mutation step is gated
+   with
    `if: steps.detect.outputs.has_changes == 'true'`. Manual `workflow_dispatch`
    runs bypass the guard by setting `has_changes=true` unconditionally and
    running a full (unscoped) mutation against both the root crate and
@@ -136,14 +142,31 @@ running up to two targeted invocations:
 
 ### Execution, artefacts, and summary
 
-1. **Execution:** Installs `cargo-mutants` via `cargo binstall`, then runs the
-   scoped invocations described above with a per-mutant timeout multiplier to
-   bound execution time.
-2. **Artefact:** Uploads the `mutants.out/` directory (or directories) as
+1. **Execution:** Installs `cargo-mutants` via `cargo binstall` (the shared
+   `setup-rust` action provides `cargo-binstall`), then runs the scoped
+   invocations described above with `--in-place` (the upstream CI
+   recommendation, which reuses the existing build cache instead of copying
+   the tree) and a per-mutant timeout multiplier to bound execution time. The
+   job carries an explicit `timeout-minutes` ceiling as a backstop against
+   runaway full runs.
+2. **Output locations:** `cargo-mutants` creates `mutants.out/` inside the
+   source directory it operates on. Note that `--output DIR` places
+   `mutants.out/` _within_ `DIR` (it does not rename the directory), so the
+   workflow relies on the defaults instead: the root run writes
+   `./mutants.out/` and the `wireframe_testing` run writes
+   `wireframe_testing/mutants.out/`.
+3. **Exit-code handling:** `cargo mutants` exits non-zero for informative
+   outcomes as well as genuine failures: `0` all caught, `1` usage error, `2`
+   mutants missed, `3` tests timed out, `4` baseline tests already failing,
+   `70` internal error. Because this workflow is informational, exit codes
+   `2` and `3` are treated as success (the survivors are the deliverable, not
+   a failure), while `1`, `4`, and `70` still fail the job so genuine faults
+   remain visible.
+4. **Artefact:** Uploads the `mutants.out/` directory (or directories) as
    GitHub Actions artefacts, preserving `outcomes.json` (machine-readable) and
    the human-readable log. When both root and `wireframe_testing` runs occur,
    separate artefacts are uploaded.
-3. **Summary:** Posts a Markdown summary to the GitHub Actions job summary
+5. **Summary:** Posts a Markdown summary to the GitHub Actions job summary
    (`$GITHUB_STEP_SUMMARY`) listing surviving mutants with file, line, and
    mutation description — directly usable as a test-improvement backlog.
 
@@ -169,6 +192,7 @@ on:
 jobs:
   mutants:
     runs-on: ubuntu-latest
+    timeout-minutes: 300
     permissions:
       contents: read
     env:
@@ -178,6 +202,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || 'main' }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Detect changed Rust files
         id: detect
@@ -192,21 +217,22 @@ jobs:
           fi
 
           # Use commit timestamps (not reflog) — safe in fresh CI clones.
+          # The 25-hour window absorbs GitHub cron start-time drift.
           # git log already filters to *.rs; case below matches prefixes
-          # including nested directories (e.g. src/foo/bar.rs).
-          changed=$(git log --since="24 hours ago" --name-only \
-            --format="" origin/main -- '*.rs' | sort -u)
-
+          # including nested directories (e.g. src/foo/bar.rs). Files
+          # deleted or renamed since the change are skipped.
           root_files=""
           wt_files=""
-          for f in $changed; do
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
             case "$f" in
               src/*|examples/*|benches/*)
                 root_files="${root_files:+$root_files }$f" ;;
               wireframe_testing/src/*)
                 wt_files="${wt_files:+$wt_files }$f" ;;
             esac
-          done
+          done < <(git log --since="25 hours ago" --name-only \
+            --format="" origin/main -- '*.rs' | sort -u)
 
           if [ -z "$root_files" ] && [ -z "$wt_files" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
@@ -238,9 +264,17 @@ jobs:
           for f in ${{ steps.detect.outputs.root_files }}; do
             args="$args --file $f"
           done
+          # Exit 2 (missed mutants) and 3 (timeouts) are informative
+          # outcomes, not failures; 1, 4, and 70 are genuine faults.
+          set +e
           # shellcheck disable=SC2086
-          cargo mutants --timeout-multiplier 3 \
-            --output mutants.out $args
+          cargo mutants --in-place --timeout-multiplier 3 $args
+          status=$?
+          set -e
+          case "$status" in
+            0|2|3) exit 0 ;;
+            *) exit "$status" ;;
+          esac
 
       - name: Run mutation testing (wireframe_testing)
         if: >-
@@ -253,10 +287,16 @@ jobs:
             # Strip the wireframe_testing/ prefix for --file.
             args="$args --file ${f#wireframe_testing/}"
           done
+          set +e
           # shellcheck disable=SC2086
-          cargo mutants --timeout-multiplier 3 \
-            --dir wireframe_testing \
-            --output mutants-wt.out $args
+          cargo mutants --in-place --timeout-multiplier 3 \
+            --dir wireframe_testing $args
+          status=$?
+          set -e
+          case "$status" in
+            0|2|3) exit 0 ;;
+            *) exit "$status" ;;
+          esac
 
       - name: Upload mutation report (root)
         if: >-
@@ -276,7 +316,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mutation-report-wireframe-testing
-          path: mutants-wt.out/
+          path: wireframe_testing/mutants.out/
 
       - name: Post summary
         if: >-
@@ -324,7 +364,7 @@ jobs:
           }
 
           post_results "root crate" "mutants.out"
-          post_results "wireframe_testing" "mutants-wt.out"
+          post_results "wireframe_testing" "wireframe_testing/mutants.out"
 ```
 
 ## Known Risks and Limitations
@@ -337,6 +377,14 @@ jobs:
 - **False survivors:** Some mutants survive because the mutated behaviour is
   semantically equivalent to the original (e.g. replacing `x + 0` with `x`).
   These require human triage and cannot be eliminated automatically.
+- **`wireframe_testing` false survivors:** The companion crate's logic is
+  exercised chiefly by the root crate's test suite; `wireframe_testing`
+  itself carries only a small number of in-crate tests. Because
+  `cargo mutants --dir wireframe_testing` runs only that package's own
+  tests, most mutants there will appear to survive even when the root
+  crate's tests would catch the fault. The `wireframe_testing` results
+  table is therefore advisory until the crate gains meaningful in-crate
+  coverage; treat its survivors with scepticism during triage.
 - **Runner cost:** Scheduled runs consume GitHub Actions minutes. The daily
   schedule starts every day, but the change-detection guard ensures the
   expensive mutation step only runs when `main` received relevant Rust source
@@ -344,8 +392,20 @@ jobs:
   seconds.
 - **Change detection edge cases:** The `git log --since` guard uses commit
   timestamps, not author timestamps. Force-pushed or rebased commits may carry
-  original timestamps outside the 24-hour window. A manual `workflow_dispatch`
-  run bypasses the guard entirely, providing a fallback.
+  original timestamps outside the 25-hour window, and merge commits whose
+  constituent commits were created earlier are similarly invisible (the
+  repository's squash-merge convention makes this unlikely in practice).
+  There is also no catch-up: if a scheduled run fails or is skipped, commits
+  from that window are never mutation-tested. A manual `workflow_dispatch`
+  run bypasses the guard entirely, providing the fallback in all these
+  cases. Diffing against the SHA of the last successful run (via the GitHub
+  API) would close the gap completely but was rejected as disproportionate
+  for an informational workflow.
+- **Scheduled-workflow suspension:** GitHub automatically disables cron
+  triggers on repositories with no activity for 60 days. On a quiet
+  repository the workflow silently stops running until re-enabled — an
+  acceptable failure mode, since no code changes means nothing new to
+  mutate.
 - **Manifest-only changes:** Changes to `Cargo.toml` or `Cargo.lock` without
   accompanying Rust source changes are not detected. If a manifest change
   affects mutation outcomes (e.g. enabling a feature that changes conditional
@@ -360,6 +420,16 @@ jobs:
   issue automatically.
 - Exact `--timeout-multiplier` value — needs calibration against the current
   test suite runtime.
+- Whether to adopt `--in-diff` (line-level scoping from a diff) in place of
+  file-level `--file` scoping for scheduled runs, once the initial workflow
+  has proven itself. `--in-diff` tests only mutants on changed lines, which
+  is cheaper but misses mutants elsewhere in a changed file.
+- Whether full `workflow_dispatch` runs need `--shard` support to split the
+  work across parallel jobs, should single-job runs approach the
+  `timeout-minutes` ceiling.
+- Whether to keep the `wireframe_testing` invocation given its false-survivor
+  noise (see Known Risks), or to drop it until the crate has meaningful
+  in-crate test coverage.
 
 ## Resolved Decisions
 
@@ -373,9 +443,28 @@ jobs:
 - **Schedule cadence:** Changed from weekly to daily. The change-detection
   guard ensures that the expensive mutation step only runs when relevant source
   changes landed on `main`, making quiet days a cheap no-op.
-- **Change detection mechanism:** Uses `git log --since="24 hours ago"` with
-  commit timestamps rather than `origin/main@{24.hours.ago}` (which relies on
-  reflog state unavailable in fresh CI clones).
+- **Change detection mechanism:** Uses `git log --since="25 hours ago"` with
+  commit timestamps rather than `origin/main@{25.hours.ago}` (which relies on
+  reflog state unavailable in fresh CI clones). The window exceeds the
+  24-hour cadence by one hour to absorb GitHub cron start-time drift;
+  occasional double-testing of a file is preferred over silently dropping a
+  commit. Files no longer present at the checked-out tip are filtered out
+  before scoping.
+- **Exit-code policy:** `cargo mutants` exit codes `2` (missed mutants) and
+  `3` (timeouts) are treated as success because the workflow is
+  informational — survivors are its output, not a failure. Exit codes `1`
+  (usage error), `4` (baseline tests failing), and `70` (internal error)
+  still fail the job so genuine faults surface as red runs.
+- **Output directories:** The workflow relies on the default output
+  locations (`./mutants.out/` for the root crate,
+  `wireframe_testing/mutants.out/` for the companion crate) because
+  `--output DIR` creates `mutants.out/` _within_ `DIR` rather than renaming
+  it, which would otherwise nest the report one level deeper than the
+  summary and artefact steps expect.
+- **Build strategy:** Runs use `--in-place`, the upstream recommendation for
+  CI, so mutation builds reuse the runner's existing build cache instead of
+  copying the source tree. The job also sets `timeout-minutes: 300` as a
+  hard backstop against unbounded full runs.
 - **Code change definition:** The detection monitors `src/**/*.rs`,
   `wireframe_testing/src/**/*.rs`, `examples/**/*.rs`, and `benches/**/*.rs`.
   Manifest-only changes (`Cargo.toml`, `Cargo.lock`) are excluded because

--- a/docs/adr-007-mutation-testing-with-cargo-mutants.md
+++ b/docs/adr-007-mutation-testing-with-cargo-mutants.md
@@ -189,6 +189,13 @@ on:
         required: false
         default: "main"
 
+# Serialize runs per target branch: a dispatch during a scheduled run
+# (or vice versa) queues rather than racing on runner usage. Runs are
+# informational, so queued runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.event.inputs.branch || 'main' }}
+  cancel-in-progress: false
+
 jobs:
   mutants:
     runs-on: ubuntu-latest
@@ -198,7 +205,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.inputs.branch || 'main' }}
           fetch-depth: 0
@@ -280,6 +287,16 @@ jobs:
             *) exit "$status" ;;
           esac
 
+      - name: Reset working tree
+        # Belt-and-braces: `--in-place` restores mutated sources itself,
+        # but a restore bug or unclean tool exit must not poison the
+        # wireframe_testing run that reuses this checkout.
+        if: >-
+          steps.detect.outputs.has_changes == 'true'
+          && (steps.detect.outputs.wt_files != ''
+              || steps.detect.outputs.dispatch == 'true')
+        run: git checkout -- .
+
       - name: Run mutation testing (wireframe_testing)
         if: >-
           steps.detect.outputs.has_changes == 'true'
@@ -309,7 +326,7 @@ jobs:
           always()
           && (steps.detect.outputs.root_files != ''
               || steps.detect.outputs.dispatch == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutation-report-root
           path: mutants.out/
@@ -319,7 +336,7 @@ jobs:
           always()
           && (steps.detect.outputs.wt_files != ''
               || steps.detect.outputs.dispatch == 'true')
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mutation-report-wireframe-testing
           path: wireframe_testing/mutants.out/

--- a/docs/adr-007-mutation-testing-with-cargo-mutants.md
+++ b/docs/adr-007-mutation-testing-with-cargo-mutants.md
@@ -77,7 +77,7 @@ _Table 1: Comparison of mutation testing approaches._
 Introduce `cargo-mutants` as a scheduled GitHub Actions workflow with manual
 dispatch support. The workflow runs daily but uses a change-detection guard so
 that the expensive mutation step is a cheap no-op when no relevant Rust source
-files changed on `main` in the preceding 24 hours.
+files changed on `main` in the preceding 25 hours.
 
 ### Schedule and change detection
 
@@ -411,7 +411,7 @@ jobs:
 - **Runner cost:** Scheduled runs consume GitHub Actions minutes. The daily
   schedule starts every day, but the change-detection guard ensures the
   expensive mutation step only runs when `main` received relevant Rust source
-  changes in the preceding 24 hours. On quiet days the workflow exits in
+  changes in the preceding 25 hours. On quiet days the workflow exits in
   seconds.
 - **Change detection edge cases:** The `git log --since` guard uses commit
   timestamps, not author timestamps. Force-pushed or rebased commits may carry
@@ -457,7 +457,7 @@ jobs:
 ## Resolved Decisions
 
 - **Scope filtering:** Mutations are scoped to files changed in the preceding
-  24 hours using repeated `--file` arguments rather than running against the
+  25 hours using repeated `--file` arguments rather than running against the
   full workspace. This was chosen to keep daily runs fast and focused.
 - **Workspace split:** `wireframe_testing` is not a workspace member, so it
   requires a separate `cargo mutants --dir wireframe_testing` invocation.

--- a/docs/adr-007-mutation-testing-with-cargo-mutants.md
+++ b/docs/adr-007-mutation-testing-with-cargo-mutants.md
@@ -208,7 +208,7 @@ jobs:
         id: detect
         run: |
           # Manual dispatch bypasses change detection — always run.
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "root_files=" >> "$GITHUB_OUTPUT"
             echo "wt_files=" >> "$GITHUB_OUTPUT"
@@ -239,7 +239,7 @@ jobs:
             echo "## Mutation testing skipped" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "No Rust source changes on \`main\` in the last" \
-              "24 hours." >> "$GITHUB_STEP_SUMMARY"
+              "25 hours." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "root_files=$root_files" >> "$GITHUB_OUTPUT"
@@ -252,6 +252,8 @@ jobs:
 
       - name: Install cargo-mutants
         if: steps.detect.outputs.has_changes == 'true'
+        # Unpinned for the initial rollout; pin once the first successful
+        # run confirms a known-good version.
         run: cargo binstall --no-confirm cargo-mutants
 
       - name: Run mutation testing (root crate)
@@ -259,9 +261,11 @@ jobs:
           steps.detect.outputs.has_changes == 'true'
           && (steps.detect.outputs.root_files != ''
               || steps.detect.outputs.dispatch == 'true')
+        env:
+          ROOT_FILES: ${{ steps.detect.outputs.root_files }}
         run: |
           args=""
-          for f in ${{ steps.detect.outputs.root_files }}; do
+          for f in $ROOT_FILES; do
             args="$args --file $f"
           done
           # Exit 2 (missed mutants) and 3 (timeouts) are informative
@@ -281,9 +285,11 @@ jobs:
           steps.detect.outputs.has_changes == 'true'
           && (steps.detect.outputs.wt_files != ''
               || steps.detect.outputs.dispatch == 'true')
+        env:
+          WT_FILES: ${{ steps.detect.outputs.wt_files }}
         run: |
           args=""
-          for f in ${{ steps.detect.outputs.wt_files }}; do
+          for f in $WT_FILES; do
             # Strip the wireframe_testing/ prefix for --file.
             args="$args --file ${f#wireframe_testing/}"
           done

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -174,6 +174,32 @@ Install Whitaker through the standalone installer described in the
 [Whitaker user's guide](whitaker-users-guide.md) so local linting matches
 continuous integration (CI).
 
+## Mutation testing
+
+Scheduled mutation testing runs in CI via
+`.github/workflows/mutation-testing.yml` (see
+[ADR-007](adr-007-mutation-testing-with-cargo-mutants.md) for the design
+and its rationale). Key points for contributors:
+
+- The workflow is informational only: it never gates pull requests, and
+  surviving mutants do not fail the run. It executes daily against `main`,
+  scoped to Rust files changed in the preceding 25 hours, and skips
+  cheaply when nothing changed. It can be dispatched manually against any
+  branch from the Actions tab, which runs full (unscoped) mutations.
+- [`cargo-mutants`](https://mutants.rs/) is a CI-runtime dependency only,
+  installed in the workflow via `cargo binstall`; it is not a Cargo
+  dependency and is not required locally. To reproduce a run locally,
+  install it with `cargo install cargo-mutants` and run, for example,
+  `cargo mutants --in-place --file src/frame/mod.rs`.
+- Results appear in the workflow's job summary (caught/missed/timeout
+  counts plus a table of surviving mutants) and as downloadable
+  `mutation-report-*` artefacts containing `mutants.out/`.
+- Surviving mutants are a test-improvement backlog: triage them for
+  equivalent mutations (false survivors) before writing tests. Mutants in
+  `wireframe_testing` are mostly false survivors because that crate's
+  logic is exercised chiefly by the root crate's suite; treat its table
+  as advisory.
+
 ## Cargo workspace semantics
 
 Wireframe now uses a hybrid root manifest: the repository root `Cargo.toml`

--- a/docs/execplans/adopt-cargo-mutants-workflow.md
+++ b/docs/execplans/adopt-cargo-mutants-workflow.md
@@ -189,6 +189,22 @@ results table (or skip message) and download the artefacts.
   shell-injection vector (a crafted file name would be expanded into the
   script before execution); environment variables are inert data. The ADR
   sketch was updated to match.
+- 2026-07-04 (review feedback round): Added a branch-keyed `concurrency`
+  group (`cancel-in-progress: false` — informational runs queue rather
+  than cancel), pinned `actions/checkout` and `actions/upload-artifact`
+  to full commit SHAs (matching the repo's majority pinning convention),
+  inserted a `git checkout -- .` tree-reset step before the
+  `wireframe_testing` run (belt-and-braces against `--in-place` restore
+  bugs; the second run is already skipped when the first fails), and
+  documented the workflow and the `cargo-mutants` CI-only dependency in
+  `docs/developers-guide.md`. Declined the request for a bespoke
+  workflow test harness in this repo: the detection, exit-code, and
+  summary logic is scheduled for extraction into `leynos/shared-actions`
+  as tested Python helpers with an act + pytest integration harness (see
+  `shared-actions` ExecPlan `add-mutation-testing-workflows.md`), and
+  wireframe's copy becomes a thin caller at that point; building a
+  throwaway harness here would duplicate that work without protecting
+  the eventual shape.
 - 2026-07-04: Kept the `wireframe_testing` invocation despite expected
   false-survivor noise, recording the caveat in the ADR's Known Risks and
   the possible removal in Outstanding Decisions. Rationale: the results

--- a/docs/execplans/adopt-cargo-mutants-workflow.md
+++ b/docs/execplans/adopt-cargo-mutants-workflow.md
@@ -4,7 +4,8 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IN PROGRESS (Stages A and C complete; Stages B and D outstanding)
+Status: COMPLETE (all stages done; post-merge observable-behaviour checks
+and version pinning remain as follow-ups — see Outcomes & retrospective)
 
 ## Purpose / big picture
 
@@ -94,13 +95,20 @@ results table (or skip message) and download the artefacts.
   field names confirmed from source; `--output` semantics, exit codes,
   no-mutants behaviour, and `--in-place` guidance confirmed against the
   cargo-mutants handbook and source).
-- [ ] Stage B: Create the workflow file.
+- [x] Stage B: Create the workflow file (2026-07-04: implemented per the
+  corrected ADR sketch, with step outputs passed via `env:` blocks; jq
+  summary logic smoke-tested against a synthetic `outcomes.json`; detect
+  loop smoke-tested against real git history, confirming both the
+  bucketing and the skip path).
 - [x] Stage C: Update the ADR to reflect corrections (2026-07-04: output
   paths, exit-code policy, 25-hour window, deleted-file guard,
   `--in-place`, `timeout-minutes`, `persist-credentials`,
   `wireframe_testing` false-survivor caveat, cron drift and suspension
   risks all recorded in the ADR).
-- [ ] Stage D: Validation and commit.
+- [x] Stage D: Validation and commit (2026-07-04: YAML syntax and
+  yamllint clean; `make markdownlint` 0 errors; `make nixie` green;
+  CodeRabbit agent review completed with 0 findings; committed as
+  8556814).
 
 ## Surprises & discoveries
 
@@ -189,7 +197,40 @@ results table (or skip message) and download the artefacts.
 
 ## Outcomes & retrospective
 
-(To be completed.)
+Implemented 2026-07-04 on branch `adopt-cargo-mutants-workflow` in three
+commits: ADR/plan hardening (8a5f266), the workflow itself (8556814),
+and this plan closure. All deterministic gates passed and a CodeRabbit
+agent review reported zero findings.
+
+What went well:
+
+- Verifying tool behaviour against upstream source before implementation
+  caught two defects that would have shipped silently: the `--output`
+  nesting (empty job summaries) and the missed-mutant exit code (red
+  runs on an "informational" workflow).
+- Smoke-testing the jq summary against a synthetic `outcomes.json` and
+  the detect loop against real git history validated the shell logic
+  without needing a live Actions run.
+
+Post-merge follow-ups (not blocking this plan):
+
+1. Trigger a manual `workflow_dispatch` run; confirm the job summary
+   and artefacts against real `outcomes.json` output.
+2. Pin the `cargo-mutants` version confirmed by that run and note the
+   validated version next to the jq filters.
+3. Calibrate `--timeout-multiplier` against observed baseline runtime.
+4. Feed lessons into the shared-actions reusable workflow (see
+   `~/docs/mutation-testing-rollout-plan.md`, phase 2).
+
+Lessons for the shared-actions generalization:
+
+- The `outcomes.json` schema pin belongs in the shared workflow, not in
+  callers, because upstream documents the format as unstable.
+- Pass step outputs into scripts via `env:` blocks from the outset;
+  direct `${{ ... }}` interpolation into shell text is an injection
+  vector that reviewers will (rightly) flag.
+- Most repos will not need the two-invocation split; make the
+  extra-crate handling an opt-in input rather than the default shape.
 
 ## Context and orientation
 

--- a/docs/execplans/adopt-cargo-mutants-workflow.md
+++ b/docs/execplans/adopt-cargo-mutants-workflow.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
 `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS (Stages A and C complete; Stages B and D outstanding)
 
 ## Purpose / big picture
 
@@ -12,14 +12,14 @@ After this change, the Wireframe project has a GitHub Actions workflow that runs
 `cargo-mutants` on a daily schedule (and on demand for any branch). The
 workflow uses a change-detection guard so that the expensive mutation step is a
 cheap no-op when no relevant Rust source files changed on `main` in the
-preceding 24 hours. When changes are detected, mutations are scoped to only the
+preceding 25 hours. When changes are detected, mutations are scoped to only the
 changed files using repeated `--file` arguments. The root crate and
 `wireframe_testing` (which is not a workspace member) are handled as separate
 targeted invocations. Each run produces:
 
 1. Downloadable artefacts containing the `mutants.out/` directory (and
-   `mutants-wt.out/` when `wireframe_testing` files changed), including
-   `outcomes.json`.
+   `wireframe_testing/mutants.out/` when `wireframe_testing` files changed),
+   including `outcomes.json`.
 2. A Markdown summary posted to the GitHub Actions job summary page listing
    counts (caught, missed, timed out) and a table of every surviving mutant
    with its file, line, and mutation description — or a skip message when no
@@ -37,12 +37,27 @@ results table (or skip message) and download the artefacts.
 - The Rust toolchain setup must use the same shared action as `ci.yml`:
   `leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332`.
 - Change detection must use `git log --since` with commit timestamps (not
-  reflog-based `@{24.hours.ago}`) because fresh CI clones lack reflog state.
+  reflog-based `@{25.hours.ago}`) because fresh CI clones lack reflog state.
+  The window is 25 hours (one hour wider than the daily cadence) to absorb
+  GitHub cron start-time drift, and files absent from the checked-out tip
+  must be filtered out before scoping.
 - The detection step must monitor: `src/**/*.rs`,
   `wireframe_testing/src/**/*.rs`, `examples/**/*.rs`, `benches/**/*.rs`.
   Manifest-only changes (`Cargo.toml`, `Cargo.lock`) are excluded.
 - `wireframe_testing` is not a workspace member, so it requires a separate
   `cargo mutants --dir wireframe_testing` invocation.
+- Mutation runs must not use `--output`: `--output DIR` creates
+  `mutants.out/` _within_ `DIR`, so the workflow relies on the defaults —
+  `./mutants.out/` for the root crate and `wireframe_testing/mutants.out/`
+  for the companion crate — and all artefact and summary paths must match.
+- Run steps must treat `cargo mutants` exit codes `2` (missed mutants) and
+  `3` (timeouts) as success, and exit codes `1`, `4`, and `70` as failures.
+  The workflow is informational; survivors must not produce red runs.
+- Mutation runs must pass `--in-place` (upstream CI recommendation) and the
+  job must set `timeout-minutes: 300` as a backstop against unbounded full
+  runs.
+- The checkout step must set `persist-credentials: false`; the workflow only
+  needs read access.
 - The ADR at `docs/adr-007-mutation-testing-with-cargo-mutants.md` must be
   updated to reflect any corrections discovered during implementation
   (especially the jq field names in the workflow sketch).
@@ -75,16 +90,23 @@ results table (or skip message) and download the artefacts.
 
 ## Progress
 
-- [ ] Stage A: Research and correct ADR sketch.
+- [x] Stage A: Research and correct ADR sketch (2026-07-04: `outcomes.json`
+  field names confirmed from source; `--output` semantics, exit codes,
+  no-mutants behaviour, and `--in-place` guidance confirmed against the
+  cargo-mutants handbook and source).
 - [ ] Stage B: Create the workflow file.
-- [ ] Stage C: Update the ADR to reflect corrections.
+- [x] Stage C: Update the ADR to reflect corrections (2026-07-04: output
+  paths, exit-code policy, 25-hour window, deleted-file guard,
+  `--in-place`, `timeout-minutes`, `persist-credentials`,
+  `wireframe_testing` false-survivor caveat, cron drift and suspension
+  risks all recorded in the ADR).
 - [ ] Stage D: Validation and commit.
 
 ## Surprises & discoveries
 
 - `origin/main@{24.hours.ago}` relies on reflog state, which is not available
-  in fresh CI clones. The safer alternative is `git log --since="24 hours ago"`
-  using commit timestamps.
+  in fresh CI clones. The safer alternative is `git log --since` using commit
+  timestamps.
 - `wireframe_testing` is not a workspace member, so
   `cargo mutants --workspace` from the repo root does not cover it. A second
   invocation with `--dir wireframe_testing` is required.
@@ -92,6 +114,30 @@ results table (or skip message) and download the artefacts.
   to be scoped to specific changed files rather than full-crate sweeps.
 - There is no `build.rs` in this repository, so it does not need to be
   included in the change-detection patterns.
+- `--output DIR` places `mutants.out/` _within_ `DIR` (confirmed from
+  `OutputDir::new` in cargo-mutants source): `--output mutants.out` would
+  produce `mutants.out/mutants.out/outcomes.json` and silently break the
+  summary step. The defaults (`./mutants.out/`, and
+  `wireframe_testing/mutants.out/` under `--dir`) are used instead.
+- `cargo mutants` exits non-zero for informative outcomes: `2` = missed
+  mutants, `3` = timeouts. Without explicit exit-code handling, every run
+  with a surviving mutant would show as a failed workflow, contradicting
+  the "purely informational" intent. Exit codes `1` (usage), `4` (baseline
+  failing), `5`/`6` (`--in-diff` problems), and `70` (internal error)
+  indicate genuine faults.
+- If scoping matches no mutants (for example, every changed file was
+  subsequently deleted), `cargo mutants` exits successfully with a warning,
+  so stale `--file` arguments are benign — the tip-existence guard is
+  belt-and-braces.
+- The cargo-mutants handbook recommends `--in-place` for CI so runs reuse
+  the existing build cache instead of copying the tree. `--in-place` is
+  incompatible with `-j` parallelism, which this workflow does not use.
+- `cargo-binstall` is provided by the shared `setup-rust` action (confirmed:
+  `ci.yml` runs `cargo binstall` immediately after it), so no separate
+  install step is needed.
+- `wireframe_testing` has only a handful of in-crate tests; its logic is
+  exercised mainly by the root crate's suite. Its mutation results will be
+  noisy with false survivors — recorded as a known limitation in the ADR.
 
 ## Decision log
 
@@ -107,6 +153,32 @@ results table (or skip message) and download the artefacts.
 - 2026-03-31: Split mutation runs into root crate and `wireframe_testing`
   invocations. Rationale: `wireframe_testing` is not a workspace member and
   requires `--dir wireframe_testing` for `cargo-mutants` to find it.
+- 2026-07-04: Dropped `--output` from both invocations and aligned artefact
+  and summary paths with the default output locations. Rationale:
+  `--output DIR` nests `mutants.out/` inside `DIR`, so the sketched
+  `--output mutants.out` would have hidden the report from the summary jq
+  and produced doubly nested artefacts.
+- 2026-07-04: Treat exit codes `2` and `3` as success in the run steps;
+  `1`, `4`, and `70` still fail the job. Rationale: the workflow is
+  informational — survivors are its deliverable, not a failure — but broken
+  invocations and failing baselines must stay visible as red runs.
+- 2026-07-04: Widened the change-detection window from 24 to 25 hours and
+  added a tip-existence guard (`[ -f "$f" ]`) before scoping. Rationale:
+  GitHub cron start times drift by up to an hour, which would silently drop
+  commits landing in the gap; deleted or renamed files should not reach
+  `--file`. Diffing against the last successful run's SHA was considered
+  and rejected as disproportionate complexity for an informational
+  workflow.
+- 2026-07-04: Added `--in-place` to both invocations, `timeout-minutes: 300`
+  on the job, and `persist-credentials: false` on checkout. Rationale:
+  upstream recommends `--in-place` in CI for build-cache reuse; full
+  dispatch runs are otherwise unbounded on a 2-core runner; the workflow
+  needs only read access.
+- 2026-07-04: Kept the `wireframe_testing` invocation despite expected
+  false-survivor noise, recording the caveat in the ADR's Known Risks and
+  the possible removal in Outstanding Decisions. Rationale: the results
+  remain useful for the crate's genuinely in-crate logic, and dropping the
+  run is trivial later if triage noise proves too high.
 
 ## Outcomes & retrospective
 
@@ -164,9 +236,27 @@ Therefore the correct jq filter for surviving mutants is:
 
 And the correct count filters use `.outcomes[]` (not `.[]`).
 
+**cargo-mutants behavioural facts** (confirmed 2026-07-04 against the
+cargo-mutants handbook at <https://mutants.rs/> and the upstream source):
+
+- `--output DIR` creates `mutants.out/` _within_ `DIR`; the default is
+  `mutants.out/` in the source directory being mutated (for `--dir
+  wireframe_testing`, that is `wireframe_testing/mutants.out/`).
+- Exit codes: `0` all caught, `1` usage error, `2` missed mutants, `3`
+  timeouts, `4` baseline tests already failing, `5`/`6` `--in-diff`
+  problems, `70` internal error.
+- If no mutants match the scoping arguments, `cargo mutants` warns and
+  exits `0`.
+- `--in-place` mutates the source tree directly (restoring after each
+  mutant) instead of copying it, reusing the build cache; recommended for
+  CI. Incompatible with `-j` parallelism.
+- `--in-diff` and `--shard` exist as future refinements (line-level scoping
+  and parallel splitting respectively); both are recorded as outstanding
+  decisions in the ADR.
+
 ## Plan of work
 
-### Stage A: Research and correct ADR sketch
+### Stage A: Research and correct ADR sketch (complete)
 
 Identify the corrections needed to the ADR's workflow sketch:
 
@@ -183,6 +273,11 @@ Identify the corrections needed to the ADR's workflow sketch:
 5. The mutant's description is `.scenario.Mutant.name` (not
    `.mutant.description`).
 
+Additional corrections confirmed 2026-07-04 (see "cargo-mutants behavioural
+facts" above): no `--output`, exit-code handling in the run steps,
+`--in-place`, the 25-hour window, the tip-existence guard,
+`timeout-minutes`, and `persist-credentials: false`.
+
 No code changes in this stage — just confirming the corrections above.
 
 ### Stage B: Create the workflow file
@@ -192,13 +287,15 @@ Create `.github/workflows/mutation-testing.yml` with the following structure:
 - **Triggers:** `schedule` (cron `30 4 * * *`, daily 04:30 UTC) and
   `workflow_dispatch` with an optional `branch` input defaulting to `main`.
 - **Job:** `mutants`, running on `ubuntu-latest`, with `contents: read`
-  permissions.
+  permissions and `timeout-minutes: 300`.
 - **Steps:**
   1. Checkout the repository at the selected branch with full history
-     (`fetch-depth: 0`).
-  2. Detect changed Rust files on `origin/main` in the last 24 hours using
-     `git log --since="24 hours ago"` (commit timestamps, not reflog). Sort
-     changes into root-crate files and `wireframe_testing` files. Set step
+     (`fetch-depth: 0`) and `persist-credentials: false`.
+  2. Detect changed Rust files on `origin/main` in the last 25 hours using
+     `git log --since="25 hours ago"` (commit timestamps, not reflog),
+     skipping files absent from the checked-out tip (`[ -f "$f" ]`). Sort
+     changes into root-crate files and `wireframe_testing` files using a
+     `while read` loop (not `for f in $var` word-splitting). Set step
      outputs: `has_changes`, `root_files`, `wt_files`, `dispatch`. For
      `workflow_dispatch` runs, bypass the guard by setting `has_changes=true`
      and `dispatch=true` unconditionally (runs full, unscoped mutations).
@@ -206,28 +303,44 @@ Create `.github/workflows/mutation-testing.yml` with the following structure:
      `$GITHUB_STEP_SUMMARY` and skip all subsequent heavy steps.
   4. Setup Rust using the shared action (gated on `has_changes`).
   5. Install `cargo-mutants` via `cargo binstall --no-confirm cargo-mutants`
-     (gated on `has_changes`).
-  6. Run `cargo mutants` for root crate with `--file` args for changed files
-     (gated on `root_files` being non-empty or `dispatch` being true).
-  7. Run `cargo mutants --dir wireframe_testing` with `--file` args for
-     changed `wireframe_testing` files (gated on `wt_files` being non-empty
-     or `dispatch` being true).
-  8. Upload separate artefacts for root and `wireframe_testing` reports.
+     (gated on `has_changes`; `cargo-binstall` is provided by the shared
+     action).
+  6. Run `cargo mutants --in-place` for the root crate with `--file` args
+     for changed files (gated on `root_files` being non-empty or `dispatch`
+     being true). Wrap the invocation in exit-code handling: `0`, `2`, and
+     `3` succeed; anything else fails the step. Output lands in
+     `./mutants.out/` (no `--output`).
+  7. Run `cargo mutants --in-place --dir wireframe_testing` with `--file`
+     args for changed `wireframe_testing` files (gated on `wt_files` being
+     non-empty or `dispatch` being true), with the same exit-code handling.
+     Output lands in `wireframe_testing/mutants.out/`.
+  8. Upload separate artefacts for root (`mutants.out/`) and
+     `wireframe_testing` (`wireframe_testing/mutants.out/`) reports.
   9. Post a Markdown summary to `$GITHUB_STEP_SUMMARY` using corrected jq
      filters (with `if: always()`), calling a `post_results` shell function
-     for each report directory.
+     for each report directory (`mutants.out` and
+     `wireframe_testing/mutants.out`).
 
-### Stage C: Update the ADR
+### Stage C: Update the ADR (complete)
 
 Update the ADR at `docs/adr-007-mutation-testing-with-cargo-mutants.md` to
 reflect:
 
-- Daily schedule with change-detection guard.
-- Revised workflow sketch with `fetch-depth: 0`, `detect` step, gated
-  steps, split root/`wireframe_testing` invocations.
-- Updated risk and limitation sections for the new approach.
-- Resolved decisions section documenting the design choices.
+- Daily schedule with change-detection guard (25-hour window, tip-existence
+  guard).
+- Revised workflow sketch with `fetch-depth: 0`,
+  `persist-credentials: false`, `timeout-minutes: 300`, `detect` step,
+  gated steps, split root/`wireframe_testing` invocations using default
+  output locations, `--in-place`, and exit-code handling.
+- Updated risk and limitation sections for the new approach, including
+  `wireframe_testing` false survivors, cron drift, no-catch-up, and
+  scheduled-workflow suspension.
+- Resolved decisions section documenting the design choices; outstanding
+  decisions for `--in-diff`, `--shard`, and whether to keep the
+  `wireframe_testing` run.
 - Corrected jq field names (`.outcomes[]`, `.scenario.Mutant.file`, etc.).
+
+Completed 2026-07-04 alongside Stage A.
 
 ### Stage D: Validation and commit
 
@@ -248,20 +361,17 @@ above, including the `detect` step, gated `Setup Rust` / `Install` /
 separate artefact uploads, and the `post_results` shell function in the summary
 step.
 
-**Stage C — update ADR:**
+**Stage C — update ADR (complete 2026-07-04):**
 
-Edit `docs/adr-007-mutation-testing-with-cargo-mutants.md`:
-
-- Replace all `.[]` with `.outcomes[]` in the jq filters.
-- Replace `.scenario == "Mutant"` with `.scenario != "Baseline"` (or an
-  object-type check).
-- Replace `.mutant.source_file` with `.scenario.Mutant.file`.
-- Replace `.mutant.line` with `.scenario.Mutant.span.start.line`.
-- Replace `.mutant.description` with `.scenario.Mutant.name`.
-- Change schedule from weekly to daily with change-detection guard.
-- Add workspace split handling (root crate vs `wireframe_testing`).
-- Add "Resolved Decisions" section documenting design choices.
-- Update risks and limitations for the revised approach.
+The ADR at `docs/adr-007-mutation-testing-with-cargo-mutants.md` already
+carries the corrected jq field names, daily schedule with guard, workspace
+split, and Resolved Decisions section, plus the 2026-07-04 corrections:
+default output locations (no `--output`), exit-code policy, 25-hour window
+with tip-existence guard, `--in-place`, `timeout-minutes: 300`,
+`persist-credentials: false`, and the expanded risks (including
+`wireframe_testing` false survivors and cron drift/suspension). No further
+ADR edits are expected in this task; Stage B must implement the workflow
+exactly as the ADR sketch now describes.
 
 **Stage D — validate:**
 
@@ -299,14 +409,20 @@ git commit
 - `.github/workflows/mutation-testing.yml` is syntactically valid YAML.
 - The workflow file contains both `schedule` (daily) and `workflow_dispatch`
   triggers.
-- The workflow checks out with `fetch-depth: 0` and has a `detect` step that
-  uses `git log --since="24 hours ago"` (not reflog).
+- The workflow checks out with `fetch-depth: 0` and
+  `persist-credentials: false`, and has a `detect` step that uses
+  `git log --since="25 hours ago"` (not reflog) with a tip-existence guard.
+- The job sets `timeout-minutes: 300`.
 - Heavy steps (`Setup Rust`, `Install cargo-mutants`, `Run mutation testing`)
   are gated on `steps.detect.outputs.has_changes == 'true'`.
 - `workflow_dispatch` runs bypass the change-detection guard by setting
   `has_changes=true` unconditionally and running full (unscoped) mutations.
 - Root crate and `wireframe_testing` mutation runs are separate steps with
-  appropriate `--file` and `--dir` arguments.
+  appropriate `--file` and `--dir` arguments, both passing `--in-place`,
+  neither passing `--output`, and both wrapping the invocation in the
+  exit-code handling (`0`/`2`/`3` succeed; all else fails).
+- Artefact and summary paths reference `mutants.out/` and
+  `wireframe_testing/mutants.out/`.
 - The jq filters in both the workflow and the ADR use the corrected field
   names (`.outcomes[]`, `.scenario.Mutant.file`, etc.).
 
@@ -343,8 +459,25 @@ The change-detection snippet (for reference during implementation):
 
 ```sh
 # Use commit timestamps (not reflog) — safe in fresh CI clones.
-changed=$(git log --since="24 hours ago" --name-only \
-  --format="" origin/main -- '*.rs' | sort -u)
+# 25-hour window absorbs GitHub cron start-time drift.
+git log --since="25 hours ago" --name-only \
+  --format="" origin/main -- '*.rs' | sort -u
+# Consume with a `while IFS= read -r f` loop, skipping entries where
+# `[ -f "$f" ]` fails (deleted or renamed since the change).
+```
+
+The exit-code wrapper for the run steps (for reference during
+implementation):
+
+```sh
+set +e
+cargo mutants --in-place --timeout-multiplier 3 $args
+status=$?
+set -e
+case "$status" in
+  0|2|3) exit 0 ;;  # all caught / missed mutants / timeouts: informative
+  *) exit "$status" ;;  # usage error, failing baseline, internal error
+esac
 ```
 
 The corrected jq snippet for the summary step (for reference during

--- a/docs/execplans/adopt-cargo-mutants-workflow.md
+++ b/docs/execplans/adopt-cargo-mutants-workflow.md
@@ -174,6 +174,13 @@ results table (or skip message) and download the artefacts.
   upstream recommends `--in-place` in CI for build-cache reuse; full
   dispatch runs are otherwise unbounded on a 2-core runner; the workflow
   needs only read access.
+- 2026-07-04: Passed step outputs into run scripts via `env:` blocks
+  (`ROOT_FILES`, `WT_FILES`) and used `$GITHUB_EVENT_NAME` instead of
+  interpolating `${{ ... }}` expressions directly into shell text.
+  Rationale: direct interpolation of file names into script bodies is a
+  shell-injection vector (a crafted file name would be expanded into the
+  script before execution); environment variables are inert data. The ADR
+  sketch was updated to match.
 - 2026-07-04: Kept the `wireframe_testing` invocation despite expected
   false-survivor noise, recording the caveat in the ADR's Known Risks and
   the possible removal in Outstanding Decisions. Rationale: the results


### PR DESCRIPTION
## Summary

This branch adopts an informational `cargo-mutants` workflow for Wireframe so mutation testing can run daily on recent Rust source changes, or on demand for any branch, without blocking pull requests. It also hardens ADR 007 and the completed ExecPlan around the verified `cargo-mutants` behaviours that affect CI correctness: default output locations, informative exit codes, scoped file arguments, `--in-place`, and the non-workspace `wireframe_testing` crate.

Execplan: [docs/execplans/adopt-cargo-mutants-workflow.md](https://github.com/leynos/wireframe/blob/adopt-cargo-mutants-workflow/docs/execplans/adopt-cargo-mutants-workflow.md)

## Review walkthrough

- Start with [.github/workflows/mutation-testing.yml](https://github.com/leynos/wireframe/blob/adopt-cargo-mutants-workflow/.github/workflows/mutation-testing.yml) to review the scheduled and manually dispatchable workflow, change-detection guard, split root and `wireframe_testing` mutation runs, artefact uploads, and job-summary generation.
- Then review [docs/adr-007-mutation-testing-with-cargo-mutants.md](https://github.com/leynos/wireframe/blob/adopt-cargo-mutants-workflow/docs/adr-007-mutation-testing-with-cargo-mutants.md) for the design rationale, corrected workflow sketch, resolved decisions, known risks, and follow-up decisions.
- Finish with [docs/execplans/adopt-cargo-mutants-workflow.md](https://github.com/leynos/wireframe/blob/adopt-cargo-mutants-workflow/docs/execplans/adopt-cargo-mutants-workflow.md) for the implementation record, validation evidence, and post-merge follow-ups.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/mutation-testing.yml'))"`: passed with no output.
- `make markdownlint`: passed with `Summary: 0 error(s)`.
- `make nixie`: passed; all Mermaid diagrams validated successfully.
- `coderabbit review --agent`: completed with 0 findings.

## Notes

The workflow intentionally remains informational: missed mutants and timeouts are reported in the Actions summary and artefacts, but do not turn the run red. Post-merge follow-ups remain to trigger a manual workflow run, pin the confirmed `cargo-mutants` version, calibrate the timeout multiplier, and feed the pattern into the shared-actions rollout.

## References

- ExecPlan: [docs/execplans/adopt-cargo-mutants-workflow.md](https://github.com/leynos/wireframe/blob/adopt-cargo-mutants-workflow/docs/execplans/adopt-cargo-mutants-workflow.md)
- ADR: [docs/adr-007-mutation-testing-with-cargo-mutants.md](https://github.com/leynos/wireframe/blob/adopt-cargo-mutants-workflow/docs/adr-007-mutation-testing-with-cargo-mutants.md)
