### PR TITLE
Wire the CodeScene mode: check coverage gate on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,6 @@ jobs:
       # ratchet baseline every pull request compares against — is produced
       # by coverage-main.yml on push, so generation is kept out of
       # main-push runs to avoid doing the work twice.
-      #
-      # The CodeScene PR "Code Coverage" gate (`cs-coverage check`,
-      # mode: check) is intentionally NOT wired here yet: CodeScene project
-      # 68308 has no coverage-gate configuration, so `cs-coverage check`
-      # fails with "Lacks the gates configuration" and would turn this
-      # required job permanently red. It is deferred to a fast-follow once
-      # the gate is provisioned (see coverage-main.yml).
       - name: Test and Measure Coverage
         if: github.event_name == 'pull_request'
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
@@ -69,3 +62,14 @@ jobs:
           output-path: lcov.info
           format: lcov
           with-ratchet: 'true'
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/68308
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -6,10 +6,8 @@ name: Coverage (main)
 # readable by every pull-request run, so the baseline written here is the
 # one PR ratchet checks compare against.
 #
-# The pull-request `cs-coverage check` gate is deferred (see ci.yml):
-# CodeScene project 68308 currently has no gate configuration. The first
-# `mode: upload` from this workflow may provision it; once the gate is
-# live the PR `mode: check` step can be added in a fast-follow.
+# The pull-request `cs-coverage check` gate is wired in ci.yml
+# (CodeScene project 68308's coverage gate is enabled).
 
 on:
   push:


### PR DESCRIPTION
## Summary

- CodeScene project 68308's coverage-gate configuration is now
  provisioned, so the previously deferred `cs-coverage check` gate step
  can be added to the pull-request coverage job.
- Add the guarded `mode: check` step after coverage generation in
  `ci.yml`, matching the repo's existing `lcov` format and the
  shared-actions pin (`927edd4`) already used for `generate-coverage`
  and the `coverage-main.yml` upload step.
- Update the comment in `coverage-main.yml`, which previously described
  the gate as deferred pending provisioning.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/wireframe/blob/codescene-mode-check/.github/workflows/ci.yml) —
  replaces the deferred-gate comment with a guarded
  `upload-codescene-coverage@927edd4` step in `mode: check`, run only
  when `CS_ACCESS_TOKEN` is set and the event is a pull request. The job
  already checks out with `fetch-depth: 0`, which `cs-coverage check`
  needs to resolve the merge base.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/wireframe/blob/codescene-mode-check/.github/workflows/coverage-main.yml) —
  comment-only update; `mode: upload` on push to `main` is unchanged.

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow
      files.
- [x] `make test-workflow-contracts` passes locally.
- [ ] CI on this pull request: the "Test and Measure Coverage" step
      passes the ratchet, and the new "Check coverage against CodeScene
      gates" step executes (not skipped) and succeeds, with the
      `CodeScene Code Coverage` check completing green.
