### PR TITLE
Tune the mutation caller after the Stage E dispatch run (#578)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -28,13 +28,17 @@ jobs:
       id-token: write # OIDC workflow-source resolution
     uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
     with:
-      # Companion crate outside the root workspace; its coverage lives
-      # mainly in the root crate's tests, so treat its survivors table
-      # as advisory (ADR-007).
-      extra-crate-dirs: "wireframe_testing"
+      # The wireframe_testing companion target is temporarily disabled:
+      # its doctests fail to compile standalone, so the mutation
+      # baseline cannot pass (#578). Restore
+      # `extra-crate-dirs: "wireframe_testing"` when that issue closes.
       # Illustrative codecs and test-support scaffolding whose
       # survivors are noise (#571).
       exclude-globs: "src/codec/examples.rs,src/test_helpers.rs,src/connection/test_support.rs"
       # Match the CI baseline (`make test` runs --all-features) so
       # feature-gated tests run against mutants (#571).
       extra-args: "--all-features"
+      # Eight shards: the first six-shard dispatch run (Stage E) lost
+      # shard 2 to the 300-minute ceiling because timeout-prone mutants
+      # cluster unevenly; extra shards buy headroom.
+      shard-count: 8

--- a/docs/execplans/adopt-shared-mutation-workflow.md
+++ b/docs/execplans/adopt-shared-mutation-workflow.md
@@ -121,7 +121,20 @@ feature-gated tests now run.
   "Mutation testing" section to `docs/users-guide.md` covering the
   shared workflow, `--all-features` rationale, scaffolding excludes,
   the two run modes, report locations, and the ADR-007 cross-link.
-- [ ] Stage E (post-merge, outside this branch): dispatch a manual run;
+- [x] (2026-07-06) Stage E: dispatch run 28806201980 executed. The
+  machinery validated — detect emitted the full matrix, five of six
+  root shards completed and were merged into one summary by the
+  summarize job. Two failures, both diagnosed: root shard 2 hit the
+  300-minute job ceiling (timeout-prone mutants cluster unevenly; its
+  cancelled run also skipped the always() artefact upload — a shared
+  workflow improvement follows), and the wireframe_testing target's
+  unmutated baseline fails because the crate's doctests do not compile
+  standalone (#578 — never caught before, as CI does not run the
+  non-member crate's own tests). This branch raises shard-count to 8
+  and parks the wireframe_testing target until #578 closes.
+- [ ] Stage E follow-ups: re-enable wireframe_testing when #578 is
+  fixed; confirm serde-bridge survivors are gone from the next full
+  run's summary; consider re-dispatch after the shard bump.: dispatch a manual run;
   confirm shard fan-out, merged summary, and the disappearance of the
   serde-bridge false survivors; then update the estate rollout plan
   and the shared-actions ExecPlan Stage G.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -134,9 +134,14 @@ def test_with_block_carries_the_caller_configuration() -> None:
     """The caller passes the companion crate, excludes, and feature args."""
     with_block = _mutation_job(_load()).get("with")
     assert isinstance(with_block, dict), "jobs.mutation.with is missing"
-    assert with_block.get("extra-crate-dirs") == "wireframe_testing", (
-        f"with.extra-crate-dirs must be 'wireframe_testing', got "
-        f"{with_block.get('extra-crate-dirs')!r}"
+    assert "extra-crate-dirs" not in with_block, (
+        "the wireframe_testing target stays disabled until its doctests "
+        "compile (#578); restore the extra-crate-dirs assertion when "
+        "re-enabling it"
+    )
+    assert with_block.get("shard-count") == 8, (
+        f"with.shard-count must be 8 (Stage E: six shards lost one leg "
+        f"to the job ceiling), got {with_block.get('shard-count')!r}"
     )
     assert with_block.get("extra-args") == "--all-features", (
         f"with.extra-args must be '--all-features' so feature-gated tests run "


### PR DESCRIPTION
## Summary

Remediation from the first sharded mutation dispatch run ([28806201980](https://github.com/leynos/wireframe/actions/runs/28806201980)): raise `shard-count` to 8 (shard 2 hit the 300-minute ceiling) and temporarily disable the `wireframe_testing` target whose baseline cannot pass while its doctests fail to compile (#578). Contract tests updated to pin the new shape; Stage E outcome recorded in the [ExecPlan](https://github.com/leynos/wireframe/blob/tune-mutation-caller-after-stage-e/docs/execplans/adopt-shared-mutation-workflow.md).

## Validation

- `make test-workflow-contracts`: 6 passed
- YAML parse and `make markdownlint`: clean