### PR TITLE
Stop pinning the mutation workflow's exact shared-actions SHA

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -213,6 +213,42 @@ and its rationale). Key points for contributors:
   logic is exercised chiefly by the root crate's suite; treat its table
   as advisory.
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Cargo workspace semantics
 
 Wireframe now uses a hybrid root manifest: the repository root `Cargo.toml`

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,19 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; wireframe's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the pin
-at a branch, widening permissions, or losing the issue-571
+PyYAML and pin the contract it must uphold, so drift (repointing the
+reference at a branch, widening permissions, or losing the issue-571
 configuration) fails CI on the pull request rather than surfacing in a
-scheduled or manual run.
+scheduled or manual run. The tests assert that the caller references the
+correct reusable workflow at a commit SHA; Dependabot owns the SHA value,
+so no specific SHA is asserted here.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,16 +24,8 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The repo-wide leynos/shared-actions pin. Originally documented in
-#: docs/execplans/adopt-shared-mutation-workflow.md (the merge commit of
-#: leynos/shared-actions PR #319); bumped to the single estate-wide pin
-#: that carries the CodeScene coverage `mode: check` gate
-#: (leynos/shared-actions PR #334). Every shared-actions reference in the
-#: repo shares this SHA; bump them together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 SCAFFOLDING_EXCLUDES = (
@@ -63,25 +58,13 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call mutation-cargo.yml pinned to a 40-hex commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; the execution plan documents {PINNED_SHA!r} — "
-        "bump the plan and this test together with the workflow"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"40-character lowercase hex commit SHA, not a branch or tag: {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing workflow contract test asserted the caller's
  `uses:` reference matched a hard-coded, documented commit SHA. Every
  Dependabot bump of `leynos/shared-actions/.github/workflows/mutation-cargo.yml`
  therefore failed CI until a human edited the constant by hand.
- Replace the exact-SHA equality with a shape assertion: the reference
  must point at the correct reusable workflow path and be pinned to a
  40-hex commit SHA (not a mutable branch/tag), without asserting which
  SHA. Dependabot now owns the SHA value.
- Document the policy in the developers' guide (new "Workflow pins and
  Dependabot" section) so future contract tests follow the same
  shape-only pattern.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: dropped
  `PINNED_SHA`/`EXPECTED_USES` and the "bump the plan and this test
  together" doc-comment; added a `USES_RE` regex
  (`^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`)
  and a single `test_uses_reference_is_pinned_to_a_commit_sha` assertion.
  Updated the module docstring accordingly. All other assertions
  (permissions, concurrency, triggers, `with:` block, scaffolding
  excludes) are unchanged.
- `docs/developers-guide.md`: added the "Workflow pins and Dependabot"
  subsection recording the policy, with the canonical do/don't list and
  example snippet.
- The workflow file itself (`.github/workflows/mutation-testing.yml`)
  and its current pinned SHA are untouched — Dependabot continues to
  move it.
- No other repo contract test (Python or Rust) pins a shared-actions
  SHA, and `.github/dependabot.yml` already has a `github-actions`
  ecosystem entry with `directory: "/"` and a weekly schedule, so no
  further changes were needed there.

## Validation

- `make test-workflow-contracts` passes (6/6), confirming the regex
  matches the workflow's current pinned SHA.
- Manually verified the regex accepts a hypothetical different 40-hex
  SHA and rejects a branch ref such as `@main`.
- `markdownlint-cli2 docs/developers-guide.md` passes with 0 errors.
