### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.1'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       # Full history is required for the CodeScene `cs-coverage check` gate,
       # which diffs a pull request against its merge base.


### PR DESCRIPTION
## What changed and why

Whitaker's rolling release now pins toolchain `nightly-2026-05-28`, which
requires `cargo-dylint` 6.0.1. The CI-pinned `whitaker-installer` version
provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that
nightly, so the CI lint step has been failing. `whitaker-installer` 0.2.6
fixes this by provisioning `cargo-dylint` 6.0.1, and its prebuilt
dependency binaries are now published.

This bumps `WHITAKER_INSTALLER_VERSION` from `0.2.1` to `0.2.6` in the CI
workflow so the cached installer, and the `cargo binstall` fallback, pull
in the fixed version.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/wireframe/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
