### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Format
         run: make check-fmt
       - name: Cache Whitaker installer
@@ -66,7 +66,7 @@ jobs:
       # main-push runs to avoid doing the work twice.
       - name: Test and Measure Coverage
         if: github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: lcov.info
           format: lcov

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@29eea2635ee0f92e42c05f4cd360b7f1a2f00b12
+        uses: leynos/shared-actions/.github/actions/setup-rust@18bed1ca49a6de3d8882bd72635a32ae3f023d57
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: lcov.info
           format: lcov

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@c3141c3d4cb2a2828d2abbcf3d94b15197740c58
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary
Bumps every `leynos/shared-actions` workflow and action reference to
`18bed1ca49a6de3d8882bd72635a32ae3f023d57` (current upstream main at
the time of the estate sweep).

This picks up the coverage-ratchet fix from shared-actions#353: the
baseline can now advance (cache save-key fix) and a symmetric ±1pp
dead-band absorbs coverage measurement noise. It also carries the
whitaker-installer 0.2.6 bump and the mutation-run workspace
relocation.

## Review walkthrough
Mechanical SHA substitution in `.github/workflows/` only. References
already at or beyond the fix commit are left untouched. Dependabot
retains ownership of future bumps; contract tests assert shape (path @
40-hex SHA), not the value.

## Validation
CI on this pull request exercises the bumped references directly.

## Summary by Sourcery

Update GitHub workflows to use a newer pinned revision of the shared leynos actions.

CI:
- Bump leynos/shared-actions setup-rust and generate-coverage action references in CI and coverage workflows to commit 18bed1ca49a6de3d8882bd72635a32ae3f023d57.
- Update dependabot automerge reusable workflow reference to the same shared-actions commit.