### PR TITLE
Kill mutation-testing survivors and widen scaffolding excludes (#566, #567, #569, #570, #593, #595, #598)

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -33,8 +33,12 @@ jobs:
       # baseline cannot pass (#578). Restore
       # `extra-crate-dirs: "wireframe_testing"` when that issue closes.
       # Illustrative codecs and test-support scaffolding whose
-      # survivors are noise (#571).
-      exclude-globs: "src/codec/examples.rs,src/test_helpers.rs,src/connection/test_support.rs"
+      # survivors are noise (#571). The `src/test_helpers.rs` glob only
+      # matches the module root; `src/test_helpers/**` also covers the
+      # helper submodules (frame_codec.rs, pool_client.rs). `src/**/tests.rs`
+      # covers the cfg(test)-only test modules split into companion files,
+      # which cargo-mutants cannot detect as test code (#599).
+      exclude-globs: "src/codec/examples.rs,src/test_helpers.rs,src/test_helpers/**,src/connection/test_support.rs,src/**/tests.rs"
       # Match the CI baseline (`make test` runs --all-features) so
       # feature-gated tests run against mutants (#571).
       extra-args: "--all-features"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1622,6 +1622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mutants"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add0ac067452ff1aca8c5002111bd6b1c895baee6e45fcbc44e0193aea17be56"
+
+[[package]]
 name = "newt-hype"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3641,6 +3647,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-util",
  "mockall",
+ "mutants",
  "pretty_assertions",
  "proptest",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ rstest-bdd-macros = { version = "0.5.0", features = ["strict-compile-time-valida
 wireframe = { path = ".", features = ["test-support", "pool", "testkit"] }
 wireframe_testing = { path = "./wireframe_testing" }
 logtest = "2.0.0"
+# No-op decorator attributes recognised by cargo-mutants; used only under
+# cfg(test) to annotate equivalent mutants, so no production dependency.
+mutants = "0.0.4"
 proptest = "1.7.0"
 googletest = "0.14.3"
 pretty_assertions = "1.4.1"

--- a/docs/adr-007-mutation-testing-with-cargo-mutants.md
+++ b/docs/adr-007-mutation-testing-with-cargo-mutants.md
@@ -2,23 +2,34 @@
 
 ## Status
 
-Accepted. Amended 2026-07-05: the decision stands, but the bespoke
-workflow implementation described in the sketch below has been
-superseded — `.github/workflows/mutation-testing.yml` is now a thin
-caller of the shared reusable workflow
-`leynos/shared-actions/.github/workflows/mutation-cargo.yml` (pinned by
-commit SHA), which generalizes this design and adds shard fan-out for
-full dispatch runs, a merged cross-shard summary, tested helper
-scripts, and a pinned `cargo-mutants` version. The caller enables
-`--all-features` (so feature-gated tests run against mutants) and
-excludes example/test-support scaffolding, addressing issue #571. The
-sketch below is retained as the historical record of the design the
-shared workflow was generalized from; the caller-facing contract now
-lives in the shared repository's `docs/mutation-cargo-workflow.md`.
+Accepted. Amended 2026-07-05: the decision stands, but the bespoke workflow
+implementation described in the sketch below has been superseded —
+`.github/workflows/mutation-testing.yml` is now a thin caller of the shared
+reusable workflow `leynos/shared-actions/.github/workflows/mutation-cargo.yml`
+(pinned by commit SHA), which generalizes this design and adds shard fan-out
+for full dispatch runs, a merged cross-shard summary, tested helper scripts,
+and a pinned `cargo-mutants` version. The caller enables `--all-features` (so
+feature-gated tests run against mutants) and excludes example/test-support
+scaffolding, addressing issue #571. The sketch below is retained as the
+historical record of the design the shared workflow was generalized from; the
+caller-facing contract now lives in the shared repository's
+`docs/mutation-cargo-workflow.md`.
+
+Amended 2026-07-17: full dispatch runs now fan out across eight shards (the
+first six-shard run lost a leg to the job ceiling), and the exclude-globs
+additionally cover `src/test_helpers/**` and `src/**/tests.rs` — the
+module-root glob missed the `src/test_helpers/` submodules, and cfg(test)-only
+companion `tests.rs` files are invisible to cargo-mutants' test-code detection
+(#599). The caller contract (reusable-workflow reference shape, permissions,
+triggers, excludes, extra-args, and shard count) is pinned by
+`tests/workflow_contracts/mutation_testing_test.py`. Equivalent mutants are
+annotated in source with `#[cfg_attr(test, mutants::skip)]` and a justification
+comment, using the `mutants` crate of no-op decorator attributes as a
+dev-dependency so production builds are unaffected.
 
 ## Date
 
-2026-03-31 (amended 2026-07-05).
+2026-03-31 (amended 2026-07-05 and 2026-07-17).
 
 ## Context and Problem Statement
 
@@ -109,12 +120,11 @@ files changed on `main` in the preceding 25 hours.
    relies on reflog state, which is not available in fresh CI clones. The
    window is 25 hours rather than 24 because GitHub cron start times drift
    (runs routinely begin 15–60 minutes late); the extra hour means a commit
-   landing just after one run still falls inside the next run's window, at
-   the cost of occasionally re-testing a file. Files that no longer exist at
-   the checked-out tip (deleted or renamed within the window) are filtered
-   out before being passed to `--file`. The result is stored as a step
-   output (`has_changes=true|false`) and the heavy mutation step is gated
-   with
+   landing just after one run still falls inside the next run's window, at the
+   cost of occasionally re-testing a file. Files that no longer exist at the
+   checked-out tip (deleted or renamed within the window) are filtered out
+   before being passed to `--file`. The result is stored as a step output
+   (`has_changes=true|false`) and the heavy mutation step is gated with
    `if: steps.detect.outputs.has_changes == 'true'`. Manual `workflow_dispatch`
    runs bypass the guard by setting `has_changes=true` unconditionally and
    running a full (unscoped) mutation against both the root crate and
@@ -157,10 +167,10 @@ running up to two targeted invocations:
 1. **Execution:** Installs `cargo-mutants` via `cargo binstall` (the shared
    `setup-rust` action provides `cargo-binstall`), then runs the scoped
    invocations described above with `--in-place` (the upstream CI
-   recommendation, which reuses the existing build cache instead of copying
-   the tree) and a per-mutant timeout multiplier to bound execution time. The
-   job carries an explicit `timeout-minutes` ceiling as a backstop against
-   runaway full runs.
+   recommendation, which reuses the existing build cache instead of copying the
+   tree) and a per-mutant timeout multiplier to bound execution time. The job
+   carries an explicit `timeout-minutes` ceiling as a backstop against runaway
+   full runs.
 2. **Output locations:** `cargo-mutants` creates `mutants.out/` inside the
    source directory it operates on. Note that `--output DIR` places
    `mutants.out/` _within_ `DIR` (it does not rename the directory), so the
@@ -170,9 +180,9 @@ running up to two targeted invocations:
 3. **Exit-code handling:** `cargo mutants` exits non-zero for informative
    outcomes as well as genuine failures: `0` all caught, `1` usage error, `2`
    mutants missed, `3` tests timed out, `4` baseline tests already failing,
-   `70` internal error. Because this workflow is informational, exit codes
-   `2` and `3` are treated as success (the survivors are the deliverable, not
-   a failure), while `1`, `4`, and `70` still fail the job so genuine faults
+   `70` internal error. Because this workflow is informational, exit codes `2`
+   and `3` are treated as success (the survivors are the deliverable, not a
+   failure), while `1`, `4`, and `70` still fail the job so genuine faults
    remain visible.
 4. **Artefact:** Uploads the `mutants.out/` directory (or directories) as
    GitHub Actions artefacts, preserving `outcomes.json` (machine-readable) and
@@ -413,13 +423,13 @@ jobs:
   semantically equivalent to the original (e.g. replacing `x + 0` with `x`).
   These require human triage and cannot be eliminated automatically.
 - **`wireframe_testing` false survivors:** The companion crate's logic is
-  exercised chiefly by the root crate's test suite; `wireframe_testing`
-  itself carries only a small number of in-crate tests. Because
-  `cargo mutants --dir wireframe_testing` runs only that package's own
-  tests, most mutants there will appear to survive even when the root
-  crate's tests would catch the fault. The `wireframe_testing` results
-  table is therefore advisory until the crate gains meaningful in-crate
-  coverage; treat its survivors with scepticism during triage.
+  exercised chiefly by the root crate's test suite; `wireframe_testing` itself
+  carries only a small number of in-crate tests. Because
+  `cargo mutants --dir wireframe_testing` runs only that package's own tests,
+  most mutants there will appear to survive even when the root crate's tests
+  would catch the fault. The `wireframe_testing` results table is therefore
+  advisory until the crate gains meaningful in-crate coverage; treat its
+  survivors with scepticism during triage.
 - **Runner cost:** Scheduled runs consume GitHub Actions minutes. The daily
   schedule starts every day, but the change-detection guard ensures the
   expensive mutation step only runs when `main` received relevant Rust source
@@ -429,18 +439,17 @@ jobs:
   timestamps, not author timestamps. Force-pushed or rebased commits may carry
   original timestamps outside the 25-hour window, and merge commits whose
   constituent commits were created earlier are similarly invisible (the
-  repository's squash-merge convention makes this unlikely in practice).
-  There is also no catch-up: if a scheduled run fails or is skipped, commits
-  from that window are never mutation-tested. A manual `workflow_dispatch`
-  run bypasses the guard entirely, providing the fallback in all these
-  cases. Diffing against the SHA of the last successful run (via the GitHub
-  API) would close the gap completely but was rejected as disproportionate
-  for an informational workflow.
+  repository's squash-merge convention makes this unlikely in practice). There
+  is also no catch-up: if a scheduled run fails or is skipped, commits from
+  that window are never mutation-tested. A manual `workflow_dispatch` run
+  bypasses the guard entirely, providing the fallback in all these cases.
+  Diffing against the SHA of the last successful run (via the GitHub API) would
+  close the gap completely but was rejected as disproportionate for an
+  informational workflow.
 - **Scheduled-workflow suspension:** GitHub automatically disables cron
-  triggers on repositories with no activity for 60 days. On a quiet
-  repository the workflow silently stops running until re-enabled — an
-  acceptable failure mode, since no code changes means nothing new to
-  mutate.
+  triggers on repositories with no activity for 60 days. On a quiet repository
+  the workflow silently stops running until re-enabled — an acceptable failure
+  mode, since no code changes means nothing new to mutate.
 - **Manifest-only changes:** Changes to `Cargo.toml` or `Cargo.lock` without
   accompanying Rust source changes are not detected. If a manifest change
   affects mutation outcomes (e.g. enabling a feature that changes conditional
@@ -456,9 +465,9 @@ jobs:
 - Exact `--timeout-multiplier` value — needs calibration against the current
   test suite runtime.
 - Whether to adopt `--in-diff` (line-level scoping from a diff) in place of
-  file-level `--file` scoping for scheduled runs, once the initial workflow
-  has proven itself. `--in-diff` tests only mutants on changed lines, which
-  is cheaper but misses mutants elsewhere in a changed file.
+  file-level `--file` scoping for scheduled runs, once the initial workflow has
+  proven itself. `--in-diff` tests only mutants on changed lines, which is
+  cheaper but misses mutants elsewhere in a changed file.
 - Whether full `workflow_dispatch` runs need `--shard` support to split the
   work across parallel jobs, should single-job runs approach the
   `timeout-minutes` ceiling.
@@ -480,26 +489,25 @@ jobs:
   changes landed on `main`, making quiet days a cheap no-op.
 - **Change detection mechanism:** Uses `git log --since="25 hours ago"` with
   commit timestamps rather than `origin/main@{25.hours.ago}` (which relies on
-  reflog state unavailable in fresh CI clones). The window exceeds the
-  24-hour cadence by one hour to absorb GitHub cron start-time drift;
-  occasional double-testing of a file is preferred over silently dropping a
-  commit. Files no longer present at the checked-out tip are filtered out
-  before scoping.
+  reflog state unavailable in fresh CI clones). The window exceeds the 24-hour
+  cadence by one hour to absorb GitHub cron start-time drift; occasional
+  double-testing of a file is preferred over silently dropping a commit. Files
+  no longer present at the checked-out tip are filtered out before scoping.
 - **Exit-code policy:** `cargo mutants` exit codes `2` (missed mutants) and
-  `3` (timeouts) are treated as success because the workflow is
-  informational — survivors are its output, not a failure. Exit codes `1`
-  (usage error), `4` (baseline tests failing), and `70` (internal error)
-  still fail the job so genuine faults surface as red runs.
+  `3` (timeouts) are treated as success because the workflow is informational —
+  survivors are its output, not a failure. Exit codes `1` (usage error), `4`
+  (baseline tests failing), and `70` (internal error) still fail the job so
+  genuine faults surface as red runs.
 - **Output directories:** The workflow relies on the default output
   locations (`./mutants.out/` for the root crate,
   `wireframe_testing/mutants.out/` for the companion crate) because
-  `--output DIR` creates `mutants.out/` _within_ `DIR` rather than renaming
-  it, which would otherwise nest the report one level deeper than the
-  summary and artefact steps expect.
+  `--output DIR` creates `mutants.out/` _within_ `DIR` rather than renaming it,
+  which would otherwise nest the report one level deeper than the summary and
+  artefact steps expect.
 - **Build strategy:** Runs use `--in-place`, the upstream recommendation for
   CI, so mutation builds reuse the runner's existing build cache instead of
-  copying the source tree. The job also sets `timeout-minutes: 300` as a
-  hard backstop against unbounded full runs.
+  copying the source tree. The job also sets `timeout-minutes: 300` as a hard
+  backstop against unbounded full runs.
 - **Code change definition:** The detection monitors `src/**/*.rs`,
   `wireframe_testing/src/**/*.rs`, `examples/**/*.rs`, and `benches/**/*.rs`.
   Manifest-only changes (`Cargo.toml`, `Cargo.lock`) are excluded because

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -178,52 +178,59 @@ continuous integration (CI).
 
 Scheduled mutation testing runs in CI via
 `.github/workflows/mutation-testing.yml` (see
-[ADR-007](adr-007-mutation-testing-with-cargo-mutants.md) for the design
-and its rationale). Key points for contributors:
+[ADR-007](adr-007-mutation-testing-with-cargo-mutants.md) for the design and
+its rationale). Key points for contributors:
 
 - The workflow is a thin caller of the shared reusable workflow
-  `leynos/shared-actions/.github/workflows/mutation-cargo.yml` (pinned
-  by commit SHA; caller guide in that repository's
-  `docs/mutation-cargo-workflow.md`). It is informational only: it
-  never gates pull requests, and surviving mutants do not fail the run.
-  Scheduled runs execute daily, scoped to Rust files changed in the
-  preceding 25 hours, and skip cheaply when nothing changed. Manual
-  dispatch (select the branch in the Actions "Run workflow" control)
-  runs full mutations, fanned out across six shards with one merged
-  summary.
+  `leynos/shared-actions/.github/workflows/mutation-cargo.yml` (pinned by
+  commit SHA; caller guide in that repository's
+  `docs/mutation-cargo-workflow.md`). It is informational only: it never gates
+  pull requests, and surviving mutants do not fail the run. Scheduled runs
+  execute daily, scoped to Rust files changed in the preceding 25 hours, and
+  skip cheaply when nothing changed. Manual dispatch (select the branch in the
+  Actions "Run workflow" control) runs full mutations, fanned out across eight
+  shards with one merged summary.
 - The caller passes `--all-features` so feature-gated tests (e.g. the
-  `serializer-serde` bridge round-trips) run against mutants, and
-  excludes the example/test-support scaffolding
-  (`src/codec/examples.rs`, `src/test_helpers.rs`,
-  `src/connection/test_support.rs`) whose survivors are noise — both
-  per issue #571.
+  `serializer-serde` bridge round-trips) run against mutants, and excludes the
+  example/test-support scaffolding whose survivors are noise — both per issue
+  #571: `src/codec/examples.rs`, `src/test_helpers.rs`, `src/test_helpers/**`
+  (the module-root glob does not match the directory's submodules),
+  `src/connection/test_support.rs`, and `src/**/tests.rs` (cfg(test) companion
+  files that cargo-mutants cannot detect as test code, #599). The contract test
+  `tests/workflow_contracts/mutation_testing_test.py` (run via
+  `make test-workflow-contracts`) pins this exclude list, the `--all-features`
+  extra-args, and the shard count.
+- Mutants proven equivalent (incapable of changing observable
+  behaviour) are annotated in source with `#[cfg_attr(test, mutants::skip)]`
+  plus a one-line justification. The attribute comes from the
+  [`mutants`](https://docs.rs/mutants) crate, a dev-dependency of no-op
+  decorator attributes; keep skips rare, justified, and reserved for stateless
+  equivalences — prefer a killing test wherever the mutation is observable.
 - [`cargo-mutants`](https://mutants.rs/) is a CI-runtime dependency
-  only, installed by the shared workflow at a pinned version; it is not
-  a Cargo dependency and is not required locally. To reproduce a run
-  locally, install it with `cargo install cargo-mutants` and run, for
-  example,
+  only, installed by the shared workflow at a pinned version; it is not a Cargo
+  dependency and is not required locally. To reproduce a run locally, install
+  it with `cargo install cargo-mutants` and run, for example,
   `cargo mutants --in-place --all-features --file src/frame/mod.rs`.
 - Results appear in the run's merged job summary (caught/missed/timeout
-  counts plus a table of surviving mutants per target) and as
-  downloadable `mutation-report-*` artefacts containing `mutants.out/`
-  (one per shard on full runs).
+  counts plus a table of surviving mutants per target) and as downloadable
+  `mutation-report-*` artefacts containing `mutants.out/` (one per shard on
+  full runs).
 - Surviving mutants are a test-improvement backlog: triage them for
   equivalent mutations (false survivors) before writing tests. Mutants in
-  `wireframe_testing` are mostly false survivors because that crate's
-  logic is exercised chiefly by the root crate's suite; treat its table
-  as advisory.
+  `wireframe_testing` are mostly false survivors because that crate's logic is
+  exercised chiefly by the root crate's suite; treat its table as advisory.
 
 ## Workflow pins and Dependabot
 
-Dependabot owns the upgrade of GitHub Actions and reusable workflows,
-including calls into `leynos/shared-actions`. Contract tests that assert a
-caller's exact commit SHA create a lockstep dependency: every time Dependabot
-opens a bump PR, the test fails until a human edits the pinned constant to
-match. That defeats the purpose of automated dependency updates and turns a
-routine bump into a manual chore.
+Dependabot owns the upgrade of GitHub Actions and reusable workflows, including
+calls into `leynos/shared-actions`. Contract tests that assert a caller's exact
+commit SHA create a lockstep dependency: every time Dependabot opens a bump PR,
+the test fails until a human edits the pinned constant to match. That defeats
+the purpose of automated dependency updates and turns a routine bump into a
+manual chore.
 
-Contract tests may still verify the *shape* of a reusable-workflow caller.
-They must not verify the specific SHA value.
+Contract tests may still verify the *shape* of a reusable-workflow caller. They
+must not verify the specific SHA value.
 
 - Do assert the workflow references the correct reusable workflow path.
 - Do assert the ref is pinned to a full 40-character commit SHA, not a

--- a/src/client/connect_parts.rs
+++ b/src/client/connect_parts.rs
@@ -20,6 +20,9 @@ use super::{
 };
 use crate::{rewind_stream::RewindStream, serializer::Serializer};
 
+// Equivalent mutant: a pre-allocation hint later min'd against the codec's
+// max_frame_length, so `*`→`+`/`/` cannot change observable behaviour.
+#[cfg_attr(test, mutants::skip)]
 const INITIAL_READ_BUFFER_CAPACITY: usize = 64 * 1024;
 
 /// Cloneable connection recipe used by pooled reconnect paths.

--- a/src/client/pool/slot.rs
+++ b/src/client/pool/slot.rs
@@ -174,7 +174,7 @@ mod tests {
         max_in_flight: usize,
         idle_timeout: Duration,
     ) -> Arc<PoolSlot<BincodeSerializer, (), ()>> {
-        let addr: SocketAddr = "127.0.0.1:1".parse().expect("valid address");
+        let addr = SocketAddr::from(([127, 0, 0, 1], 1));
         let parts = ClientBuildParts {
             serializer: BincodeSerializer,
             codec_config: ClientCodecConfig::default(),
@@ -219,7 +219,7 @@ mod tests {
     async fn clear_last_returned_at_resets_recycle_decision() {
         let slot = test_slot(1, Duration::from_millis(1));
 
-        *slot.lock_last_returned_at() = Some(tokio::time::Instant::now() - Duration::from_secs(60));
+        *slot.lock_last_returned_at() = Some(tokio::time::Instant::now() - Duration::from_mins(1));
         assert!(
             slot.should_recycle_idle(),
             "stale timestamp must trigger a recycle"

--- a/src/client/pool/slot.rs
+++ b/src/client/pool/slot.rs
@@ -47,9 +47,6 @@ where
         }
     }
 
-    // Equivalent mutant: the synchronous fast path; forcing `None` merely
-    // defers to the async `acquire_permit`, which yields an identical lease.
-    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn try_acquire_permit(self: &Arc<Self>) -> Option<OwnedSemaphorePermit> {
         self.permits.clone().try_acquire_owned().ok()
     }
@@ -98,9 +95,6 @@ where
             .is_some_and(|returned_at| returned_at.elapsed() >= self.idle_timeout)
     }
 
-    // Equivalent mutant: the cleared value is overwritten by SlotConnection's
-    // drop before any subsequent read, so an empty body is indistinguishable.
-    #[cfg_attr(test, mutants::skip)]
     fn clear_last_returned_at(&self) { *self.lock_last_returned_at() = None; }
 
     fn lock_last_returned_at(&self) -> MutexGuard<'_, Option<Instant>> {
@@ -152,5 +146,93 @@ where
         } else {
             *last_returned_at = Some(Instant::now());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for slot admission permits and idle-recycle bookkeeping.
+
+    use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+    use super::PoolSlot;
+    use crate::{
+        client::{
+            ClientCodecConfig,
+            SocketOptions,
+            connect_parts::ClientBuildParts,
+            hooks::{LifecycleHooks, RequestHooks},
+            pool::manager::WireframeConnectionManager,
+            tracing_config::TracingConfig,
+        },
+        serializer::BincodeSerializer,
+    };
+
+    /// Build a slot without connecting: `build_unchecked` creates the bb8
+    /// pool lazily, and these tests never touch the socket path.
+    fn test_slot(
+        max_in_flight: usize,
+        idle_timeout: Duration,
+    ) -> Arc<PoolSlot<BincodeSerializer, (), ()>> {
+        let addr: SocketAddr = "127.0.0.1:1".parse().expect("valid address");
+        let parts = ClientBuildParts {
+            serializer: BincodeSerializer,
+            codec_config: ClientCodecConfig::default(),
+            socket_options: SocketOptions::default(),
+            preamble_config: None,
+            lifecycle_hooks: LifecycleHooks::default(),
+            request_hooks: RequestHooks::default(),
+            tracing_config: TracingConfig::default(),
+        };
+        let pool = bb8::Pool::builder()
+            .max_size(1)
+            .build_unchecked(WireframeConnectionManager::new(addr, parts));
+        Arc::new(PoolSlot::new(pool, max_in_flight, idle_timeout))
+    }
+
+    /// The synchronous fast path must hand out a permit while capacity
+    /// remains and refuse once it is exhausted; forcing `None` would push
+    /// every acquire onto the waiting path.
+    #[tokio::test]
+    async fn try_acquire_permit_reflects_capacity() {
+        let slot = test_slot(1, Duration::from_secs(30));
+
+        let held = slot.try_acquire_permit();
+        assert!(held.is_some(), "fresh slot must yield an immediate permit");
+        assert!(
+            slot.try_acquire_permit().is_none(),
+            "exhausted slot must refuse an immediate permit"
+        );
+
+        drop(held);
+        assert!(
+            slot.try_acquire_permit().is_some(),
+            "released capacity must be immediately reusable"
+        );
+    }
+
+    /// Clearing the idle timestamp must reset the recycle decision; leaving
+    /// a stale timestamp would recycle the freshly created connection on the
+    /// next checkout after a recycle whose lease never sets a new timestamp
+    /// (for example when the replacement checkout fails).
+    #[tokio::test]
+    async fn clear_last_returned_at_resets_recycle_decision() {
+        let slot = test_slot(1, Duration::from_millis(1));
+
+        *slot.lock_last_returned_at() = Some(tokio::time::Instant::now() - Duration::from_secs(60));
+        assert!(
+            slot.should_recycle_idle(),
+            "stale timestamp must trigger a recycle"
+        );
+
+        slot.clear_last_returned_at();
+        assert!(
+            slot.lock_last_returned_at().is_none(),
+            "clear must remove the timestamp"
+        );
+        assert!(
+            !slot.should_recycle_idle(),
+            "cleared timestamp must not trigger a recycle"
+        );
     }
 }

--- a/src/client/pool/slot.rs
+++ b/src/client/pool/slot.rs
@@ -47,6 +47,9 @@ where
         }
     }
 
+    // Equivalent mutant: the synchronous fast path; forcing `None` merely
+    // defers to the async `acquire_permit`, which yields an identical lease.
+    #[cfg_attr(test, mutants::skip)]
     pub(crate) fn try_acquire_permit(self: &Arc<Self>) -> Option<OwnedSemaphorePermit> {
         self.permits.clone().try_acquire_owned().ok()
     }
@@ -95,6 +98,9 @@ where
             .is_some_and(|returned_at| returned_at.elapsed() >= self.idle_timeout)
     }
 
+    // Equivalent mutant: the cleared value is overwritten by SlotConnection's
+    // drop before any subsequent read, so an empty body is indistinguishable.
+    #[cfg_attr(test, mutants::skip)]
     fn clear_last_returned_at(&self) { *self.lock_last_returned_at() = None; }
 
     fn lock_last_returned_at(&self) -> MutexGuard<'_, Option<Instant>> {

--- a/src/client/runtime.rs
+++ b/src/client/runtime.rs
@@ -102,6 +102,9 @@ impl WireframeClient<BincodeSerializer, TcpStream, ()> {
     /// # Ok(())
     /// # }
     /// ```
+    // Equivalent mutant: `WireframeClientBuilder::new()` is literally what its
+    // `Default` impl returns, so `builder`→`Default::default()` is a no-op.
+    #[cfg_attr(test, mutants::skip)]
     #[must_use]
     pub fn builder() -> WireframeClientBuilder<BincodeSerializer, (), ()> {
         WireframeClientBuilder::new()

--- a/src/client/tests/mod.rs
+++ b/src/client/tests/mod.rs
@@ -10,6 +10,7 @@ mod pool;
 mod pool_handle;
 mod request_hooks;
 mod send_streaming;
+mod send_streaming_config;
 mod send_streaming_infra;
 mod streaming;
 mod streaming_helpers;

--- a/src/client/tests/send_streaming.rs
+++ b/src/client/tests/send_streaming.rs
@@ -385,3 +385,19 @@ async fn reports_frames_sent(protocol_header: Vec<u8>) -> TestResult {
 
     Ok(())
 }
+
+/// The `chunk_size` getter has no production callers (internal code reads the
+/// field directly), so its accessor mutants survive unless asserted directly.
+/// The neighbouring `timeout` getter is guarded the same way.
+#[test]
+fn config_accessors_reflect_builder() {
+    let default = SendStreamingConfig::default();
+    assert_eq!(default.chunk_size(), None, "default chunk size is unset");
+    assert_eq!(default.timeout(), None, "default timeout is unset");
+
+    let configured = SendStreamingConfig::default()
+        .with_chunk_size(4096)
+        .with_timeout(Duration::from_secs(3));
+    assert_eq!(configured.chunk_size(), Some(4096));
+    assert_eq!(configured.timeout(), Some(Duration::from_secs(3)));
+}

--- a/src/client/tests/send_streaming.rs
+++ b/src/client/tests/send_streaming.rs
@@ -385,19 +385,3 @@ async fn reports_frames_sent(protocol_header: Vec<u8>) -> TestResult {
 
     Ok(())
 }
-
-/// The `chunk_size` getter has no production callers (internal code reads the
-/// field directly), so its accessor mutants survive unless asserted directly.
-/// The neighbouring `timeout` getter is guarded the same way.
-#[test]
-fn config_accessors_reflect_builder() {
-    let default = SendStreamingConfig::default();
-    assert_eq!(default.chunk_size(), None, "default chunk size is unset");
-    assert_eq!(default.timeout(), None, "default timeout is unset");
-
-    let configured = SendStreamingConfig::default()
-        .with_chunk_size(4096)
-        .with_timeout(Duration::from_secs(3));
-    assert_eq!(configured.chunk_size(), Some(4096));
-    assert_eq!(configured.timeout(), Some(Duration::from_secs(3)));
-}

--- a/src/client/tests/send_streaming_config.rs
+++ b/src/client/tests/send_streaming_config.rs
@@ -1,0 +1,21 @@
+//! Unit tests for [`SendStreamingConfig`] accessors.
+
+use std::time::Duration;
+
+use crate::client::SendStreamingConfig;
+
+/// The `chunk_size` getter has no production callers (internal code reads the
+/// field directly), so its accessor mutants survive unless asserted directly.
+/// The neighbouring `timeout` getter is guarded the same way.
+#[test]
+fn config_accessors_reflect_builder() {
+    let default = SendStreamingConfig::default();
+    assert_eq!(default.chunk_size(), None, "default chunk size is unset");
+    assert_eq!(default.timeout(), None, "default timeout is unset");
+
+    let configured = SendStreamingConfig::default()
+        .with_chunk_size(4096)
+        .with_timeout(Duration::from_secs(3));
+    assert_eq!(configured.chunk_size(), Some(4096));
+    assert_eq!(configured.timeout(), Some(Duration::from_secs(3)));
+}

--- a/src/client/tests/streaming.rs
+++ b/src/client/tests/streaming.rs
@@ -99,6 +99,10 @@ async fn response_stream_terminates_on_terminator(
     assert!(first.is_some(), "should yield one data frame");
     assert!(first.expect("some").is_ok(), "data frame should be Ok");
 
+    // Mid-stream, before the terminator is polled, the stream must report
+    // that it has not terminated (guards the `is_terminated` false polarity).
+    assert!(!stream.is_terminated(), "stream should not be terminated mid-stream");
+
     // Second poll returns None (terminator consumed).
     let second = stream.next().await;
     assert!(second.is_none(), "stream should terminate after terminator");

--- a/src/client/tests/streaming.rs
+++ b/src/client/tests/streaming.rs
@@ -101,7 +101,10 @@ async fn response_stream_terminates_on_terminator(
 
     // Mid-stream, before the terminator is polled, the stream must report
     // that it has not terminated (guards the `is_terminated` false polarity).
-    assert!(!stream.is_terminated(), "stream should not be terminated mid-stream");
+    assert!(
+        !stream.is_terminated(),
+        "stream should not be terminated mid-stream"
+    );
 
     // Second poll returns None (terminator consumed).
     let second = stream.next().await;

--- a/src/codec/tests.rs
+++ b/src/codec/tests.rs
@@ -315,3 +315,15 @@ fn mysql_decode_produces_zero_copy_payload() {
 }
 
 mod property;
+
+/// The inherent `max_frame_length` shadows the `FrameCodec` trait method in
+/// direct calls, so the trait impl is only observable through trait dispatch.
+#[test]
+fn frame_codec_trait_max_frame_length_matches_configuration() {
+    let codec = LengthDelimitedFrameCodec::new(256);
+    // UFCS resolves to the trait method rather than the inherent one.
+    assert_eq!(
+        <LengthDelimitedFrameCodec as FrameCodec>::max_frame_length(&codec),
+        256,
+    );
+}

--- a/src/connection/multi_packet.rs
+++ b/src/connection/multi_packet.rs
@@ -78,12 +78,6 @@ impl<F> MultiPacketContext<F> {
     pub(super) fn channel_mut(&mut self) -> Option<&mut mpsc::Receiver<F>> { self.channel.as_mut() }
 
     /// Returns `true` if correlation stamping is enabled.
-    // Equivalent mutant (`is_stamping_enabled` → `true`): the only construction
-    // site installs the channel via `install(Some(rx), _)`, which always yields
-    // `Enabled`, so a `Disabled` stamp never coexists with an active channel.
-    // Every reachable call during frame processing therefore already returns
-    // `true`; forcing it changes nothing. See #569.
-    #[cfg_attr(test, mutants::skip)]
     pub(super) fn is_stamping_enabled(&self) -> bool {
         matches!(self.stamp, MultiPacketStamp::Enabled(_))
     }
@@ -93,5 +87,43 @@ impl<F> MultiPacketContext<F> {
             MultiPacketStamp::Enabled(value) => value,
             MultiPacketStamp::Disabled => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the stamping invariant: stamping is enabled exactly
+    //! when a channel is installed.
+
+    use tokio::sync::mpsc;
+
+    use super::MultiPacketContext;
+
+    #[test]
+    fn stamping_tracks_channel_installation() {
+        let mut ctx = MultiPacketContext::<u8>::new();
+        assert!(
+            !ctx.is_stamping_enabled(),
+            "a fresh context must not stamp frames"
+        );
+
+        let (_tx, rx) = mpsc::channel(1);
+        ctx.install(Some(rx), Some(7));
+        assert!(
+            ctx.is_stamping_enabled(),
+            "installing a channel must enable stamping"
+        );
+        assert_eq!(ctx.correlation_id(), Some(7));
+
+        ctx.install(None, Some(9));
+        assert!(
+            !ctx.is_stamping_enabled(),
+            "removing the channel must disable stamping"
+        );
+        assert_eq!(
+            ctx.correlation_id(),
+            None,
+            "a disabled context must not expose a correlation id"
+        );
     }
 }

--- a/src/connection/multi_packet.rs
+++ b/src/connection/multi_packet.rs
@@ -78,6 +78,12 @@ impl<F> MultiPacketContext<F> {
     pub(super) fn channel_mut(&mut self) -> Option<&mut mpsc::Receiver<F>> { self.channel.as_mut() }
 
     /// Returns `true` if correlation stamping is enabled.
+    // Equivalent mutant (`is_stamping_enabled` → `true`): the only construction
+    // site installs the channel via `install(Some(rx), _)`, which always yields
+    // `Enabled`, so a `Disabled` stamp never coexists with an active channel.
+    // Every reachable call during frame processing therefore already returns
+    // `true`; forcing it changes nothing. See #569.
+    #[cfg_attr(test, mutants::skip)]
     pub(super) fn is_stamping_enabled(&self) -> bool {
         matches!(self.stamp, MultiPacketStamp::Enabled(_))
     }

--- a/src/connection/test_support.rs
+++ b/src/connection/test_support.rs
@@ -213,6 +213,9 @@ impl ActorStateHarness {
     /// Mark a source as closed.
     pub fn mark_closed(&mut self) { self.state.mark_closed(); }
 
+    /// Begin shutdown, transitioning an active state to shutting-down.
+    pub fn start_shutdown(&mut self) { self.state.start_shutdown(); }
+
     /// Observe the current state snapshot.
     #[must_use]
     pub fn snapshot(&self) -> ActorStateSnapshot {

--- a/src/message_assembler/budget.rs
+++ b/src/message_assembler/budget.rs
@@ -21,7 +21,7 @@ pub(super) struct AggregateBudgets {
 
 impl AggregateBudgets {
     /// Returns `true` when at least one aggregate budget limit is configured.
-    // Equivalent mutant (`is_enabled` → `true`): a hot-path optimisation only;
+    // Equivalent mutant (`is_enabled` → `true`): a hot-path optimization only;
     // `check_aggregate_budgets` returns `Ok(())` when both budgets are `None`,
     // so forcing the gate on changes nothing observable.
     #[cfg_attr(test, mutants::skip)]

--- a/src/message_assembler/budget.rs
+++ b/src/message_assembler/budget.rs
@@ -21,6 +21,10 @@ pub(super) struct AggregateBudgets {
 
 impl AggregateBudgets {
     /// Returns `true` when at least one aggregate budget limit is configured.
+    // Equivalent mutant (`is_enabled` → `true`): a hot-path optimisation only;
+    // `check_aggregate_budgets` returns `Ok(())` when both budgets are `None`,
+    // so forcing the gate on changes nothing observable.
+    #[cfg_attr(test, mutants::skip)]
     pub(super) const fn is_enabled(&self) -> bool {
         self.connection.is_some() || self.in_flight.is_some()
     }

--- a/src/message_assembler/budget_enforcement_tests.rs
+++ b/src/message_assembler/budget_enforcement_tests.rs
@@ -12,6 +12,7 @@ use super::{
     nz,
     submit_first,
     submit_first_at,
+    submit_first_with_total,
     unbounded_state,
 };
 use crate::message_assembler::{
@@ -302,4 +303,64 @@ fn single_frame_message_not_subject_to_aggregate_budgets(
 
     // Buffered bytes unchanged (single-frame was never buffered)
     assert_eq!(state.total_buffered_bytes(), 19);
+}
+
+// =============================================================================
+// Boundary-equality cases (`>` must not become `>=`)
+// =============================================================================
+
+/// A first frame whose body exactly fills the connection budget must be
+/// accepted; the guard is `new_total > limit`, so a `>=` mutant would wrongly
+/// reject the exact-fit case.
+#[rstest]
+fn connection_budget_accepts_exact_fit(
+    #[from(connection_budgeted_state)] mut state: MessageAssemblyState,
+) {
+    submit_first(&mut state, 1, &[0u8; 20], false).expect("exact-fit frame accepted");
+    assert_eq!(state.buffered_count(), 1);
+    assert_eq!(state.total_buffered_bytes(), 20);
+}
+
+/// A message that reassembles to exactly the per-message size limit must
+/// complete; the size guard is `new_len > max`, so a `>=` mutant would reject
+/// the exact-limit assembly.
+#[test]
+fn size_limit_accepts_exact_total() {
+    let mut state = MessageAssemblyState::new(nz(10), Duration::from_secs(30));
+    submit_first(&mut state, 1, &[0u8; 5], false).expect("first frame within limit");
+
+    let cont = continuation_header(1, 1, 5, true);
+    let msg = state
+        .accept_continuation_frame(&cont, &[0u8; 5])
+        .expect("continuation accepted")
+        .expect("message completes at exact limit");
+    assert_eq!(msg.body().len(), 10);
+}
+
+/// A first frame declaring a total body length equal to the per-message limit
+/// must pass early validation; `accept_first_frame`'s guard is
+/// `total_message_size > max`, so a `>=` mutant would reject the exact case.
+#[test]
+fn declared_total_at_size_limit_is_accepted() {
+    let mut state = MessageAssemblyState::new(nz(10), Duration::from_secs(30));
+    submit_first_with_total(&mut state, 1, &[], 10).expect("declared exact total accepted");
+}
+
+// =============================================================================
+// Wall-clock purge (no-argument variant)
+// =============================================================================
+
+/// The no-argument `purge_expired()` reads the wall clock; with a zero timeout
+/// a buffered assembly is immediately expired, so it must return the evicted
+/// key and empty the state (guards the `-> vec![]` mutant).
+#[test]
+fn wall_clock_purge_evicts_expired_assembly() {
+    let mut state = MessageAssemblyState::new(nz(1024), Duration::ZERO);
+    submit_first(&mut state, 7, &[0u8; 5], false).expect("buffered first frame");
+    assert_eq!(state.buffered_count(), 1);
+
+    let evicted = state.purge_expired();
+    assert_eq!(evicted, vec![MessageKey(7)]);
+    assert_eq!(state.buffered_count(), 0);
+    assert_eq!(state.total_buffered_bytes(), 0);
 }

--- a/src/message_assembler/budget_enforcement_tests.rs
+++ b/src/message_assembler/budget_enforcement_tests.rs
@@ -12,14 +12,15 @@ use super::{
     nz,
     submit_first,
     submit_first_at,
-    submit_first_with_total,
     unbounded_state,
 };
 use crate::message_assembler::{
+    EnvelopeRouting,
+    FirstFrameInput,
     MessageAssemblyError,
     MessageAssemblyState,
     MessageKey,
-    test_helpers::continuation_header,
+    test_helpers::{continuation_header, first_header_with_total},
 };
 
 // =============================================================================
@@ -343,7 +344,12 @@ fn size_limit_accepts_exact_total() {
 #[test]
 fn declared_total_at_size_limit_is_accepted() {
     let mut state = MessageAssemblyState::new(nz(10), Duration::from_secs(30));
-    submit_first_with_total(&mut state, 1, &[], 10).expect("declared exact total accepted");
+    let header = first_header_with_total(1, 0, 10);
+    let input = FirstFrameInput::new(&header, EnvelopeRouting::default(), vec![], &[])
+        .expect("valid first-frame input");
+    state
+        .accept_first_frame(input)
+        .expect("declared exact total accepted");
 }
 
 // =============================================================================

--- a/src/message_assembler/budget_tests.rs
+++ b/src/message_assembler/budget_tests.rs
@@ -62,7 +62,8 @@ fn submit_first_with_total(
 ) -> Result<Option<crate::message_assembler::AssembledMessage>, MessageAssemblyError> {
     let header =
         crate::message_assembler::test_helpers::first_header_with_total(key, body.len(), total);
-    let input = FirstFrameInput::new(&header, EnvelopeRouting::default(), vec![], body).unwrap();
+    let input = FirstFrameInput::new(&header, EnvelopeRouting::default(), vec![], body)
+        .expect("valid first-frame input");
     state.accept_first_frame(input)
 }
 

--- a/src/message_assembler/budget_tests.rs
+++ b/src/message_assembler/budget_tests.rs
@@ -52,21 +52,6 @@ fn submit_first(
     state.accept_first_frame(input)
 }
 
-/// Submit a first frame that declares a `total` body length up front,
-/// exercising the early size-limit validation on the first frame.
-fn submit_first_with_total(
-    state: &mut MessageAssemblyState,
-    key: u64,
-    body: &[u8],
-    total: usize,
-) -> Result<Option<crate::message_assembler::AssembledMessage>, MessageAssemblyError> {
-    let header =
-        crate::message_assembler::test_helpers::first_header_with_total(key, body.len(), total);
-    let input = FirstFrameInput::new(&header, EnvelopeRouting::default(), vec![], body)
-        .expect("valid first-frame input");
-    state.accept_first_frame(input)
-}
-
 /// Submit a first frame at a specific timestamp.
 fn submit_first_at(
     state: &mut MessageAssemblyState,

--- a/src/message_assembler/budget_tests.rs
+++ b/src/message_assembler/budget_tests.rs
@@ -52,6 +52,20 @@ fn submit_first(
     state.accept_first_frame(input)
 }
 
+/// Submit a first frame that declares a `total` body length up front,
+/// exercising the early size-limit validation on the first frame.
+fn submit_first_with_total(
+    state: &mut MessageAssemblyState,
+    key: u64,
+    body: &[u8],
+    total: usize,
+) -> Result<Option<crate::message_assembler::AssembledMessage>, MessageAssemblyError> {
+    let header =
+        crate::message_assembler::test_helpers::first_header_with_total(key, body.len(), total);
+    let input = FirstFrameInput::new(&header, EnvelopeRouting::default(), vec![], body).unwrap();
+    state.accept_first_frame(input)
+}
+
 /// Submit a first frame at a specific timestamp.
 fn submit_first_at(
     state: &mut MessageAssemblyState,

--- a/src/push/queues/mod.rs
+++ b/src/push/queues/mod.rs
@@ -113,6 +113,9 @@ impl<F> PushQueueConfig<F> {
 
 impl<F: FrameLike> PushQueues<F> {
     /// Start building a new set of push queues.
+    // Equivalent mutant: `from(Default::default())` reduces to the same value
+    // via the blanket `From<T> for T` identity, so it is indistinguishable.
+    #[cfg_attr(test, mutants::skip)]
     #[must_use]
     pub fn builder() -> PushQueuesBuilder<F> { PushQueuesBuilder::default() }
 

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -356,6 +356,10 @@ impl RequestParts {
         self
     }
 
+    // Equivalent mutant (`found != expected` guard → `true`): when the ids are
+    // equal the data path is identical to the mismatch arm bar a spurious
+    // `warn!`, so the returned correlation is unchanged.
+    #[cfg_attr(test, mutants::skip)]
     #[inline]
     fn select_correlation(current: Option<u64>, source: Option<u64>) -> CorrelationResult {
         match (current, source) {

--- a/src/server/runtime/backoff.rs
+++ b/src/server/runtime/backoff.rs
@@ -53,6 +53,9 @@ impl BackoffConfig {
     /// assert_eq!(normalized.initial_delay, Duration::from_millis(1));
     /// assert_eq!(normalized.max_delay, Duration::from_millis(5));
     /// ```
+    // Equivalent mutant (`initial_delay > max_delay` → `>=`): when the two
+    // durations are equal the swap moves identical values, a no-op.
+    #[cfg_attr(test, mutants::skip)]
     #[must_use]
     pub fn normalized(mut self) -> Self {
         self.initial_delay = self.initial_delay.max(Duration::from_millis(1));

--- a/src/session.rs
+++ b/src/session.rs
@@ -93,6 +93,11 @@ impl<F: FrameLike> SessionRegistry<F> {
     /// registry.insert(id, &handle);
     /// assert!(registry.get(&id).is_some());
     /// ```
+    // Equivalent mutant (`strong_count() == 0` → `!=`): assessed in #566. The
+    // opportunistic removal only runs once the handle has already failed to
+    // upgrade, so `get` returns `None` regardless; the sole difference is a
+    // lingering dead entry that later pruning reclaims.
+    #[cfg_attr(test, mutants::skip)]
     pub fn get(&self, id: &ConnectionId) -> Option<PushHandle<F>> {
         let guard = self.0.get(id);
         let handle = guard.as_ref().and_then(|weak| weak.upgrade());

--- a/src/session.rs
+++ b/src/session.rs
@@ -93,11 +93,6 @@ impl<F: FrameLike> SessionRegistry<F> {
     /// registry.insert(id, &handle);
     /// assert!(registry.get(&id).is_some());
     /// ```
-    // Equivalent mutant (`strong_count() == 0` → `!=`): assessed in #566. The
-    // opportunistic removal only runs once the handle has already failed to
-    // upgrade, so `get` returns `None` regardless; the sole difference is a
-    // lingering dead entry that later pruning reclaims.
-    #[cfg_attr(test, mutants::skip)]
     pub fn get(&self, id: &ConnectionId) -> Option<PushHandle<F>> {
         let guard = self.0.get(id);
         let handle = guard.as_ref().and_then(|weak| weak.upgrade());
@@ -258,4 +253,36 @@ impl<F: FrameLike> SessionRegistry<F> {
     /// ```
     #[must_use]
     pub fn active_ids(&self) -> Vec<ConnectionId> { self.retain_and_collect(|id, _| id) }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for lazy dead-entry cleanup in the session registry.
+
+    use super::{ConnectionId, SessionRegistry};
+    use crate::push::PushQueues;
+
+    /// A failed lookup must also evict the dead weak entry; retaining it
+    /// grows the registry until a later `prune`, which is the observable
+    /// difference the `strong_count() == 0` guard protects.
+    #[tokio::test]
+    async fn get_evicts_dead_entry_from_registry() {
+        let registry = SessionRegistry::<u8>::default();
+        let id = ConnectionId::new(1);
+
+        let (queues, handle) = PushQueues::<u8>::builder()
+            .high_capacity(1)
+            .low_capacity(1)
+            .build()
+            .expect("failed to build PushQueues");
+        registry.insert(id, &handle);
+        drop(handle);
+        drop(queues);
+
+        assert!(registry.get(&id).is_none(), "dead handle must not upgrade");
+        assert!(
+            registry.0.is_empty(),
+            "failed lookup must evict the dead entry rather than leave it to prune"
+        );
+    }
 }

--- a/tests/codec_error.rs
+++ b/tests/codec_error.rs
@@ -175,6 +175,40 @@ fn wireframe_error_from_codec_method() {
 }
 
 #[test]
+fn wireframe_error_io_is_not_clean_close() {
+    use wireframe::WireframeError;
+
+    // The Io wrapper never represents a clean close, so `is_clean_close`
+    // forced to a constant `true` must fail here.
+    let wf_err: WireframeError<()> = WireframeError::from_io(io::Error::other("reset"));
+
+    assert!(!wf_err.is_clean_close());
+}
+
+#[test]
+fn wireframe_error_from_mid_frame_codec_is_not_clean_close() {
+    use wireframe::WireframeError;
+
+    // A non-EOF codec error wrapped at the `WireframeError` level must
+    // still report `false`, guarding the wrapper's own polarity.
+    let codec_err = CodecError::Framing(FramingError::InvalidLengthEncoding);
+    let wf_err: WireframeError<()> = WireframeError::from_codec(codec_err);
+
+    assert!(!wf_err.is_clean_close());
+}
+
+#[test]
+fn wireframe_error_protocol_is_not_clean_close() {
+    use wireframe::WireframeError;
+
+    // The Protocol variant carries no codec error, so the `matches!`
+    // guard must reject it.
+    let wf_err: WireframeError<&str> = WireframeError::from("boom");
+
+    assert!(!wf_err.is_clean_close());
+}
+
+#[test]
 fn wireframe_error_codec_variant_displays_correctly() {
     use wireframe::WireframeError;
 

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -519,6 +519,21 @@ async fn poll_queue_returns_none_after_close() {
     assert!(value.is_none());
 }
 
+#[test]
+fn actor_state_reports_shutting_down_after_start_shutdown() {
+    // `is_shutting_down` is only ever asserted false elsewhere; drive the
+    // transition and assert the positive polarity so a constant-`false`
+    // mutant cannot survive.
+    let mut harness = ActorStateHarness::new(false, false);
+    assert!(!harness.snapshot().is_shutting_down, "should start active");
+
+    harness.start_shutdown();
+    let snapshot = harness.snapshot();
+    assert!(snapshot.is_shutting_down, "should be shutting down");
+    assert!(!snapshot.is_active, "shutting down is not active");
+    assert!(!snapshot.is_done, "shutting down is not done");
+}
+
 #[rstest(
     has_multi,
     expected_marks,

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -90,3 +90,15 @@ fn shared_state_missing_error(request: MessageRequest, mut empty_payload: Payloa
         _ => panic!("unexpected error"),
     }
 }
+
+/// `take_body_stream` yields the stream exactly once; the second call must
+/// return `None`, guarding against a mutant that always reports `None`.
+#[test]
+fn take_body_stream_returns_stream_once() {
+    let mut req = MessageRequest::default();
+    let (_tx, stream) = wireframe::request::body_channel(4);
+    req.set_body_stream(stream);
+
+    assert!(req.take_body_stream().is_some(), "first take should yield the stream");
+    assert!(req.take_body_stream().is_none(), "second take should be empty");
+}

--- a/tests/extractor.rs
+++ b/tests/extractor.rs
@@ -99,6 +99,12 @@ fn take_body_stream_returns_stream_once() {
     let (_tx, stream) = wireframe::request::body_channel(4);
     req.set_body_stream(stream);
 
-    assert!(req.take_body_stream().is_some(), "first take should yield the stream");
-    assert!(req.take_body_stream().is_none(), "second take should be empty");
+    assert!(
+        req.take_body_stream().is_some(),
+        "first take should yield the stream"
+    );
+    assert!(
+        req.take_body_stream().is_none(),
+        "second take should be empty"
+    );
 }

--- a/tests/middleware.rs
+++ b/tests/middleware.rs
@@ -74,3 +74,11 @@ fn service_request_setter_updates_correlation_id() {
     let _ = req.set_correlation_id(None);
     assert_eq!(req.correlation_id(), None);
 }
+
+/// The `frame` accessor has no production callers, so a mutant returning a
+/// leaked constant vector survives unless asserted directly.
+#[test]
+fn service_request_frame_borrows_original_bytes() {
+    let req = ServiceRequest::new(vec![1, 2, 3], None);
+    assert_eq!(req.frame(), &[1, 2, 3]);
+}

--- a/tests/packet_parts.rs
+++ b/tests/packet_parts.rs
@@ -4,6 +4,15 @@
 use wireframe::app::{Envelope, Packet, PacketParts};
 
 #[test]
+fn plain_envelope_is_not_a_stream_terminator() {
+    // `Envelope` does not override the `Packet::is_stream_terminator` default,
+    // so a plain data envelope must report `false`. Terminator tests all use
+    // types that override the method, leaving the default's false case unguarded.
+    let env = Envelope::new(1, None, vec![42]);
+    assert!(!env.is_stream_terminator());
+}
+
+#[test]
 fn envelope_from_parts_round_trip() {
     let env = Envelope::new(2, Some(5), vec![1, 2]);
     let parts = env.into_parts();

--- a/tests/serializer.rs
+++ b/tests/serializer.rs
@@ -1,0 +1,13 @@
+//! Tests for serializer configuration accessors.
+//!
+//! The `should_deserialize_after_parse` override on [`BincodeSerializer`] is
+//! consumed by the inbound handler but never asserted, so a mutant forcing it
+//! to the trait default (`true`) survives without a direct check.
+#![cfg(not(loom))]
+
+use wireframe::serializer::{BincodeSerializer, Serializer};
+
+#[test]
+fn bincode_serializer_does_not_deserialize_after_parse() {
+    assert!(!BincodeSerializer.should_deserialize_after_parse());
+}

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -234,36 +234,38 @@ impl wireframe::message_assembler::MessageAssembler for DemoAssembler {
 }
 
 #[rstest]
-fn protocol_accessor_reflects_installation() -> TestResult<()> {
+fn protocol_accessor_reflects_installation() {
     // A bare builder installs no protocol; the accessor must report `None`
     // rather than a constant, and `Some` once one is installed.
-    let bare = TestApp::new()?;
+    let bare = TestApp::new().expect("builder");
     assert!(
         bare.protocol().is_none(),
         "bare builder should have no protocol"
     );
 
     let counter = Arc::new(AtomicUsize::new(0));
-    let app = TestApp::new()?.with_protocol(TestProtocol { counter });
+    let app = TestApp::new()
+        .expect("builder")
+        .with_protocol(TestProtocol { counter });
     assert!(
         app.protocol().is_some(),
         "installed protocol should be visible"
     );
-    Ok(())
 }
 
 #[rstest]
-fn message_assembler_accessor_reflects_installation() -> TestResult<()> {
-    let bare = TestApp::new()?;
+fn message_assembler_accessor_reflects_installation() {
+    let bare = TestApp::new().expect("builder");
     assert!(
         bare.message_assembler().is_none(),
         "bare builder should have no assembler"
     );
 
-    let app = TestApp::new()?.with_message_assembler(DemoAssembler);
+    let app = TestApp::new()
+        .expect("builder")
+        .with_message_assembler(DemoAssembler);
     assert!(
         app.message_assembler().is_some(),
         "installed assembler should be visible"
     );
-    Ok(())
 }

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -238,11 +238,17 @@ fn protocol_accessor_reflects_installation() -> TestResult<()> {
     // A bare builder installs no protocol; the accessor must report `None`
     // rather than a constant, and `Some` once one is installed.
     let bare = TestApp::new()?;
-    assert!(bare.protocol().is_none(), "bare builder should have no protocol");
+    assert!(
+        bare.protocol().is_none(),
+        "bare builder should have no protocol"
+    );
 
     let counter = Arc::new(AtomicUsize::new(0));
     let app = TestApp::new()?.with_protocol(TestProtocol { counter });
-    assert!(app.protocol().is_some(), "installed protocol should be visible");
+    assert!(
+        app.protocol().is_some(),
+        "installed protocol should be visible"
+    );
     Ok(())
 }
 

--- a/tests/wireframe_protocol.rs
+++ b/tests/wireframe_protocol.rs
@@ -220,3 +220,44 @@ async fn connection_actor_uses_protocol_from_builder(queues: QueueResult) -> Tes
     );
     Ok(())
 }
+
+/// A no-op assembler used purely to exercise the `message_assembler` accessor.
+struct DemoAssembler;
+
+impl wireframe::message_assembler::MessageAssembler for DemoAssembler {
+    fn parse_frame_header(
+        &self,
+        _payload: &[u8],
+    ) -> Result<wireframe::message_assembler::ParsedFrameHeader, io::Error> {
+        Err(io::Error::new(io::ErrorKind::InvalidData, "unimplemented"))
+    }
+}
+
+#[rstest]
+fn protocol_accessor_reflects_installation() -> TestResult<()> {
+    // A bare builder installs no protocol; the accessor must report `None`
+    // rather than a constant, and `Some` once one is installed.
+    let bare = TestApp::new()?;
+    assert!(bare.protocol().is_none(), "bare builder should have no protocol");
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let app = TestApp::new()?.with_protocol(TestProtocol { counter });
+    assert!(app.protocol().is_some(), "installed protocol should be visible");
+    Ok(())
+}
+
+#[rstest]
+fn message_assembler_accessor_reflects_installation() -> TestResult<()> {
+    let bare = TestApp::new()?;
+    assert!(
+        bare.message_assembler().is_none(),
+        "bare builder should have no assembler"
+    );
+
+    let app = TestApp::new()?.with_message_assembler(DemoAssembler);
+    assert!(
+        app.message_assembler().is_some(),
+        "installed assembler should be visible"
+    );
+    Ok(())
+}

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -30,8 +30,14 @@ USES_RE = re.compile(
 
 SCAFFOLDING_EXCLUDES = (
     "src/test_helpers.rs",
+    # The module-root glob above matches only src/test_helpers.rs; the
+    # directory glob covers the helper submodules (#599).
+    "src/test_helpers/**",
     "src/connection/test_support.rs",
     "src/codec/examples.rs",
+    # cfg(test)-only test modules split into companion files, which
+    # cargo-mutants cannot detect as test code (#599).
+    "src/**/tests.rs",
 )
 
 


### PR DESCRIPTION
## Summary

Addresses #566, #567, #569, #570, #593, #595, and #598, plus the
mutation-testing worklist's scaffolding-exclude and equivalent-mutant items
(dataset: run 29074771985, `main` @ 94a5d44). This is a survivor-triage pass:
it kills the highest-value category-1 survivors, annotates equivalent
mutants, and widens the caller's scaffolding exclude-globs. Survivors that
need heavy asynchronous or fragmentation harnesses are deferred to their
issues (listed below) to stay within the survivor-triage tolerance.

## Review walkthrough

### Scaffolding exclude-glob fix (32 noise survivors)

The `src/test_helpers.rs` exclude glob matched only the module root, so the
`src/test_helpers/` submodules (22 noise survivors) and the cfg(test)-only
companion `tests.rs` files (10 survivors) were still mutated. The
[caller workflow](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/.github/workflows/mutation-testing.yml)
now excludes `src/test_helpers/**` and a repo-wide `src/**/tests.rs`, and the
[workflow contract test](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/workflow_contracts/mutation_testing_test.py)
pins both. `make test-workflow-contracts` passes.

### Category 1: survivors killed (before → after, per file)

| Issue | Survivor | File | Before | After |
|---|---|---|---|---|
| #567 | `WireframeError::is_clean_close` → `true` | [src/error.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/error.rs) | 1 | 0 |
| #598 | `protocol()` / `message_assembler()` → `None` | [src/app/builder/protocol.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/app/builder/protocol.rs) | 2 | 0 |
| #598 | trait `max_frame_length` → `0`/`1` | [src/codec.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/codec.rs) | 2 | 0 |
| #598 | `ServiceRequest::frame` → leaked vecs | [src/middleware.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/middleware.rs) | 3 | 0 |
| #598 | `should_deserialize_after_parse` → `true` | [src/serializer.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/serializer.rs) | 1 | 0 |
| #598 | `take_body_stream` → `None` | [src/extractor/request.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/extractor/request.rs) | 1 | 0 |
| #569 | `Packet::is_stream_terminator` → `true` | [src/app/envelope.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/app/envelope.rs) | 1 | 0 |
| #569 | `is_terminated` → `true` (mid-stream) | [src/client/response_stream.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/client/response_stream.rs) | 1 | 0 |
| #569 | `is_shutting_down` → `false` | [src/connection/state.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/connection/state.rs) | 1 | 0 |
| #593, #570 | `chunk_size` → `None`/`Some(0)`/`Some(1)`; `timeout` → `None` | [src/client/send_streaming.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/client/send_streaming.rs) | 4 | 0 |
| #595 | `check_aggregate_budgets` / `check_size_limit` `>` → `>=` | [src/message_assembler/budget.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/message_assembler/budget.rs) | 2 | 0 |
| #595 | `accept_first_frame_at` `>` → `>=`; `purge_expired` → `vec![]` | [src/message_assembler/state.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/message_assembler/state.rs) | 2 | 0 |

Totals for the files touched by this PR: 21 targeted survivors before, 0
after (confirmed by scoped re-runs, see Validation).

New tests live in
[tests/codec_error.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/codec_error.rs),
[tests/wireframe_protocol.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/wireframe_protocol.rs),
[tests/middleware.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/middleware.rs),
[tests/serializer.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/serializer.rs) (new file),
[tests/extractor.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/extractor.rs),
[tests/packet_parts.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/packet_parts.rs),
[tests/connection.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/tests/connection.rs),
[src/codec/tests.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/codec/tests.rs),
[src/client/tests/streaming.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/client/tests/streaming.rs),
[src/client/tests/send_streaming.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/client/tests/send_streaming.rs), and
[src/message_assembler/budget_enforcement_tests.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/message_assembler/budget_enforcement_tests.rs).
A small `start_shutdown` helper was added to
[src/connection/test_support.rs](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/src/connection/test_support.rs)
to drive the shutting-down polarity.

### Category 2: equivalent mutants annotated

Marked with `#[cfg_attr(test, mutants::skip)]` (new `mutants = "0.0.4"`
dev-dependency; no production dependency) with a one-line justification each:

- `src/client/connect_parts.rs` — `INITIAL_READ_BUFFER_CAPACITY` (pre-allocation hint, min'd against `max_frame_length`; pure constant arithmetic)
- `src/client/runtime.rs` — `builder` (`Default` is literally `Self::new()`; pure constructor identity)
- `src/push/queues/mod.rs` — `builder` (blanket `From<T> for T` identity; pure constructor identity)
- `src/request/mod.rs` — `select_correlation` guard (pure function; the equal-id path returns the identical value bar a spurious `warn!`)
- `src/server/runtime/backoff.rs` — `normalized` (pure function; the `>=` variant swaps two equal `Duration`s, a no-op)
- `src/message_assembler/budget.rs` — `is_enabled` (#595 accepted; pure function over two `Option`s guarding a hot-path shortcut whose slow path returns the same result)

All six retained skips are **stateless equivalences of pure functions or
constants** — the mutated expression's value is provably identical for every
input, so no example, property, or model-checking harness could distinguish
them; a justification comment is the proportionate evidence.

Four skips originally proposed here were **removed in review** and replaced
with unit tests that kill the mutants (red-green verified, scoped
`cargo mutants` confirmed):

- `src/client/pool/slot.rs` `try_acquire_permit` — the reviewer is right that
  forcing `None` removes the non-blocking fast path; a permit-capacity unit
  test now kills all variants.
- `src/client/pool/slot.rs` `clear_last_returned_at` — a stale timestamp can
  trigger a spurious recycle of a fresh connection whose lease never wrote a
  new timestamp; a recycle-decision unit test now kills the empty-body mutant.
- `src/session.rs` `get` cleanup predicate — retaining the dead weak entry
  grows the registry until a later `prune`; a unit test asserts the failed
  lookup evicts the entry.
- `src/connection/multi_packet.rs` `is_stamping_enabled` — although the
  disabled polarity is unreachable through today's actor API, it is directly
  assertable at unit level, so a stamping-invariant test replaces the
  reachability argument.

### Deferred to the issues (outside this PR's tolerance)

- **#593** — `client_pool.rs:149` `is_shutdown`, `client_pool.rs:187`
  `ordered_slots` rotation, `scheduler.rs:210` `notify_shutdown`: need a live
  pool + test-server harness across a shutdown. `scheduler.rs:101`
  `has_waiters` remains accepted (loom-only) per the issue.
- **#595** — `codec_driver.rs:87` `FramePipeline::purge_expired` delegation:
  needs a fragmentation pipeline with an injected partial reassembly.
- **#570** — `client/hooks.rs:111` `LifecycleHooks::clone`: needs a
  pool-recycle reconnect test asserting a configured hook still fires.
- **#596** — `fragment/adapter.rs:133` trait `purge_expired`:
  `FragmentAdapter` is public API, so deleting the never-dispatched impl is a
  breaking change; a dyn-dispatch test is the non-breaking alternative.
- **#564, #565, #566 (prune), #568, #594, #597, #599's remaining areas** —
  untouched here; their issues remain open with full analyses.

## Validation

- Red-green per module: each mutant hand-applied, new test observed failing,
  mutant reverted, test observed passing. Transcript for #567 (`src/error.rs`,
  `is_clean_close` body → `true`):

  ```text
  $ cargo test --test codec_error --all-features wireframe_error_
  test result: FAILED. 2 passed; 3 failed
      wireframe_error_io_is_not_clean_close
      wireframe_error_from_mid_frame_codec_is_not_clean_close
      wireframe_error_protocol_is_not_clean_close
  # mutant reverted
  $ cargo test --test codec_error --all-features wireframe_error_
  test result: ok. 5 passed; 0 failed
  ```

- Scoped `cargo mutants --all-features` confirmation over the touched files,
  filtered to the targeted functions:
  - #567 + #598 files: 24 mutants tested — 20 caught, 4 unviable, **0 missed**.
  - #569 + #593 + #595 files: 42 mutants tested — 35 caught, 6 unviable,
    1 timeout, **0 missed**. The timeout is `is_shutting_down` → `true`,
    which #569 already documents as the timing-out variant (the surviving
    `false` variant is now caught).
  - Review follow-up files (`pool/slot.rs`, `session.rs`,
    `multi_packet.rs` after de-skipping): all targeted mutants caught,
    **0 missed** (see the review-response comment for the run summary).
- `make check-fmt`, `make lint` (clippy + whitaker), `make test`
  (`--all-targets --all-features`), `make test-doc`,
  `make test-workflow-contracts`, and `make markdownlint` all pass.

## Documentation

The [developers' guide](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/docs/developers-guide.md)
mutation-testing section and
[ADR-007](https://github.com/leynos/wireframe/blob/kill-mutation-survivors/docs/adr-007-mutation-testing-with-cargo-mutants.md)
now record the eight-shard dispatch fan-out, the widened exclude-globs, the
workflow contract test, and the `mutants::skip` annotation convention with its
dev-dependency.

No production behaviour changed: every non-test source edit is either a
`mutants::skip` annotation with a justification comment or a `#[cfg(test)]`
module.
