### PR TITLE
Wire main-branch CodeScene coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,14 @@ jobs:
       BUILD_PROFILE: debug
       WHITAKER_INSTALLER_VERSION: '0.2.1'
     steps:
+      # Full history so the deferred CodeScene `cs-coverage check` gate
+      # (which diffs a pull request against its merge base) can be added
+      # without a further checkout change.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Cache Whitaker installer
@@ -45,18 +50,22 @@ jobs:
           enable-cache: true
       - name: Workflow contract tests
         run: make test-workflow-contracts
+      # Coverage runs on pull requests only and drives the ratchet gate.
+      # Main-branch coverage — the CodeScene upload plus the authoritative
+      # ratchet baseline every pull request compares against — is produced
+      # by coverage-main.yml on push, so generation is kept out of
+      # main-push runs to avoid doing the work twice.
+      #
+      # The CodeScene PR "Code Coverage" gate (`cs-coverage check`,
+      # mode: check) is intentionally NOT wired here yet: CodeScene project
+      # 68308 has no coverage-gate configuration, so `cs-coverage check`
+      # fails with "Lacks the gates configuration" and would turn this
+      # required job permanently red. It is deferred to a fast-follow once
+      # the gate is provisioned (see coverage-main.yml).
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        if: github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
-        
-        with:
-          format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+          with-ratchet: 'true'

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,44 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push. This workflow also
+# advances the coverage ratchet baseline: caches saved on main are
+# readable by every pull-request run, so the baseline written here is the
+# one PR ratchet checks compare against.
+#
+# The pull-request `cs-coverage check` gate is deferred (see ci.yml):
+# CodeScene project 68308 currently has no gate configuration. The first
+# `mode: upload` from this workflow may provision it; once the gate is
+# live the PR `mode: check` step can be added in a fast-follow.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+    steps:
+      - uses: actions/checkout@v7
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Test and Measure Coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # The wireframe_testing companion target is temporarily disabled:
       # its doctests fail to compile standalone, so the mutation

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -21,10 +21,13 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA documented in
+#: The repo-wide leynos/shared-actions pin. Originally documented in
 #: docs/execplans/adopt-shared-mutation-workflow.md (the merge commit of
-#: leynos/shared-actions PR #319). Bump both together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: leynos/shared-actions PR #319); bumped to the single estate-wide pin
+#: that carries the CodeScene coverage `mode: check` gate
+#: (leynos/shared-actions PR #334). Every shared-actions reference in the
+#: repo shares this SHA; bump them together.
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

Begin onboarding wireframe to the estate CodeScene coverage gate,
following the pattern in [mxd#362](https://github.com/leynos/mxd/pull/362).
This PR lands the behaviour-preserving, always-green half — the
shared-actions pin bump and the main-branch coverage upload — and
**defers the pull-request `cs-coverage check` gate** because CodeScene
has not yet provisioned this project's gate configuration.

### Why the PR gate is deferred

Wiring the PR `mode: check` step and running it on this branch's own head
produced, after a successful coverage run:

```
HTTP call succeeded, but the received project-config isn't valid. Lacks the gates configuration.
##[error]Configuration problem: check logs
```

Authentication and the project id (68308) are correct — the HTTP call
succeeds — but CodeScene project 68308 has no coverage-gate
configuration, so `cs-coverage check` errors and would turn the required
`build-test` job permanently red. This is a CodeScene-side per-project
feature (only mxd's project has it enabled today) and matches the
byte-identical failures on ddlint #287 (project 69278) and chutoro #156
(project 71838). Per the estate rollout recipe's "coverage-gate
bootstrap blocker" note, the sequencing is: merge the upload half first,
watch the first `coverage-main.yml` upload (open question: does it
auto-provision the gate?), then add `mode: check` in a fast-follow once
the gate is live.

CodeScene project id: **68308**. This is not a required check — it
blocks via the status rollup, not the branch ruleset.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/wireframe/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — bump the shared-actions references to the estate pin `927edd4`;
  check out with `fetch-depth: 0` (so the deferred merge-base diff
  needs no further checkout change); scope coverage generation to pull
  requests and enable the coverage ratchet there; and remove the old
  CodeScene upload step (with the token now set it would attempt a
  `mode: upload` on a pull request, which CodeScene rejects for
  non-analysed branches). A comment records why the `mode: check` gate
  is deferred.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/wireframe/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new workflow. On push to main it uploads coverage (`mode: upload`)
  and writes the authoritative ratchet baseline that pull-request runs
  compare against. Generation is kept out of main-push `ci.yml` runs so
  main coverage is computed once, not twice.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/wireframe/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml)
  and
  [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/wireframe/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  — bump their shared-actions references to the same `927edd4` pin so
  the repo carries a single estate-wide pin. Their reusable-workflow
  input contracts are unchanged at that SHA (mutation-cargo gains only
  an optional `setup-commands` input; dependabot-automerge is identical).
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/wireframe/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py)
  — update the pinned-SHA contract to match the bump.

Coverage behaviour is otherwise preserved: `generate-coverage` keeps its
`use-cargo-nextest` default (wireframe already ran coverage under
nextest) and the `lcov` / `lcov.info` output.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on all four touched
  workflows — parses.
- `make test-workflow-contracts` — 6 passed.
- CI on this branch's own head: format, lint, Whitaker, workflow-contract
  tests and the coverage run all pass. (An earlier revision proved the
  deferred `mode: check` step is what fails, for the CodeScene-side reason
  above; it has been removed from this PR.)

## Follow-ups

1. After merge, watch the first `coverage-main.yml` run on main and
   confirm the `mode: upload` succeeds and the ratchet baseline saves.
2. Re-test `cs-coverage check` against project 68308. If the upload
   provisioned the gate, add the guarded PR `mode: check` step (with
   `fetch-depth: 0`); otherwise flag that CodeScene must enable the gate
   before that step can land.
