### PR TITLE
Design protocol-agnostic wireframe_testing harness lifecycle

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -35,7 +35,7 @@ reference when navigating the project's design and architecture material.
 - [ADR 001: multi-packet streaming response API](adr-001-multi-packet-streaming-response-api.md)
   Accepted response API for multi-packet and streaming replies.
 - [ADR 002: streaming requests and shared message assembly](adr-002-streaming-requests-and-shared-message-assembly.md)
-  Decision for streaming requests and shared assembly behaviour.
+  Decision for request streaming and shared assembly behaviour.
 - [ADR 003: replace Cucumber with rstest-bdd](adr-003-replace-cucumber-with-rstest-bdd.md)
   Decision to use Rust-native behaviour-driven development (BDD) tests.
 - [ADR 004: pluggable protocol codecs](adr-004-pluggable-protocol-codecs.md)

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -86,8 +86,8 @@ the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
   fixtures for clean tests.
 - [Mocking network outages](mocking-network-outages-in-rust.md) Tutorial for
   simulating network outages in tests.
-- [Testing helpers](wireframe-testing-crate.md) Design and public API for the
-  `wireframe_testing` companion crate.
+- [Testing helpers](wireframe-testing-crate.md) In-process server and client
+  pair helpers provided by the `wireframe_testing` companion crate.
 
 ## Operations and resilience
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -24,11 +24,9 @@ reference when navigating the project's design and architecture material.
 
 ## Requests for comments
 
-- [RFC 0001: protocol-agnostic test harness lifecycle][rfc-0001]
+- [RFC 0001: protocol-agnostic test harness lifecycle](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md)
   Proposed server lifecycle and custom-client connector layers for
   `wireframe_testing`.
-
-[rfc-0001]: rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
 
 ## Architectural decision records
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -22,12 +22,20 @@ reference when navigating the project's design and architecture material.
 - [Preamble validator](preamble-validator.md) Validating client connection
   preambles.
 
+## Requests for comments
+
+- [RFC 0001: protocol-agnostic test harness lifecycle][rfc-0001]
+  Proposed server lifecycle and custom-client connector layers for
+  `wireframe_testing`.
+
+[rfc-0001]: rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+
 ## Architectural decision records
 
 - [ADR 001: multi-packet streaming response API](adr-001-multi-packet-streaming-response-api.md)
   Accepted response API for multi-packet and streaming replies.
 - [ADR 002: streaming requests and shared message assembly](adr-002-streaming-requests-and-shared-message-assembly.md)
-  Decision for request streaming and shared assembly behaviour.
+  Decision for streaming requests and shared assembly behaviour.
 - [ADR 003: replace Cucumber with rstest-bdd](adr-003-replace-cucumber-with-rstest-bdd.md)
   Decision to use Rust-native behaviour-driven development (BDD) tests.
 - [ADR 004: pluggable protocol codecs](adr-004-pluggable-protocol-codecs.md)
@@ -78,8 +86,8 @@ the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md
   fixtures for clean tests.
 - [Mocking network outages](mocking-network-outages-in-rust.md) Tutorial for
   simulating network outages in tests.
-- [Testing helpers](wireframe-testing-crate.md) Planned companion crate with
-  testing helpers.
+- [Testing helpers](wireframe-testing-crate.md) Design and public API for the
+  `wireframe_testing` companion crate.
 
 ## Operations and resilience
 

--- a/docs/execplans/17-3-2-in-process-server-and-client-pair-test-harness.md
+++ b/docs/execplans/17-3-2-in-process-server-and-client-pair-test-harness.md
@@ -277,6 +277,11 @@ Observable success:
   graceful shutdown should call `shutdown()`. Date/Author: 2026-04-04 / review
   refinement.
 
+  Correction (2026-08-17): `Drop` was subsequently changed from immediate
+  abort to scheduled bounded cleanup — signal, then a detached task racing
+  the join against a 100 ms grace period, aborting only on timeout; immediate
+  abort remains when no runtime is current. See RFC 0001 section 5.3.
+
 - Decision: tear down the server task when the client connection fails in
   `spawn_wireframe_pair`. Rationale: the server was spawned before the client
   `connect` call; if that call fails the server task and bound listener would
@@ -615,6 +620,12 @@ Post-review refinements (2026-04-04):
 - Replaced the OS-thread-based `Drop` safety net (5-second sleep before
   abort) with an immediate `handle.abort()` after signalling shutdown. Callers
   wanting graceful teardown should call `shutdown()`.
+
+  Correction (2026-08-17): this immediate-abort behaviour was subsequently
+  replaced by scheduled bounded cleanup — signal, then a detached task
+  racing the join against a 100 ms grace period, aborting only on timeout;
+  immediate abort remains when no runtime is current. See RFC 0001
+  section 5.3.
 - Added server task cleanup on client connect failure so
   `spawn_wireframe_pair` never leaks a detached server task.
 - Extracted the echo app setup into `wireframe_testing::echo_app_factory`

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -1,0 +1,466 @@
+# RFC 0001: Protocol-agnostic test harness lifecycle
+
+## Preamble
+
+- RFC number: 0001
+- Status: Proposed
+- Created: 2026-07-18
+- Audience: Wireframe maintainers and downstream protocol-crate authors
+- Extends: roadmap item `17.3.2`
+- Related: [Wireframe testing crate design](../wireframe-testing-crate.md),
+  [client design](../wireframe-client-design.md), and
+  [the original pair-harness execution plan][pair-plan]
+
+<!-- markdownlint-disable-next-line MD013 -->
+[pair-plan]: ../execplans/17-3-2-in-process-server-and-client-pair-test-harness.md
+
+## 1. Summary
+
+`wireframe_testing::client_pair` currently couples server lifecycle management
+with one concrete client configuration. That convenience API remains useful for
+the default length-delimited protocol, but it cannot host downstream protocols
+that select a different codec, negotiate a typed preamble, or construct their
+own client.
+
+This RFC adds a lower-level, protocol-agnostic server lifecycle primitive. It
+accepts a fully configured, unbound `WireframeServer`, reserves or accepts a
+loopback listener, waits for readiness, and returns a
+`RunningWireframeServer`. An optional asynchronous connector composes that
+handle with any caller-owned client. Existing `WireframePair` functions remain
+source-compatible wrappers for the default client.
+
+The proposal also makes `wireframe_testing` an explicit quality-gate target.
+The root package is currently the only default workspace member, so the
+Makefile's unqualified Cargo commands do not validate the companion crate's own
+tests and doctests. Issue #578 records the resulting documentation drift.
+
+## 2. Problem
+
+The first pair harness solved repeated loopback setup for Wireframe's default
+client. Its public shape deliberately stayed concrete because no downstream
+consumer had yet demonstrated a broader requirement. The implementation now
+contains five constraints that block a real protocol integration:
+
+1. `WireframePair` stores a concrete
+   `WireframeClient<BincodeSerializer, RewindStream<TcpStream>, ()>`.
+2. The client callback must return the same
+   `WireframeClientBuilder<BincodeSerializer, (), ()>` type it receives.
+3. Type-changing client methods, including `with_preamble` and
+   `on_connection_setup`, cannot pass through that callback.
+4. The helper constructs the server internally, so callers cannot configure a
+   server preamble, preamble hooks, worker policy, or other server options.
+5. No server-only lifecycle handle exists for a protocol-specific client.
+
+The [mxd server behavioural-test design][mxd-design] is the first concrete
+downstream case. It needs Wireframe's loopback lifecycle and readiness
+handling, but it speaks Hotline framing and performs a Hotline preamble
+exchange. A byte adapter cannot repair this mismatch because the incompatible
+choices occur before framed traffic begins.
+
+[mxd-design]: https://github.com/leynos/mxd/pull/401
+
+Without an upstream primitive, each downstream crate must reimplement listener
+reservation, readiness signalling, task ownership, connection-failure cleanup,
+explicit shutdown, and defensive drop behaviour. Repetition at that boundary
+invites port races and orphaned tasks.
+
+## 3. Goals and non-goals
+
+### 3.1. Goals
+
+- Separate server lifecycle ownership from the default client convenience API.
+- Accept every valid `WireframeServer` serializer, context, packet, codec, and
+  preamble combination without erasing its configuration.
+- Bind the listener before task spawn and wait for an explicit readiness signal.
+- Provide bounded, idempotent, and cancellation-safe explicit shutdown.
+- Clean up the server when a caller-supplied client connector fails.
+- Keep the existing `WireframePair`, `spawn_wireframe_pair`, and
+  `spawn_wireframe_pair_default` APIs source-compatible.
+- Preserve real loopback Transmission Control Protocol (TCP) coverage.
+- Give failures enough lifecycle-stage context to diagnose startup and cleanup.
+- Validate the companion crate directly, including its doctests.
+
+### 3.2. Non-goals
+
+- Do not add a universal client trait or require all clients to implement a
+  Wireframe-specific close operation.
+- Do not move test-only lifecycle APIs into the production crate surface.
+- Do not replace in-memory codec, fragmentation, or slow-I/O drivers.
+- Do not add a test-framework-specific runtime adapter to `wireframe_testing`.
+- Do not generalize transport beyond TCP; roadmap item `18.1.1` owns that work.
+- Do not remove or deprecate the current pair helpers.
+
+## 4. Current architecture
+
+The current `spawn_wireframe_pair` function performs six operations in one
+function:
+
+1. reserve a loopback listener with `unused_listener()`;
+2. construct a default `WireframeServer` from an app factory;
+3. force one worker and bind the existing listener;
+4. attach readiness and shutdown channels, then spawn the server task;
+5. configure and connect the default `WireframeClient`; and
+6. return a concrete pair that owns both resources.
+
+The lifecycle work is reusable. Steps 2 and 5 contain the protocol assumptions.
+The target design exposes the reusable middle and retains the current function
+as a thin default-protocol façade.
+
+## 5. Proposed design
+
+### 5.1. Layered public surface
+
+The API has three layers:
+
+```plaintext
+Protocol-specific test
+        |
+        +-- spawn_wireframe_server(configured server)
+        |       |
+        |       `-- RunningWireframeServer
+        |
+        +-- spawn_wireframe_server_and_connect(server, connector)
+        |       |
+        |       `-- (RunningWireframeServer, protocol client)
+        |
+        `-- spawn_wireframe_pair(...)
+                |
+                `-- existing default WireframePair façade
+```
+
+_Figure 1: The server lifecycle is the common foundation. Protocol-specific
+clients and the existing default pair compose above it._
+
+This layering keeps the generic boundary at construction time. The running
+handle is non-generic because shutdown, task joining, and the local address do
+not depend on application or protocol types.
+
+### 5.2. Running server handle
+
+The illustrative public shape is:
+
+```rust,no_run
+use std::net::{SocketAddr, TcpListener};
+
+use wireframe::server::{Unbound, WireframeServer};
+use wireframe_testing::TestResult;
+
+pub struct RunningWireframeServer {
+    // local address, shutdown sender, task handle, and timeout policy
+}
+
+impl RunningWireframeServer {
+    pub fn local_addr(&self) -> SocketAddr;
+    pub async fn shutdown(&mut self) -> TestResult<()>;
+}
+
+pub async fn spawn_wireframe_server<F, T, Ser, Ctx, E, Codec>(
+    server: WireframeServer<F, T, Unbound, Ser, Ctx, E, Codec>,
+) -> TestResult<RunningWireframeServer>;
+
+pub async fn spawn_wireframe_server_on<F, T, Ser, Ctx, E, Codec>(
+    server: WireframeServer<F, T, Unbound, Ser, Ctx, E, Codec>,
+    listener: TcpListener,
+) -> TestResult<RunningWireframeServer>;
+```
+
+The omitted generic bounds are exactly those already required by
+`WireframeServer`. The implementation must not introduce default serializer,
+connection-state, packet, codec, or preamble bounds.
+
+`spawn_wireframe_server` calls `unused_listener()` and delegates to
+`spawn_wireframe_server_on`. The latter:
+
+1. binds the supplied listener with `bind_existing_listener`;
+2. records `local_addr` before spawning;
+3. installs a harness-owned readiness sender;
+4. starts `run_with_shutdown` in a Tokio task;
+5. waits under a bounded readiness timeout; and
+6. returns the non-generic running handle.
+
+The caller configures the server before passing it to the helper. This includes
+its app factory, worker count, codec-bearing app type, typed preamble, preamble
+success and failure hooks, preamble timeout, and accept backoff. The helper does
+not silently replace those settings. The readiness sender is the sole reserved
+setting because the harness must know when connection attempts are safe.
+
+The default helper uses documented readiness and shutdown timeouts. A compact
+options type may expose overrides if the implementation spike proves that fixed
+defaults are insufficient. Timeout configuration must not become a second
+server builder.
+
+### 5.3. Lifecycle guarantees
+
+`RunningWireframeServer::shutdown` has these guarantees:
+
+- it is idempotent;
+- it signals graceful shutdown before awaiting the task;
+- it retains enough internal state for `Drop` to recover if its future is
+  cancelled;
+- it bounds the join and aborts the task only after timeout;
+- it reports task panic, server error, and timeout as distinct failures; and
+- it releases the listener before returning success.
+
+`Drop` remains a safety net, not the normal path. Inside a Tokio runtime it
+allows a short bounded grace period before aborting. Outside a runtime it aborts
+immediately because synchronous drop cannot drive graceful asynchronous
+shutdown.
+
+Startup follows the same failure discipline. If the server exits before
+readiness, the helper joins the task and returns the underlying join or server
+error. A readiness timeout initiates cleanup before returning.
+
+### 5.4. Caller-supplied client connector
+
+A second helper removes the remaining connection boilerplate without claiming
+ownership of arbitrary client teardown semantics:
+
+```rust,no_run
+use std::{future::Future, net::SocketAddr};
+
+use wireframe_testing::{RunningWireframeServer, TestResult};
+
+pub async fn spawn_wireframe_server_and_connect<S, C, Connect, ConnectFuture>(
+    server: S,
+    connect: Connect,
+) -> TestResult<(RunningWireframeServer, C)>
+where
+    Connect: FnOnce(SocketAddr) -> ConnectFuture,
+    ConnectFuture: Future<Output = TestResult<C>>;
+```
+
+Here `S` abbreviates the fully bounded, unbound `WireframeServer` type from the
+previous section. The implementation passes the ready server's address to the
+connector. If connection fails, it shuts down and joins the server before
+returning the connector error.
+
+On success, the tuple preserves ordinary ownership. The caller closes or drops
+the protocol client according to its own contract, then explicitly shuts down
+the server. A generic pair object is intentionally absent because an arbitrary
+`C` may require an asynchronous protocol logout, expose only `Drop`, or have no
+close operation at all.
+
+When connection and cleanup both fail, diagnostics must retain both failures;
+the cleanup error must not replace the primary connector error. Single failures
+should continue to use typed `TestError` variants. The rare combined case may
+use a contextual `TestError::Msg` unless a more structured, dependency-safe
+error shape emerges during implementation.
+
+### 5.5. Existing pair compatibility
+
+The current public functions remain:
+
+```rust,no_run
+pub async fn spawn_wireframe_pair(/* existing parameters */)
+    -> TestResult<WireframePair>;
+
+pub async fn spawn_wireframe_pair_default(/* existing parameters */)
+    -> TestResult<WireframePair>;
+```
+
+Their signatures and observable behaviour do not change. Internally they:
+
+1. build the current default server and set one worker;
+2. call the new server-and-connector helper;
+3. store the resulting default client and running server; and
+4. call `WireframeClient::close` before server shutdown.
+
+`WireframePair` remains concrete. Turning it into `WireframePair<C>` would make
+client teardown either incomplete or trait-bound, while creating needless type
+noise for the common case. The lower layer supplies extensibility without
+burdening the convenience layer with unrelated generic parameters.
+
+### 5.6. Module boundaries
+
+The implementation should extract lifecycle code from `client_pair.rs`:
+
+```plaintext
+wireframe_testing/src/
+|-- server_harness/
+|   |-- mod.rs
+|   |-- lifecycle.rs
+|   `-- connector.rs
+|-- client_pair.rs
+`-- lib.rs
+```
+
+_Figure 2: `server_harness` owns protocol-neutral lifecycle code, while
+`client_pair` remains the default-client façade._
+
+No source file should exceed the repository's 400-line limit. Shared pending-
+server and bounded-shutdown machinery belongs in `server_harness`, not in both
+modules.
+
+## 6. Behavioural and diagnostic requirements
+
+The implementation must preserve these invariants:
+
+- Listener ownership begins before server task spawn, eliminating the released-
+  port race.
+- A successful spawn means the readiness signal has fired, not merely that the
+  task exists.
+- Each running handle owns exactly one shutdown sender and task handle.
+- Explicit shutdown and connector-failure cleanup join the server task.
+- Dropping one handle cannot affect another parallel test.
+- Protocol-specific setup remains outside the lifecycle module.
+- Error text identifies the lifecycle stage: bind, readiness, connect,
+  shutdown, join, or abort-after-timeout.
+- The original connector failure remains primary when cleanup also fails.
+
+The helpers continue to use real loopback TCP. In-memory `duplex` drivers remain
+the faster choice for isolated application and codec tests.
+
+## 7. Verification plan
+
+### 7.1. Lifecycle integration tests
+
+Add `rstest` coverage for:
+
+- a configured server becoming ready and accepting a connection;
+- a caller-supplied listener retaining its selected local address;
+- startup failure before readiness returning the underlying error;
+- readiness timeout cleaning up the task and listener;
+- idempotent explicit shutdown;
+- cancelled shutdown followed by `Drop` cleanup;
+- defensive drop inside and outside a Tokio runtime;
+- connector failure cleaning up the server;
+- simultaneous connector and cleanup failures retaining both diagnostics; and
+- parallel handles using distinct listeners without shared state.
+
+### 7.2. Protocol-generic proof
+
+A downstream-style test must configure all boundaries that the current pair
+cannot represent:
+
+- a non-default `FrameCodec`;
+- a typed server preamble;
+- server preamble success or failure hooks;
+- a client connector that performs the matching preamble; and
+- a protocol-specific client type that is not `WireframeClient`.
+
+The test should exchange at least one framed request and response after the
+handshake. A small Hotline-shaped fixture is acceptable; the proof must use the
+public `wireframe_testing` API rather than private test helpers.
+
+Behaviour-driven development coverage should describe observable lifecycle and
+compatibility behaviour. It should not assert private channel or task fields.
+
+### 7.3. Compatibility coverage
+
+Existing `client_pair_harness` integration and behavioural suites remain green.
+Add compile-time coverage demonstrating that the old calls infer the same
+public types after the internal refactor.
+
+### 7.4. Companion-crate quality gates
+
+The Makefile and Continuous Integration (CI) workflow must execute the
+companion crate explicitly. At minimum:
+
+```bash
+cargo test -p wireframe_testing --all-targets --all-features
+cargo test -p wireframe_testing --doc --all-features
+```
+
+The implementation must repair the currently failing doctests tracked by
+[issue #578][issue-578] before publishing the lifecycle extension. Root-package
+success alone is not sufficient evidence because `default-members = ["."]` and
+the current Make targets omit `--workspace` and `-p wireframe_testing`.
+
+[issue-578]: https://github.com/leynos/wireframe/issues/578
+
+## 8. Migration and release sequencing
+
+The change is additive and should land in five stages:
+
+1. Extract `RunningWireframeServer` and prove lifecycle behaviour without
+   changing the existing pair implementation's public surface.
+2. Refactor `WireframePair` to delegate to the new lifecycle primitive.
+3. Add the asynchronous connector and protocol-generic proof.
+4. Add explicit companion-crate tests and doctests to local and CI gates, then
+   resolve issue #578.
+5. Adopt the primitive in a downstream protocol crate, with mxd as the first
+   candidate, before declaring the extension mature.
+
+No downstream migration is mandatory. Existing callers continue to use the
+pair helpers. Protocol crates can replace only their local server lifecycle and
+keep their own scenario world, database fixtures, codec, and client.
+
+## 9. Risks and mitigations
+
+<!-- markdownlint-disable MD013 -->
+
+| Risk | Mitigation |
+| --- | --- |
+| The generic server signature produces unreadable diagnostics. | Keep generic bounds in one private helper and expose concrete examples with inferred types. |
+| Readiness ownership conflicts with a caller-provided signal. | Reserve `ready_signal` for the harness and document that constraint explicitly. |
+| Generic client teardown becomes underspecified. | Return the caller-owned client separately instead of inventing a universal close trait. |
+| Connector failure leaks a running server. | Perform explicit shutdown and join before returning the connection error. |
+| Drop hides shutdown faults. | Treat explicit `shutdown` as normative and keep `Drop` only as a bounded safety net. |
+| The convenience API becomes a breaking generic rewrite. | Keep `WireframePair` concrete and delegate internally. |
+| The companion crate drifts again. | Add package-specific all-feature and doctest gates before release. |
+
+<!-- markdownlint-enable MD013 -->
+
+_Table 1: Principal design risks and their containment strategies._
+
+## 10. Rejected alternatives
+
+### 10.1. Generalize only the client-builder callback
+
+A callback returning the same builder type cannot express `with_preamble` or
+`on_connection_setup`. Allowing an arbitrary return type merely moves the
+problem into the concrete `WireframePair` field and does not expose server
+configuration.
+
+### 10.2. Make `WireframePair` generic over every protocol type
+
+This would expose serializer, stream, connection state, preamble, and codec
+parameters at the convenience layer. It still would not define how an arbitrary
+client closes. The resulting type would be technically general but difficult to
+infer, document, and close safely.
+
+### 10.3. Accept raw bytes through the current pair
+
+The mismatch occurs at server construction, client codec selection, and the
+preamble exchange. A raw payload adapter begins too late in the connection
+lifecycle.
+
+### 10.4. Leave lifecycle ownership to downstream crates
+
+That preserves duplicated listener, readiness, task, and cleanup code in every
+protocol integration. These mechanics are Wireframe-specific enough to belong
+in its testing companion crate.
+
+### 10.5. Move the primitive into `wireframe::testkit`
+
+The feature is test-facing and already has a natural home in
+`wireframe_testing`. Moving it would widen the main crate's optional public
+surface without solving a production requirement.
+
+### 10.6. Accept an opaque server-start closure
+
+A callback that receives a listener, readiness sender, and shutdown future can
+host any server, but it also lets each caller reinterpret the lifecycle
+contract. Accepting Wireframe's public unbound-server typestate keeps binding,
+readiness, errors, and shutdown inside one implementation while retaining every
+protocol configuration supported by the server builder.
+
+## 11. Open implementation questions
+
+The implementation spike should settle two deliberately narrow questions:
+
+1. whether readiness and shutdown timeout overrides justify a small options
+   type in the first release; and
+2. whether the combined connector-and-cleanup error needs a new structured
+   `TestError` variant or a contextual message is sufficient.
+
+Neither question changes the architectural boundary: configured server in,
+non-generic running handle out, optional caller-owned client above it.
+
+## 12. Recommendation
+
+Accept the layered lifecycle design and schedule roadmap items `17.3.3` through
+`17.3.5`. The first implementation should extract the running server handle,
+retain the existing pair API as a wrapper, prove a custom preamble and codec
+through a caller-supplied connector, and make `wireframe_testing` a required
+quality-gate target.

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -137,9 +137,11 @@ not depend on application or protocol types.
 
 ### 5.2. Running server handle
 
-The illustrative public shape is:
+The illustrative public shape is (schematic; the generic bounds and method
+bodies are elided, so the block is marked `ignore` rather than advertised as
+compilable):
 
-```rust,no_run
+```rust,ignore
 use std::net::{SocketAddr, TcpListener};
 
 use wireframe::server::{Unbound, WireframeServer};
@@ -213,9 +215,10 @@ error. A readiness timeout initiates cleanup before returning.
 ### 5.4. Caller-supplied client connector
 
 A second helper removes the remaining connection boilerplate without claiming
-ownership of arbitrary client teardown semantics:
+ownership of arbitrary client teardown semantics (schematic; `S` and the
+elided bounds keep this block `ignore` rather than compilable):
 
-```rust,no_run
+```rust,ignore
 use std::{future::Future, net::SocketAddr};
 
 use wireframe_testing::{RunningWireframeServer, TestResult};
@@ -248,9 +251,10 @@ error shape emerges during implementation.
 
 ### 5.5. Existing pair compatibility
 
-The current public functions remain:
+The current public functions remain (schematic; parameters are elided, so the
+block is marked `ignore`):
 
-```rust,no_run
+```rust,ignore
 pub async fn spawn_wireframe_pair(/* existing parameters */)
     -> TestResult<WireframePair>;
 
@@ -345,11 +349,25 @@ public `wireframe_testing` API rather than private test helpers.
 Behaviour-driven development coverage should describe observable lifecycle and
 compatibility behaviour. It should not assert private channel or task fields.
 
-### 7.3. Compatibility coverage
+### 7.3. Compatibility and compile-time coverage
 
 Existing `client_pair_harness` integration and behavioural suites remain green.
-Add compile-time coverage demonstrating that the old calls infer the same
-public types after the internal refactor.
+
+Add explicit `trybuild` compile-time coverage, reusing the pattern already
+present in the root crate's `tests/compile_error.rs`. The repository already
+depends on `trybuild`, so the companion crate should gain its own UI test
+target that:
+
+- pass-checks that the retained `spawn_wireframe_pair` and
+  `spawn_wireframe_pair_default` calls still infer the same concrete
+  `WireframePair` type after the internal refactor; and
+- compile-fail-checks that a misconfigured lifecycle call (for example, a
+  connector whose future resolves to the wrong client type, or a server passed
+  after binding) is rejected with a stable diagnostic.
+
+Keep the expected-error snapshots focused on the lifecycle and connector
+boundary rather than on incidental generic-bound spew, so that unrelated
+compiler wording changes do not churn the fixtures.
 
 ### 7.4. Companion-crate quality gates
 
@@ -367,6 +385,27 @@ success alone is not sufficient evidence because `default-members = ["."]` and
 the current Make targets omit `--workspace` and `-p wireframe_testing`.
 
 [issue-578]: https://github.com/leynos/wireframe/issues/578
+
+### 7.5. Property-based invariant coverage
+
+The lifecycle guarantees in section 5.3 are stated as invariants that must hold
+across orderings and repetition, not just for the fixed sequences that the
+`rstest` cases in section 7.1 exercise. Add `proptest` coverage that generates
+these varying inputs and asserts the invariant survives:
+
+- idempotent shutdown under a generated number of repeated `shutdown` calls,
+  including interleaved `Drop`, always converges to a single joined task and one
+  released listener;
+- readiness followed by a generated schedule of connect-then-shutdown
+  operations never orphans a task or leaks a listener; and
+- a generated pool of concurrently spawned handles binds distinct listeners and
+  shuts down independently, with no cross-handle interference.
+
+These property tests supplement, and do not replace, the example-based `rstest`
+cases. Reserve an exhaustive or formal proof only for a genuine lemma or proof
+assumption (for example, a bounded state-machine argument that shutdown cannot
+deadlock); the idempotence and ordering behaviour here is adequately covered by
+property tests and does not warrant a model checker in the first release.
 
 ## 8. Migration and release sequencing
 

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -200,10 +200,13 @@ does not silently replace those settings. The readiness sender is the sole
 reserved setting because the harness must know when connection attempts are
 safe.
 
-The default helper uses documented readiness and shutdown timeouts. A compact
-options type may expose overrides if the implementation spike proves that fixed
-defaults are insufficient. Timeout configuration must not become a second
-server builder.
+The default helper should use a 5-second readiness timeout and a 5-second
+explicit shutdown join timeout; neither exists today, so these are proposed
+defaults rather than documented behaviour. The `Drop` grace period keeps the
+existing 100-millisecond value from `WireframePair`
+(`wireframe_testing/src/client_pair.rs`). A compact options type may expose
+overrides if the implementation spike proves that fixed defaults are
+insufficient. Timeout configuration must not become a second server builder.
 
 ### 5.3. Lifecycle guarantees
 
@@ -216,6 +219,12 @@ server builder.
 - it bounds the join and aborts the task only after timeout;
 - it reports task panic, server error, and timeout as distinct failures; and
 - it releases the listener before returning success.
+
+This bounded join is a deliberate departure from `WireframePair::shutdown`'s
+unbounded join, which exists so the server's result is never discarded; here a
+server that never notices the shutdown signal fails the test with a
+diagnosable timeout, reported as a distinct failure per the bullet above,
+instead of hanging the suite indefinitely.
 
 `Drop` remains a safety net, not the normal path; only an explicit
 `shutdown().await` guarantees graceful completion. Inside a Tokio runtime,
@@ -430,9 +439,12 @@ across orderings and repetition, not just for the fixed sequences that the
 `rstest` cases in section 7.1 exercise. Add `proptest` coverage that generates
 these varying inputs and asserts the invariant survives:
 
-- idempotent shutdown under a generated number of repeated `shutdown` calls,
-  including interleaved `Drop`, always converges to a single joined task and
-  one released listener;
+- repeated `shutdown` calls on a live `RunningWireframeServer`, under a
+  generated call count, always converge to a single joined task and one
+  released listener;
+- a generated trace of zero or more `shutdown` calls followed by `Drop` as the
+  terminal action converges to the same state, covering both dropping after
+  shutdown and dropping without shutdown;
 - readiness followed by a generated schedule of connect-then-shutdown
   operations never orphans a task or leaks a listener; and
 - a generated pool of concurrently spawned handles binds distinct listeners and

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -220,6 +220,19 @@ insufficient. Timeout configuration must not become a second server builder.
 - it reports task panic, server error, and timeout as distinct failures; and
 - it releases the listener before returning success.
 
+A repeated `shutdown` call returns the outcome of the terminal state already
+reached, rather than repeating the underlying work:
+
+- after a successful shutdown, a later call returns `Ok(())` without
+  re-signalling or re-joining;
+- after a timeout, a later call reports the same timeout failure rather than
+  blocking again; and
+- after a cancelled shutdown future, a later call completes the outstanding
+  join rather than starting a new one.
+
+A call after `Drop` is not expressible, because `Drop` consumes the handle and
+ends its life; this is why the list above has three cases and not four.
+
 This bounded join is a deliberate departure from `WireframePair::shutdown`'s
 unbounded join, which exists so the server's result is never discarded; here a
 server that never notices the shutdown signal fails the test with a
@@ -291,9 +304,17 @@ pub async fn spawn_wireframe_pair_default(/* existing parameters */)
 Their signatures and observable behaviour do not change. Internally they:
 
 1. build the current default server and set one worker;
-2. call the new server-and-connector helper;
+2. call the new server-and-connector helper to spawn the server and connect
+   the default client;
 3. store the resulting default client and running server; and
 4. call `WireframeClient::close` before server shutdown.
+
+`WireframePair::shutdown` keeps its own unbounded join rather than delegating
+to `RunningWireframeServer::shutdown`'s bounded join: the pair's explicit
+shutdown path exists so the server's result is always observed, and a bound
+would add a new timeout failure mode that existing callers' tests do not
+expect. If the compact options type from section 5.2 lands, the pair wrapper
+sets no shutdown bound.
 
 `WireframePair` remains concrete. Turning it into `WireframePair<C>` would make
 client teardown either incomplete or trait-bound, while creating needless type
@@ -329,7 +350,9 @@ The implementation must preserve these invariants:
   port race.
 - A successful spawn means the readiness signal has fired, not merely that the
   task exists.
-- Each running handle owns exactly one shutdown sender and task handle.
+- Each running handle owns at most one shutdown sender and at most one task
+  handle: both are present while the handle is live, both are consumed by the
+  first successful `shutdown` or by `Drop`, and neither is present thereafter.
 - Explicit shutdown and connector-failure cleanup join the server task.
 - Dropping one handle cannot affect another parallel test.
 - Protocol-specific setup remains outside the lifecycle module.
@@ -371,7 +394,10 @@ cannot represent:
 - a non-default `FrameCodec`;
 - a typed server preamble;
 - server preamble success or failure hooks;
-- a client connector that performs the matching preamble; and
+- a client connector that performs the matching preamble;
+- a client connector that builds its client via a type-changing builder
+  method, such as `with_preamble` or `on_connection_setup`, which section 2
+  identifies as unable to pass through the current callback; and
 - a protocol-specific client type that is not `WireframeClient`.
 
 The test should exchange at least one framed request and response after the
@@ -392,10 +418,13 @@ target that:
 
 - pass-checks that the retained `spawn_wireframe_pair` and
   `spawn_wireframe_pair_default` calls still infer the same concrete
-  `WireframePair` type after the internal refactor; and
+  `WireframePair` type after the internal refactor;
+- pass-checks that `spawn_wireframe_server_and_connect` accepts an arbitrary
+  caller-defined client type `C`, since section 5.4 leaves `C` unconstrained
+  and infers it from the connector future's output; and
 - compile-fail-checks that a misconfigured lifecycle call (for example, a
-  connector whose future resolves to the wrong client type, or a server passed
-  after binding) is rejected with a stable diagnostic.
+  server passed after binding, where `Unbound` and `Bound` are distinct
+  typestates) is rejected with a stable diagnostic.
 
 Keep the expected-error snapshots focused on the lifecycle and connector
 boundary rather than on incidental generic-bound spew, so that unrelated
@@ -440,11 +469,12 @@ across orderings and repetition, not just for the fixed sequences that the
 these varying inputs and asserts the invariant survives:
 
 - repeated `shutdown` calls on a live `RunningWireframeServer`, under a
-  generated call count, always converge to a single joined task and one
-  released listener;
+  generated call count, always converge to exactly one joined task and one
+  released listener across the whole trace, with the handle holding neither
+  sender nor task handle afterwards;
 - a generated trace of zero or more `shutdown` calls followed by `Drop` as the
-  terminal action converges to the same state, covering both dropping after
-  shutdown and dropping without shutdown;
+  terminal action converges to the same terminal state, covering both
+  dropping after shutdown and dropping without shutdown;
 - readiness followed by a generated schedule of connect-then-shutdown
   operations never orphans a task or leaks a listener; and
 - a generated pool of concurrently spawned handles binds distinct listeners and

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -367,7 +367,21 @@ target that:
 
 Keep the expected-error snapshots focused on the lifecycle and connector
 boundary rather than on incidental generic-bound spew, so that unrelated
-compiler wording changes do not churn the fixtures.
+compiler wording changes do not churn the fixtures. A `trybuild` `.stderr`
+fixture is a snapshot of compiler output, so it must be trimmed to the
+diagnostic under test; a fixture that captures the full generic-bound expansion
+of `WireframeServer` will churn on every unrelated toolchain bump.
+
+The runtime counterpart is the section 6 requirement that error text identify
+the lifecycle stage: bind, readiness, connect, shutdown, join, or
+abort-after-timeout. Assert that semantically rather than by whole-string
+equality. Prefer matching the typed `TestError` variant and then asserting the
+stage marker with a `googletest` matcher such as `contains_substring`, so that
+rewording the surrounding diagnostic prose does not break the suite while a
+lost or wrong stage label still fails it. Reserve exact-text assertions for the
+few messages whose precise wording is itself the contract. When connector and
+cleanup both fail, assert that both the primary and secondary causes are
+present, not merely that some error was returned.
 
 ### 7.4. Companion-crate quality gates
 

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -309,6 +309,13 @@ Their signatures and observable behaviour do not change. Internally they:
 3. store the resulting default client and running server; and
 4. call `WireframeClient::close` before server shutdown.
 
+The pair wrapper re-wraps the helper's typed startup failures back into
+`TestError::Msg`, preserving the message shape existing callers see today,
+because the compatibility promise in this section covers the variant a caller
+observes, not just the function signature. The distinct typed variants remain
+the contract of the new helper API in section 6; callers that want to match on
+a variant should use that API directly.
+
 `WireframePair::shutdown` keeps its own unbounded join rather than delegating
 to `RunningWireframeServer::shutdown`'s bounded join: the pair's explicit
 shutdown path exists so the server's result is always observed, and a bound
@@ -358,9 +365,12 @@ The implementation must preserve these invariants:
 - Protocol-specific setup remains outside the lifecycle module.
 - Error text identifies the lifecycle stage: bind, readiness, connect,
   shutdown, join, or abort-after-timeout.
-- A server-task `ServerError`, a `JoinError` from a panicked or cancelled
-  task, and a readiness or shutdown timeout each map onto distinct `TestError`
-  variants, so callers can distinguish them without parsing message text.
+- For the new server-and-connector helper, a server-task `ServerError`, a
+  `JoinError` from a panicked or cancelled task, and a readiness or shutdown
+  timeout each map onto distinct `TestError` variants, so callers can
+  distinguish them without parsing message text; the `WireframePair` wrappers
+  are the one carve-out, re-wrapping these failures as `TestError::Msg` to
+  preserve their existing observable behaviour.
 - The original connector failure remains primary when cleanup also fails.
 
 The helpers continue to use real loopback TCP. In-memory `duplex` drivers
@@ -410,6 +420,8 @@ compatibility behaviour. It should not assert private channel or task fields.
 ### 7.3. Compatibility and compile-time coverage
 
 Existing `client_pair_harness` integration and behavioural suites remain green.
+A test also pins the `WireframePair` startup-failure error shape, so a future
+refactor cannot silently switch it from `TestError::Msg` to a typed variant.
 
 Add explicit `trybuild` compile-time coverage, reusing the pattern already
 present in the root crate's `tests/compile_error.rs`. The repository already

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -166,9 +166,22 @@ pub async fn spawn_wireframe_server_on<F, T, Ser, Ctx, E, Codec>(
 ) -> TestResult<RunningWireframeServer>;
 ```
 
-The omitted generic bounds are exactly those already required by
-`WireframeServer`. The implementation must not introduce default serializer,
-connection-state, packet, codec, or preamble bounds.
+The omitted generic bounds are those already required by `WireframeServer`'s
+`run_with_shutdown`:
+
+- `F: AppFactory<Ser, Ctx, E, Codec>`;
+- `T: Preamble`;
+- `Ser: Serializer + FrameMetadata<Frame = Envelope> + Send + Sync + 'static`;
+- `Ctx: Send + 'static`;
+- `E: Packet`;
+- `Codec: FrameCodec`; and
+- `Envelope: DecodeWith<Ser> + EncodeWith<Ser>`.
+
+Because the helper drives `run_with_shutdown` inside `tokio::spawn`, the
+spawned future must also be `Send + 'static`. That is the one requirement not
+already implied by `WireframeServer` alone. The implementation must not
+introduce default serializer, connection-state, packet, codec, or preamble
+bounds.
 
 `spawn_wireframe_server` calls `unused_listener()` and delegates to
 `spawn_wireframe_server_on`. The latter:
@@ -204,10 +217,13 @@ server builder.
 - it reports task panic, server error, and timeout as distinct failures; and
 - it releases the listener before returning success.
 
-`Drop` remains a safety net, not the normal path. Inside a Tokio runtime it
-allows a short bounded grace period before aborting. Outside a runtime it
-aborts immediately because synchronous drop cannot drive graceful asynchronous
-shutdown.
+`Drop` remains a safety net, not the normal path; only an explicit
+`shutdown().await` guarantees graceful completion. Inside a Tokio runtime,
+`Drop` sends the shutdown signal and schedules bounded cleanup on a detached
+task, then returns immediately without awaiting anything. That detached task
+races the join against a short grace period and aborts the server task only
+if the period elapses first. Outside a runtime, `Drop` aborts immediately
+because there is no executor to run the scheduled cleanup.
 
 Startup follows the same failure discipline. If the server exits before
 readiness, the helper joins the task and returns the underlying join or server
@@ -310,6 +326,9 @@ The implementation must preserve these invariants:
 - Protocol-specific setup remains outside the lifecycle module.
 - Error text identifies the lifecycle stage: bind, readiness, connect,
   shutdown, join, or abort-after-timeout.
+- A server-task `ServerError`, a `JoinError` from a panicked or cancelled
+  task, and a readiness or shutdown timeout each map onto distinct `TestError`
+  variants, so callers can distinguish them without parsing message text.
 - The original connector failure remains primary when cleanup also fails.
 
 The helpers continue to use real loopback TCP. In-memory `duplex` drivers
@@ -327,7 +346,10 @@ Add `rstest` coverage for:
 - readiness timeout cleaning up the task and listener;
 - idempotent explicit shutdown;
 - cancelled shutdown followed by `Drop` cleanup;
-- defensive drop inside and outside a Tokio runtime;
+- defensive drop inside and outside a Tokio runtime, including that `Drop`
+  returns without waiting, that the detached scheduled-cleanup task completes
+  the join when the server stops within the grace period, and that it aborts
+  the task when the grace period elapses;
 - connector failure cleaning up the server;
 - simultaneous connector and cleanup failures retaining both diagnostics; and
 - parallel handles using distinct listeners without shared state.

--- a/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
+++ b/docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md
@@ -24,10 +24,10 @@ own client.
 
 This RFC adds a lower-level, protocol-agnostic server lifecycle primitive. It
 accepts a fully configured, unbound `WireframeServer`, reserves or accepts a
-loopback listener, waits for readiness, and returns a
-`RunningWireframeServer`. An optional asynchronous connector composes that
-handle with any caller-owned client. Existing `WireframePair` functions remain
-source-compatible wrappers for the default client.
+loopback listener, waits for readiness, and returns a `RunningWireframeServer`.
+An optional asynchronous connector composes that handle with any caller-owned
+client. Existing `WireframePair` functions remain source-compatible wrappers
+for the default client.
 
 The proposal also makes `wireframe_testing` an explicit quality-gate target.
 The root package is currently the only default workspace member, so the
@@ -182,9 +182,10 @@ connection-state, packet, codec, or preamble bounds.
 
 The caller configures the server before passing it to the helper. This includes
 its app factory, worker count, codec-bearing app type, typed preamble, preamble
-success and failure hooks, preamble timeout, and accept backoff. The helper does
-not silently replace those settings. The readiness sender is the sole reserved
-setting because the harness must know when connection attempts are safe.
+success and failure hooks, preamble timeout, and accept backoff. The helper
+does not silently replace those settings. The readiness sender is the sole
+reserved setting because the harness must know when connection attempts are
+safe.
 
 The default helper uses documented readiness and shutdown timeouts. A compact
 options type may expose overrides if the implementation spike proves that fixed
@@ -204,8 +205,8 @@ server builder.
 - it releases the listener before returning success.
 
 `Drop` remains a safety net, not the normal path. Inside a Tokio runtime it
-allows a short bounded grace period before aborting. Outside a runtime it aborts
-immediately because synchronous drop cannot drive graceful asynchronous
+allows a short bounded grace period before aborting. Outside a runtime it
+aborts immediately because synchronous drop cannot drive graceful asynchronous
 shutdown.
 
 Startup follows the same failure discipline. If the server exits before
@@ -215,8 +216,8 @@ error. A readiness timeout initiates cleanup before returning.
 ### 5.4. Caller-supplied client connector
 
 A second helper removes the remaining connection boilerplate without claiming
-ownership of arbitrary client teardown semantics (schematic; `S` and the
-elided bounds keep this block `ignore` rather than compilable):
+ownership of arbitrary client teardown semantics (schematic; `S` and the elided
+bounds keep this block `ignore` rather than compilable):
 
 ```rust,ignore
 use std::{future::Future, net::SocketAddr};
@@ -311,8 +312,8 @@ The implementation must preserve these invariants:
   shutdown, join, or abort-after-timeout.
 - The original connector failure remains primary when cleanup also fails.
 
-The helpers continue to use real loopback TCP. In-memory `duplex` drivers remain
-the faster choice for isolated application and codec tests.
+The helpers continue to use real loopback TCP. In-memory `duplex` drivers
+remain the faster choice for isolated application and codec tests.
 
 ## 7. Verification plan
 
@@ -408,8 +409,8 @@ across orderings and repetition, not just for the fixed sequences that the
 these varying inputs and asserts the invariant survives:
 
 - idempotent shutdown under a generated number of repeated `shutdown` calls,
-  including interleaved `Drop`, always converges to a single joined task and one
-  released listener;
+  including interleaved `Drop`, always converges to a single joined task and
+  one released listener;
 - readiness followed by a generated schedule of connect-then-shutdown
   operations never orphans a task or leaks a listener; and
 - a generated pool of concurrently spawned handles binds distinct listeners and
@@ -434,23 +435,23 @@ The change is additive and should land in five stages:
 5. Adopt the primitive in a downstream protocol crate, with mxd as the first
    candidate, before declaring the extension mature.
 
-No downstream migration is mandatory. Existing callers continue to use the
-pair helpers. Protocol crates can replace only their local server lifecycle and
-keep their own scenario world, database fixtures, codec, and client.
+No downstream migration is mandatory. Existing callers continue to use the pair
+helpers. Protocol crates can replace only their local server lifecycle and keep
+their own scenario world, database fixtures, codec, and client.
 
 ## 9. Risks and mitigations
 
 <!-- markdownlint-disable MD013 -->
 
-| Risk | Mitigation |
-| --- | --- |
+| Risk                                                          | Mitigation                                                                                  |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
 | The generic server signature produces unreadable diagnostics. | Keep generic bounds in one private helper and expose concrete examples with inferred types. |
-| Readiness ownership conflicts with a caller-provided signal. | Reserve `ready_signal` for the harness and document that constraint explicitly. |
-| Generic client teardown becomes underspecified. | Return the caller-owned client separately instead of inventing a universal close trait. |
-| Connector failure leaks a running server. | Perform explicit shutdown and join before returning the connection error. |
-| Drop hides shutdown faults. | Treat explicit `shutdown` as normative and keep `Drop` only as a bounded safety net. |
-| The convenience API becomes a breaking generic rewrite. | Keep `WireframePair` concrete and delegate internally. |
-| The companion crate drifts again. | Add package-specific all-feature and doctest gates before release. |
+| Readiness ownership conflicts with a caller-provided signal.  | Reserve `ready_signal` for the harness and document that constraint explicitly.             |
+| Generic client teardown becomes underspecified.               | Return the caller-owned client separately instead of inventing a universal close trait.     |
+| Connector failure leaks a running server.                     | Perform explicit shutdown and join before returning the connection error.                   |
+| Drop hides shutdown faults.                                   | Treat explicit `shutdown` as normative and keep `Drop` only as a bounded safety net.        |
+| The convenience API becomes a breaking generic rewrite.       | Keep `WireframePair` concrete and delegate internally.                                      |
+| The companion crate drifts again.                             | Add package-specific all-feature and doctest gates before release.                          |
 
 <!-- markdownlint-enable MD013 -->
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -805,9 +805,9 @@ document so larger deployments can adopt the library confidently.
   17.3.3.
 - [ ] 17.3.5. Make `wireframe_testing` an explicit quality-gate target. Run its
   all-feature tests and doctests in the Makefile and Continuous Integration
-  workflow, repair the examples tracked by issue #578, and prevent the companion
-  crate from drifting behind the root package. This item must complete before
-  publishing the lifecycle extension.
+  workflow, repair the examples tracked by issue #578, and prevent the
+  companion crate from drifting behind the root package. This item must
+  complete before publishing the lifecycle extension.
 
 ### 17.4. Docs and adoption
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -788,6 +788,22 @@ document so larger deployments can adopt the library confidently.
   protocols remain ergonomic.
 - [x] 17.3.2. Publish reusable test harnesses that spin up an in-process server
   and client pair, allowing downstream crates to verify compatibility.
+- [ ] 17.3.3. Extract a protocol-agnostic server lifecycle harness that
+  accepts a fully configured, unbound `WireframeServer`, binds a reserved
+  loopback listener, waits for readiness, and returns an idempotently stoppable
+  `RunningWireframeServer`. Preserve the existing pair helpers as additive,
+  source-compatible wrappers. See
+  [RFC 0001](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md).
+- [ ] 17.3.4. Add a caller-supplied asynchronous connector that composes the
+  running server with any protocol-specific client while cleaning up the server
+  if connection fails. Prove the public API with a non-default codec, a typed
+  preamble, type-changing builder configuration, and downstream-style
+  behavioural tests. Requires 17.3.3.
+- [ ] 17.3.5. Make `wireframe_testing` an explicit quality-gate target. Run its
+  all-feature tests and doctests in the Makefile and Continuous Integration
+  workflow, repair the examples tracked by issue #578, and prevent the companion
+  crate from drifting behind the root package. This item must complete before
+  publishing the lifecycle extension.
 
 ### 17.4. Docs and adoption
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -792,13 +792,17 @@ document so larger deployments can adopt the library confidently.
   accepts a fully configured, unbound `WireframeServer`, binds a reserved
   loopback listener, waits for readiness, and returns an idempotently stoppable
   `RunningWireframeServer`. Preserve the existing pair helpers as additive,
-  source-compatible wrappers. See
+  source-compatible wrappers. Cover the shutdown-idempotence, readiness, and
+  concurrent-handle invariants with `proptest` alongside the example-based
+  `rstest` cases. See
   [RFC 0001](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md).
 - [ ] 17.3.4. Add a caller-supplied asynchronous connector that composes the
   running server with any protocol-specific client while cleaning up the server
   if connection fails. Prove the public API with a non-default codec, a typed
-  preamble, type-changing builder configuration, and downstream-style
-  behavioural tests. Requires 17.3.3.
+  preamble, type-changing builder configuration, downstream-style behavioural
+  tests, and a `trybuild` compile-time test that pins the retained pair
+  helpers' inferred types and rejects misconfigured lifecycle calls. Requires
+  17.3.3.
 - [ ] 17.3.5. Make `wireframe_testing` an explicit quality-gate target. Run its
   all-feature tests and doctests in the Makefile and Continuous Integration
   workflow, repair the examples tracked by issue #578, and prevent the companion

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -814,11 +814,12 @@ document so larger deployments can adopt the library confidently.
   and for protocol-generic and `trybuild` verification
   ([§7.2](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#72-protocol-generic-proof),
   [§7.3](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#73-compatibility-and-compile-time-coverage)).
-- [ ] 17.3.5. Make `wireframe_testing` an explicit quality-gate target. Run its
-  all-feature tests and doctests in the Makefile and Continuous Integration
-  workflow, repair the examples tracked by issue #578, and prevent the
-  companion crate from drifting behind the root package. This item must
-  complete before publishing the lifecycle extension. See RFC 0001
+- [ ] 17.3.5. Make `wireframe_testing` an explicit quality-gate target. Run
+  `cargo test -p wireframe_testing --all-targets --all-features` and
+  `cargo test -p wireframe_testing --doc --all-features` in the Makefile and
+  Continuous Integration workflow, repair the examples tracked by issue #578,
+  and prevent the companion crate from drifting behind the root package. This
+  item must complete before publishing the lifecycle extension. See RFC 0001
   [§7.4](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#74-companion-crate-quality-gates).
 
 ### 17.4. Docs and adoption

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -794,20 +794,32 @@ document so larger deployments can adopt the library confidently.
   `RunningWireframeServer`. Preserve the existing pair helpers as additive,
   source-compatible wrappers. Cover the shutdown-idempotence, readiness, and
   concurrent-handle invariants with `proptest` alongside the example-based
-  `rstest` cases. See
-  [RFC 0001](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md).
+  `rstest` cases. See RFC 0001 for the lifecycle harness and
+  `RunningWireframeServer` requirements
+  ([§5.2](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#52-running-server-handle),
+  [§5.3](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#53-lifecycle-guarantees),
+  [§5.5](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#55-existing-pair-compatibility))
+  and for the `rstest` and `proptest` requirements
+  ([§7.1](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#71-lifecycle-integration-tests),
+  [§7.5](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#75-property-based-invariant-coverage)).
 - [ ] 17.3.4. Add a caller-supplied asynchronous connector that composes the
   running server with any protocol-specific client while cleaning up the server
   if connection fails. Prove the public API with a non-default codec, a typed
   preamble, type-changing builder configuration, downstream-style behavioural
   tests, and a `trybuild` compile-time test that pins the retained pair
   helpers' inferred types and rejects misconfigured lifecycle calls. Requires
-  17.3.3.
+  17.3.3. See RFC 0001 for the caller-supplied connector and
+  connection-failure cleanup
+  ([§5.4](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#54-caller-supplied-client-connector))
+  and for protocol-generic and `trybuild` verification
+  ([§7.2](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#72-protocol-generic-proof),
+  [§7.3](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#73-compatibility-and-compile-time-coverage)).
 - [ ] 17.3.5. Make `wireframe_testing` an explicit quality-gate target. Run its
   all-feature tests and doctests in the Makefile and Continuous Integration
   workflow, repair the examples tracked by issue #578, and prevent the
   companion crate from drifting behind the root package. This item must
-  complete before publishing the lifecycle extension.
+  complete before publishing the lifecycle extension. See RFC 0001
+  [§7.4](rfcs/0001-protocol-agnostic-test-harness-lifecycle.md#74-companion-crate-quality-gates).
 
 ### 17.4. Docs and adoption
 


### PR DESCRIPTION
## Summary

- add RFC 0001 for a protocol-agnostic `wireframe_testing` server lifecycle
- extend the canonical roadmap with implementation items `17.3.3` through `17.3.5`
- index the RFC and update the testing-helper description

## Why

The existing `WireframePair` is a useful convenience for Wireframe's default client, but it fixes the client codec, preamble typestate, and builder return type. It also constructs the server internally. Downstream protocols therefore cannot combine the shared listener, readiness, task ownership, and shutdown machinery with their own codec, typed preamble, server hooks, or client.

The mxd behavioural-harness design in leynos/mxd#401 supplies the first concrete downstream case. It needs Hotline framing and a Hotline preamble while retaining Wireframe's real loopback server lifecycle.

The review also found a separate release-quality gap: the workspace's default member and current Make targets do not execute the companion crate's tests and doctests explicitly. Issue #578 records resulting doctest drift.

## Proposed design

The RFC introduces three layers:

1. `spawn_wireframe_server` and `spawn_wireframe_server_on` accept a fully configured, unbound `WireframeServer` and return a non-generic `RunningWireframeServer` after listener binding and readiness.
2. `spawn_wireframe_server_and_connect` composes that handle with any caller-supplied asynchronous client connector and cleans up the server when connection fails.
3. The existing concrete `WireframePair`, `spawn_wireframe_pair`, and `spawn_wireframe_pair_default` APIs remain source-compatible convenience wrappers for the default client.

The running handle owns bounded, idempotent shutdown and task joining. The connector returns the caller-owned protocol client separately because an arbitrary client may require asynchronous logout, ordinary drop, or no explicit close operation.

The RFC also requires package-specific all-feature tests and doctests in local and Continuous Integration quality gates before publishing the extension.

## Roadmap

- `17.3.3`: extract the protocol-neutral running-server lifecycle
- `17.3.4`: add the custom connector and prove it with a non-default codec and typed preamble
- `17.3.5`: make `wireframe_testing` an explicit quality-gate target and repair #578

## Compatibility

This is a design-only, additive proposal. It changes no Rust code and does not deprecate the existing pair helpers.

## Validation

The three changed Markdown files pass:

```bash
npx --yes markdownlint-cli2@0.22.1 \
  docs/rfcs/0001-protocol-agnostic-test-harness-lifecycle.md \
  docs/contents.md \
  docs/roadmap.md
```

Result: 0 errors.

The review-feedback commit was additionally gated in a local checkout. `make check-fmt`, `make typecheck`, `make test`, `make markdownlint`, and `make nixie` all pass. `make lint` reports pre-existing `no_expect_outside_tests` findings in test-support helpers (for example `src/client/tests/helpers.rs`, `src/client/tests/request_hooks.rs`) that are untouched by this branch and identical on `main`; `main`'s tip passed CI with the same pinned whitaker `0.2.6`, so these are a local whitaker toolchain/staging drift rather than a regression introduced here. Fixing them belongs to the whitaker test-wave rollout, not this documentation-only change.

## Review feedback addressed

- Marked the schematic Rust blocks in RFC 0001 `ignore` so the RFC no longer advertises bodyless declarations as compilable `no_run` examples.
- Rewrote the `docs/contents.md` "Testing helpers" entry to describe the implemented in-process server and client pair helpers.
- Required an explicit `trybuild` compile-time UI test and `proptest`-based coverage of the shutdown, readiness, and concurrent-handle invariants; reflected both in roadmap items `17.3.3`/`17.3.4`.
- Specified the assertion style for the compile-time and runtime text: trim `trybuild` `.stderr` fixtures to the diagnostic under test so the `WireframeServer` generic-bound expansion does not churn them, and assert the §6 lifecycle-stage markers semantically (typed `TestError` variant plus a `googletest` matcher) rather than by whole-string equality.
- Skipped the suggested `[pair-plan]` change to `12-3-2-…`: only `17-3-2-in-process-server-and-client-pair-test-harness.md` exists, so the current reference is correct and the proposed target would break the link.

## Open implementation questions

- whether the first release needs a compact readiness and shutdown timeout options type
- whether simultaneous connector and cleanup failures justify a structured `TestError` variant rather than a contextual message

## References

- Lody session: <https://lody.ai/leynos/sessions/b9088842-efa6-439a-92b4-740521751139>

## Summary by Sourcery

Define an additive, protocol-agnostic testing harness lifecycle while retaining the existing default client pair helpers.

New Features:
- Propose a protocol-agnostic `wireframe_testing` server lifecycle and caller-supplied client connector for downstream protocol testing.

Enhancements:
- Document lifecycle ownership, readiness, shutdown, cleanup, compatibility, and verification requirements for the proposed harness.
- Record corrections to the existing pair-harness shutdown cleanup design.

CI:
- Plan explicit all-feature tests and doctests for the `wireframe_testing` companion crate in local and CI quality gates.

Documentation:
- Add RFC 0001 and index it in the documentation contents.
- Update the testing-helper description and extend the roadmap with implementation items 17.3.3–17.3.5.

Tests:
- Specify integration, protocol-generic, compile-time UI, property-based, and companion-crate quality-gate coverage for the planned implementation.