### PR TITLE
Import and refine runtime ownership ADRs 011-013 (#636) (#637) (#638)

### DIFF
--- a/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
+++ b/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
@@ -1,0 +1,342 @@
+# Architectural decision record (ADR) 011: runtime ownership and task-lifetime boundaries
+
+## Status
+
+Proposed.
+
+## Date
+
+Proposed 2026-08-08. Imported and refined 2026-08-23.
+
+## Context and Problem Statement
+
+Tokio does not intrinsically require application state to live behind `Arc`.
+The requirement appears when Wireframe creates an independently scheduled
+`'static` task, shares one logical resource among genuinely independent owners,
+or uses a Tokio primitive whose owned handle embeds shared state.
+
+Wireframe currently mixes those cases with several scope-bound or sole-owner
+values that also use `Arc` or owned cancellation futures. The result is a
+blurred ownership graph:
+
+- some values cross a real task boundary and correctly require shared
+  ownership;
+- some values remain within one actor but still sit behind `Arc`;
+- some futures could borrow from the current task but instead clone an owned
+  handle;
+- some coordination state has one conceptual owner but is represented as
+  `Arc<Mutex<_>>` plus spawned service tasks;
+- some immutable objects acquire one strong reference per callback adapter
+  rather than one per independently owned runtime.
+
+Concrete instances of each pattern exist in the current tree:
+
+- the connection actor clones its `CancellationToken` and awaits
+  `cancelled_owned()` inside its own `select!` loop (`src/connection/mod.rs`,
+  `src/connection/polling.rs`), where the borrowing `cancelled()` future would
+  suffice;
+- `PushHandle::push_with_priority` clones an `mpsc::Sender` before calling
+  `send`, although `send` takes `&self` (`src/push/queues/handle.rs`);
+- `FnService` stores its middleware function as `Arc<F>` despite being its
+  sole owner (`src/middleware.rs`);
+- `ProtocolHooks::from_protocol` clones the same `Arc` of the protocol
+  object once per callback adapter — six clones for one protocol
+  (`src/hooks.rs`);
+- the connection actor stores a connection-local fragmenter as
+  `Option<Arc<Fragmenter>>` although it is never shared
+  (`src/connection/mod.rs`);
+- the client-pool scheduler couples an `Arc<PoolScheduler>` root, a
+  `Mutex<SchedulerState>`, an atomic single-flight flag, and spawn-on-demand
+  service tasks (`src/client/pool/scheduler.rs`).
+
+Without an explicit policy, local fixes can remove individual clones while
+later changes recreate the same topology under different names.
+
+## Prior Art
+
+Tokio's own guidance frames the policy this ADR adopts. The Tokio tutorial
+states that spawned tasks must satisfy `'static` and that `Arc` is the tool for
+data genuinely shared between concurrent tasks — not a default for all task
+state.[^1] `tokio_util::sync::CancellationToken` deliberately offers both
+`cancelled(&self)`, whose future borrows the token, and
+`cancelled_owned(self)`, whose future consumes an owned clone; the borrowed
+form exists precisely for persistent owners awaiting cancellation in place.[^2]
+`TaskTracker` pairs with `CancellationToken` as the recommended
+graceful-shutdown mechanism for genuinely independent tasks.[^3] The actor rule
+follows the widely adopted pattern described by Alice Ryhl: one task
+exclusively owns the state, handles communicate through a command enum with
+oneshot replies, and closing the mailbox is the shutdown signal.[^4]
+
+## Traceability
+
+This ADR governs Epic [#635](https://github.com/leynos/wireframe/issues/635)
+and especially the following runtime surfaces:
+
+- `src/connection/mod.rs` and `src/connection/polling.rs`;
+- `src/push/queues/handle.rs`;
+- `src/middleware.rs`;
+- `src/hooks.rs`;
+- `src/server/runtime.rs` and `src/server/connection_spawner.rs`;
+- `src/client/pool/*`.
+
+It complements rather than supersedes:
+
+- [ADR 010](adr-010-transport-frame-boundary-for-zero-copy.md), which fixes
+  the packet/transport-frame ownership boundary;
+- [#34](https://github.com/leynos/wireframe/issues/34), which removed a
+  historical double-spawn path;
+- [#535](https://github.com/leynos/wireframe/issues/535),
+  [#548](https://github.com/leynos/wireframe/issues/548), [#550](https://github.com/leynos/wireframe/issues/550),
+  and [#593](https://github.com/leynos/wireframe/issues/593), which cover pool
+  correctness and test gaps;
+- [#547](https://github.com/leynos/wireframe/issues/547) and
+  [#549](https://github.com/leynos/wireframe/issues/549), which cover
+  protocol-hook and lifecycle correctness.
+
+Implementation of this ADR is sequenced through:
+
+- [#639](https://github.com/leynos/wireframe/issues/639), runtime ownership
+  and task-churn baselines;
+- [#640](https://github.com/leynos/wireframe/issues/640), removal of
+  unambiguous local shared-ownership taxes;
+- [#648](https://github.com/leynos/wireframe/issues/648), collapse of nested
+  application-owned sharing;
+- [#649](https://github.com/leynos/wireframe/issues/649), publication and
+  regression guidance.
+
+## Decision Drivers
+
+- Make ownership express runtime lifetime rather than compiler appeasement.
+- Avoid atomic reference-count operations on event-loop and message hot paths
+  when borrowing suffices.
+- Keep independent tasks self-contained and cancellation-safe.
+- Preserve legitimate cloneable handles and weak registries.
+- Make mutable shared state expose a protocol rather than unrestricted lock
+  access where one owner can serialize operations.
+- Retain ordinary Tokio ergonomics without introducing a custom executor or
+  unsafe lifetime extension.
+- Give reviews a stable vocabulary for rejecting accidental `'static`
+  inflation.
+
+## Options Considered
+
+### Option A: treat `Arc` as normal Tokio plumbing
+
+Continue accepting `Arc` whenever a type must satisfy
+`Clone + Send + Sync + 'static`, and optimize only after profiling identifies a
+hot path.
+
+This minimizes design work but allows ownership topology to drift. It also
+makes refactors harder because APIs stop communicating whether sharing is
+essential or incidental.
+
+### Option B: prohibit `Arc` in runtime code
+
+Require ownership transfer, borrowing, or actors everywhere and permit `Arc`
+only inside dependency types.
+
+This produces simple local rules but is too rigid. `PushHandle`, weak session
+registries, application-wide immutable state, and independent connection tasks
+have genuine multiple ownership.
+
+### Option C: use one shared root per independently owned graph and borrow beneath it (preferred)
+
+Allow `Arc` at explicit lifetime boundaries, then borrow or move fields inside
+the task. Use structured concurrency for scope-bound work and actors/channels
+for mutable coordination with one conceptual owner.
+
+This preserves legitimate sharing while making nested shared ownership
+exceptional and reviewable.
+
+| Topic                        | Option A: accept `Arc` | Option B: prohibit `Arc` | Option C: shared roots |
+| ---------------------------- | ---------------------- | ------------------------ | ---------------------- |
+| Ownership clarity            | Weak                   | Strong                   | Strong                 |
+| Fit with legitimate sharing  | Good                   | Poor                     | Good                   |
+| Hot-path refcount traffic    | High                   | Low                      | Low                    |
+| Design and review effort     | Low                    | High                     | Medium                 |
+| Resistance to topology drift | Weak                   | Strong                   | Strong                 |
+
+_Table 1: Trade-offs for the runtime ownership policy._
+
+## Decision Outcome
+
+Adopt Option C.
+
+Wireframe will apply the following rules.
+
+### 1. Spawn only for independent lifetime or scheduling
+
+Use `tokio::spawn` or `TaskTracker::spawn` when the child:
+
+- may outlive the current call scope;
+- must be independently cancelled or supervised;
+- represents a long-lived runtime component;
+- or must execute independently across Tokio worker threads.
+
+When all child work is awaited before the parent returns, prefer borrowing
+futures through `join!`, `try_join!`, `select!`, `FuturesUnordered`, or an
+equivalent scoped future collection.
+
+A spawn is not justified merely to make an async block easier to type or to
+obtain `'static`.
+
+### 2. Put `Arc` at graph roots, not on every node
+
+An independently owned task may clone one `Arc` that roots the immutable/shared
+object graph it needs. Values reachable exclusively through that root should
+ordinarily be stored by value or behind `Box`, not another `Arc`.
+
+Nested `Arc` remains appropriate when a child node has an ownership lifetime
+independent of the root, such as a cloneable public handle that can escape by
+itself.
+
+### 3. Borrow owned handles within the task
+
+If an actor already owns a `CancellationToken`, sender, route table, protocol
+object, or configuration object for the duration of an operation, call borrowed
+APIs rather than cloning an owned handle solely to create a future.
+
+Examples governed by this rule include:
+
+- `CancellationToken::cancelled()` instead of cloning then calling
+  `cancelled_owned()` inside a persistent actor loop;
+- `mpsc::Sender::send(&self, value)` without cloning the sender first;
+- borrowing a prepared route table from the application root during one
+  connection task.
+
+### 4. Move sole-owned values directly
+
+Values with exactly one runtime owner should be stored directly, even when the
+type itself supports concurrent use. Examples include a connection-local
+`Fragmenter` and a middleware function owned by one `FnService`.
+
+Thread-safe internals do not imply shared ownership at every call site.
+
+### 5. Use actors for one-owner mutable coordination
+
+When mutable state has one conceptual authority, prefer one task owning the
+state and receiving commands over `Arc<Mutex<State>>` plus multiple tasks
+mutating it.
+
+This rule applies especially to the client-pool scheduler. The actor's command
+handle may be cloneable; the scheduler state itself should have one owner.
+
+### 6. Preserve legitimate shared handles
+
+This ADR explicitly retains shared ownership where it communicates real
+semantics:
+
+- `PushHandle` and Tokio channel senders used by independent producers;
+- `SessionRegistry` weak references that do not extend connection lifetime;
+- application data values returned as owned shared handles;
+- `OwnedSemaphorePermit` and the Tokio semaphore state it references;
+- one prepared-application root shared by independent connection tasks;
+- one client-pool root shared by pool handles and leases.
+
+### 7. Do not substitute `Rc` merely to avoid atomics
+
+Wireframe targets Tokio's multithreaded runtime and exposes `Send` APIs. A
+local runtime and `Rc` may be valid in downstream applications, but core
+Wireframe runtime types should not switch to thread-local sharing solely to
+remove atomic operations.
+
+## Consequences
+
+### Positive
+
+- Types and fields communicate lifetime intent more clearly.
+- Event-loop and push hot paths avoid needless refcount operations.
+- Connection-local state becomes easier to test and reason about.
+- Actor state invariants remain behind a protocol rather than a
+  general-purpose lock.
+- Future code review can distinguish a legitimate shared handle from
+  accidental `'static` inflation.
+
+### Negative
+
+- Some refactors require more explicit lifetime parameters or scoped future
+  types.
+- Splitting builders, prepared templates, and runtimes creates more named
+  types.
+- A persistent actor task has lifecycle and shutdown machinery that must be
+  tested.
+- A single shared root can become a new god-object if capability boundaries
+  are ignored.
+
+## Rejected Shortcuts
+
+- Replacing every `Arc<T>` with `T: Clone` without checking semantic
+  ownership.
+- Hiding nested `Arc` behind type aliases while retaining the same ownership
+  graph.
+- Adding unsafe scoped-task abstractions to bypass Tokio's `'static`
+  requirement.
+- Treating microbenchmarks as the sole justification for an ownership model;
+  correctness and lifetime clarity remain primary.
+
+## Migration Plan
+
+### Phase 1: remove unambiguous local taxes
+
+Land behaviour-preserving changes that borrow existing handles or move
+sole-owned values directly.
+
+### Phase 2: establish explicit runtime roots
+
+Adopt ADR 012's prepared application root and ADR 013's client-pool
+scheduler/slot root.
+
+### Phase 3: collapse nested ownership
+
+Replace nested callback, route, protocol, assembler, scheduler, and slot `Arc`
+layers that no longer encode independent lifetimes.
+
+### Phase 4: verify and document
+
+Add benchmarks, shutdown tests, mutation tests, and developer guidance that
+make the intended ownership boundaries visible.
+
+## Verification
+
+Implementation work governed by this ADR should demonstrate:
+
+- no behaviour change in cancellation, fairness, backpressure, or shutdown;
+- no new leaked task or strong-reference cycle;
+- no loss of public cloneable-handle semantics;
+- benchmark coverage for affected hot paths;
+- tests that prove actors and connection tasks terminate after their final
+  owning handle is dropped or cancellation is requested.
+
+## Outstanding Decisions
+
+ADR 012 must decide the exact application preparation frequency and migration
+path for `AppFactory`.
+
+ADR 013 must decide the client-pool scheduler command transport, shutdown
+protocol, and bounded-waiter integration.
+
+## References
+
+- Epic [#635](https://github.com/leynos/wireframe/issues/635)
+- [ADR 010: transport-frame boundary for the zero-copy migration](adr-010-transport-frame-boundary-for-zero-copy.md)
+- [#34](https://github.com/leynos/wireframe/issues/34)
+- [#535](https://github.com/leynos/wireframe/issues/535)
+- [#547](https://github.com/leynos/wireframe/issues/547)
+- [#548](https://github.com/leynos/wireframe/issues/548)
+- [#549](https://github.com/leynos/wireframe/issues/549)
+- [#550](https://github.com/leynos/wireframe/issues/550)
+- [#593](https://github.com/leynos/wireframe/issues/593)
+- Tokio `spawn`, `CancellationToken`, `mpsc`, and semaphore APIs already used
+  by the repository
+
+[^1]: [Tokio tutorial: spawning](https://tokio.rs/tokio/tutorial/spawning),
+    on the `'static` bound and sharing data between tasks with `Arc`.
+
+[^2]: [`tokio_util::sync::CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html),
+    documenting `cancelled` and `cancelled_owned`.
+
+[^3]: [`tokio_util::task::TaskTracker`](https://docs.rs/tokio-util/latest/tokio_util/task/struct.TaskTracker.html),
+    documenting the close-then-wait shutdown contract.
+
+[^4]: Alice Ryhl,
+    [Actors with Tokio](https://ryhl.io/blog/actors-with-tokio/).

--- a/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
+++ b/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
@@ -29,25 +29,30 @@ blurred ownership graph:
 - some immutable objects acquire one strong reference per callback adapter
   rather than one per independently owned runtime.
 
-Concrete instances of each pattern exist in the current tree:
+Concrete instances of each pattern exist in the current tree. Each is annotated
+with its frequency class so baseline and benchmark effort
+([#639](https://github.com/leynos/wireframe/issues/639)) concentrates on the
+hot cases; the one-time cases are justified on clarity grounds alone:
 
 - the connection actor clones its `CancellationToken` and awaits
   `cancelled_owned()` inside its own `select!` loop (`src/connection/mod.rs`,
   `src/connection/polling.rs`), where the borrowing `cancelled()` future would
-  suffice;
+  suffice — once per actor-loop iteration;
 - `PushHandle::push_with_priority` clones an `mpsc::Sender` before calling
-  `send`, although `send` takes `&self` (`src/push/queues/handle.rs`);
-- `FnService` stores its middleware function as `Arc<F>` despite being its
-  sole owner (`src/middleware.rs`);
-- `ProtocolHooks::from_protocol` clones the same `Arc` of the protocol
-  object once per callback adapter — six clones for one protocol
-  (`src/hooks.rs`);
-- the connection actor stores a connection-local fragmenter as
-  `Option<Arc<Fragmenter>>` although it is never shared
-  (`src/connection/mod.rs`);
+  `send`, although `send` takes `&self` (`src/push/queues/handle.rs`) — once
+  per pushed message;
 - the client-pool scheduler couples an `Arc<PoolScheduler>` root, a
   `Mutex<SchedulerState>`, an atomic single-flight flag, and spawn-on-demand
-  service tasks (`src/client/pool/scheduler.rs`).
+  service tasks (`src/client/pool/scheduler.rs`) — once per acquisition or
+  lease drop;
+- `ProtocolHooks::from_protocol` clones the same `Arc` of the protocol
+  object once per callback adapter — six clones for one protocol
+  (`src/hooks.rs`) — once per connection;
+- the connection actor stores a connection-local fragmenter as
+  `Option<Arc<Fragmenter>>` although it is never shared
+  (`src/connection/mod.rs`) — once per connection;
+- `FnService` stores its middleware function as `Arc<F>` despite being its
+  sole owner (`src/middleware.rs`) — once per application build.
 
 Without an explicit policy, local fixes can remove individual clones while
 later changes recreate the same topology under different names.
@@ -137,34 +142,54 @@ only inside dependency types.
 
 This produces simple local rules but is too rigid. `PushHandle`, weak session
 registries, application-wide immutable state, and independent connection tasks
-have genuine multiple ownership.
+have genuine multiple ownership. This option is included to mark the outer
+boundary of the design space rather than as a live candidate.
 
-### Option C: use one shared root per independently owned graph and borrow beneath it (preferred)
+### Option C: use one shared root per independently owned graph and borrow beneath it
 
 Allow `Arc` at explicit lifetime boundaries, then borrow or move fields inside
 the task. Use structured concurrency for scope-bound work and actors/channels
 for mutable coordination with one conceptual owner.
 
 This preserves legitimate sharing while making nested shared ownership
-exceptional and reviewable.
+exceptional and reviewable. Enforcement rests entirely on review vocabulary,
+which is the weakest defence against the drift this ADR exists to stop.
 
-| Topic                        | Option A: accept `Arc` | Option B: prohibit `Arc` | Option C: shared roots |
-| ---------------------------- | ---------------------- | ------------------------ | ---------------------- |
-| Ownership clarity            | Weak                   | Strong                   | Strong                 |
-| Fit with legitimate sharing  | Good                   | Poor                     | Good                   |
-| Hot-path refcount traffic    | High                   | Low                      | Low                    |
-| Design and review effort     | Low                    | High                     | Medium                 |
-| Resistance to topology drift | Weak                   | Strong                   | Strong                 |
+### Option D: shared roots plus mechanical enforcement (preferred)
+
+Adopt Option C's rules and back the mechanically recognizable ones with lints.
+The repository already runs a Dylint suite in its commit gates, so the
+enforcement machinery exists today. Patterns with grep-able signatures — an
+owned-cancellation clone inside a persistent loop, a sender clone immediately
+before an `&self` `send` — gain `disallowed_methods` or custom Dylint coverage,
+with a tightly scoped, justified `#[allow]` as the escape hatch for legitimate
+rule R6 sharing. Semantic judgements (graph shape, nested-`Arc` topology)
+remain review-enforced through the
+[#649](https://github.com/leynos/wireframe/issues/649) checklist.
+
+| Topic                        | Option A: accept `Arc` | Option B: prohibit `Arc` | Option C: shared roots | Option D: C plus lints |
+| ---------------------------- | ---------------------- | ------------------------ | ---------------------- | ---------------------- |
+| Ownership clarity            | Weak                   | Strong                   | Strong                 | Strong                 |
+| Fit with legitimate sharing  | Good                   | Poor                     | Good                   | Good                   |
+| Hot-path refcount traffic    | High                   | Low                      | Low                    | Low                    |
+| Design and review effort     | Low                    | High                     | Medium                 | Medium                 |
+| Resistance to topology drift | Weak                   | Strong                   | Review-dependent       | Strong                 |
 
 _Table 1: Trade-offs for the runtime ownership policy._
 
 ## Decision Outcome
 
-Adopt Option C.
+Adopt Option D: Option C's ownership rules, with mechanical enforcement for the
+lint-expressible subset.
 
-Wireframe will apply the following rules.
+Wireframe will apply the following rules. Each rule carries a stable identifier
+(R1-R7) so reviews and the
+[#649](https://github.com/leynos/wireframe/issues/649) developer-guide
+checklist can cite it without paraphrase. The single litmus question behind R2,
+R4, and R6 is: **can this value escape its owner independently? If not, it does
+not get its own `Arc`.**
 
-### 1. Spawn only for independent lifetime or scheduling
+### R1. Spawn only for independent lifetime or scheduling
 
 Use `tokio::spawn` or `TaskTracker::spawn` when the child:
 
@@ -180,7 +205,7 @@ equivalent scoped future collection.
 A spawn is not justified merely to make an async block easier to type or to
 obtain `'static`.
 
-### 2. Put `Arc` at graph roots, not on every node
+### R2. Put `Arc` at graph roots, not on every node
 
 An independently owned task may clone one `Arc` that roots the immutable/shared
 object graph it needs. Values reachable exclusively through that root should
@@ -190,7 +215,7 @@ Nested `Arc` remains appropriate when a child node has an ownership lifetime
 independent of the root, such as a cloneable public handle that can escape by
 itself.
 
-### 3. Borrow owned handles within the task
+### R3. Borrow owned handles within the task
 
 If an actor already owns a `CancellationToken`, sender, route table, protocol
 object, or configuration object for the duration of an operation, call borrowed
@@ -204,7 +229,7 @@ Examples governed by this rule include:
 - borrowing a prepared route table from the application root during one
   connection task.
 
-### 4. Move sole-owned values directly
+### R4. Move sole-owned values directly
 
 Values with exactly one runtime owner should be stored directly, even when the
 type itself supports concurrent use. Examples include a connection-local
@@ -212,7 +237,7 @@ type itself supports concurrent use. Examples include a connection-local
 
 Thread-safe internals do not imply shared ownership at every call site.
 
-### 5. Use actors for one-owner mutable coordination
+### R5. Use actors for one-owner mutable coordination
 
 When mutable state has one conceptual authority, prefer one task owning the
 state and receiving commands over `Arc<Mutex<State>>` plus multiple tasks
@@ -221,7 +246,12 @@ mutating it.
 This rule applies especially to the client-pool scheduler. The actor's command
 handle may be cloneable; the scheduler state itself should have one owner.
 
-### 6. Preserve legitimate shared handles
+An actor is warranted when the state carries at least two coupled invariants or
+a shutdown protocol. Otherwise a plain owned struct with `&mut self` methods
+suffices; this criterion stops the policy itself from driving actor
+proliferation.
+
+### R6. Preserve legitimate shared handles
 
 This ADR explicitly retains shared ownership where it communicates real
 semantics:
@@ -233,7 +263,7 @@ semantics:
 - one prepared-application root shared by independent connection tasks;
 - one client-pool root shared by pool handles and leases.
 
-### 7. Do not substitute `Rc` merely to avoid atomics
+### R7. Do not substitute `Rc` merely to avoid atomics
 
 Wireframe targets Tokio's multithreaded runtime and exposes `Send` APIs. A
 local runtime and `Rc` may be valid in downstream applications, but core
@@ -293,19 +323,32 @@ layers that no longer encode independent lifetimes.
 
 ### Phase 4: verify and document
 
-Add benchmarks, shutdown tests, mutation tests, and developer guidance that
-make the intended ownership boundaries visible.
+Add benchmarks, shutdown tests, mutation tests, lint coverage for the
+mechanically enforceable rules, and developer guidance that makes the intended
+ownership boundaries visible. The
+[#649](https://github.com/leynos/wireframe/issues/649) developer-guide
+checklist is the canonical review artefact derived from rules R1-R7, with this
+ADR as its source of truth.
 
 ## Verification
 
 Implementation work governed by this ADR should demonstrate:
 
-- no behaviour change in cancellation, fairness, backpressure, or shutdown;
+- no change to externally contracted behaviour in cancellation, fairness,
+  backpressure, or shutdown; the intentional behaviour changes are recorded in
+  [ADR 012](adr-012-prepared-application-and-connection-runtime.md) (factory
+  evaluation frequency, readiness timing, startup error surfacing) and
+  [ADR 013](adr-013-client-pool-scheduler-and-slot-ownership.md) (lease-drop
+  servicing), and this ADR must not be cited against them;
 - no new leaked task or strong-reference cycle;
 - no loss of public cloneable-handle semantics;
 - benchmark coverage for affected hot paths;
 - tests that prove actors and connection tasks terminate after their final
-  owning handle is dropped or cancellation is requested.
+  owning handle is dropped or cancellation is requested;
+- a recorded lint-or-checklist disposition per rule under
+  [#649](https://github.com/leynos/wireframe/issues/649): R3 and R4 have
+  grep-able signatures and are lint candidates; R1, R2, R5, R6, and R7 are
+  judgement calls enforced through the review checklist.
 
 ## Outstanding Decisions
 

--- a/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
+++ b/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
@@ -4,11 +4,15 @@
 
 Proposed.
 
+First proposed on 2026-08-08 in issue
+[#636](https://github.com/leynos/wireframe/issues/636); imported and refined on
+2026-08-23 following design review.
+
 ## Date
 
-Proposed 2026-08-08. Imported and refined 2026-08-23.
+2026-08-23.
 
-## Context and Problem Statement
+## Context and problem statement
 
 Tokio does not intrinsically require application state to live behind `Arc`.
 The requirement appears when Wireframe creates an independently scheduled
@@ -57,7 +61,7 @@ hot cases; the one-time cases are justified on clarity grounds alone:
 Without an explicit policy, local fixes can remove individual clones while
 later changes recreate the same topology under different names.
 
-## Prior Art
+## Prior art
 
 Tokio's own guidance frames the policy this ADR adopts. The Tokio tutorial
 states that spawned tasks must satisfy `'static` and that `Arc` is the tool for
@@ -109,7 +113,7 @@ Implementation of this ADR is sequenced through:
 - [#649](https://github.com/leynos/wireframe/issues/649), publication and
   regression guidance.
 
-## Decision Drivers
+## Decision drivers
 
 - Make ownership express runtime lifetime rather than compiler appeasement.
 - Avoid atomic reference-count operations on event-loop and message hot paths
@@ -123,7 +127,7 @@ Implementation of this ADR is sequenced through:
 - Give reviews a stable vocabulary for rejecting accidental `'static`
   inflation.
 
-## Options Considered
+## Options considered
 
 ### Option A: treat `Arc` as normal Tokio plumbing
 
@@ -177,7 +181,7 @@ remain review-enforced through the
 
 _Table 1: Trade-offs for the runtime ownership policy._
 
-## Decision Outcome
+## Decision outcome
 
 Adopt Option D: Option C's ownership rules, with mechanical enforcement for the
 lint-expressible subset.
@@ -293,7 +297,7 @@ remove atomic operations.
 - A single shared root can become a new god-object if capability boundaries
   are ignored.
 
-## Rejected Shortcuts
+## Rejected shortcuts
 
 - Replacing every `Arc<T>` with `T: Clone` without checking semantic
   ownership.
@@ -304,7 +308,7 @@ remove atomic operations.
 - Treating microbenchmarks as the sole justification for an ownership model;
   correctness and lifetime clarity remain primary.
 
-## Migration Plan
+## Migration plan
 
 ### Phase 1: remove unambiguous local taxes
 
@@ -350,7 +354,7 @@ Implementation work governed by this ADR should demonstrate:
   grep-able signatures and are lint candidates; R1, R2, R5, R6, and R7 are
   judgement calls enforced through the review checklist.
 
-## Outstanding Decisions
+## Outstanding decisions
 
 ADR 012 must decide the exact application preparation frequency and migration
 path for `AppFactory`.

--- a/docs/adr-012-prepared-application-and-connection-runtime.md
+++ b/docs/adr-012-prepared-application-and-connection-runtime.md
@@ -1,0 +1,391 @@
+# Architectural decision record (ADR) 012: prepared application templates and connection-local runtimes
+
+## Status
+
+Proposed.
+
+## Date
+
+Proposed 2026-08-08. Imported and refined 2026-08-23.
+
+## Context and Problem Statement
+
+`WireframeApp` currently represents three different lifecycle phases:
+
+1. a mutable builder that collects routes, middleware, lifecycle callbacks,
+   protocol hooks, serializer, codec configuration, message assembly, and
+   application data;
+2. an immutable application template read by every connection;
+3. a value constructed afresh by `AppFactory::build` inside each connection
+   task.
+
+Those roles have incompatible ownership requirements.
+
+The builder must own mutable registration collections. The immutable template
+should build middleware chains once and be shared by independent connection
+tasks. The connection runtime should own stream state, lifecycle state, codec
+state, message assembly, fragmentation state, and other values that exist for
+exactly one connection.
+
+The current hybrid creates several observable problems:
+
+- route chains are built lazily from a fresh app for each connection;
+- the route table is stored as
+  `OnceCell<Arc<HashMap<u32, HandlerService<E>>>>` and cloned into connection
+  handling even though the app remains alive for the whole connection;
+- the generic server and examples use different application-sharing
+  topologies: `examples/support/runtime_bootstrap.rs` shares one
+  `Arc<WireframeApp>` across connections and bypasses `AppFactory` entirely;
+- documentation variously describes an app per worker and an app per
+  connection; the rustdoc for `WireframeServer` states that each worker
+  "receives its own `WireframeApp`", while the code builds one per accepted
+  connection;
+- application-owned callbacks and protocol objects acquire nested `Arc`
+  layers because the shared template itself is not explicit;
+- factory failures happen after a connection has already been accepted and
+  are logged rather than reported as startup failure; `ServerError` currently
+  has only `Bind` and `Accept` variants;
+- lifecycle teardown and protocol-hook correctness must be threaded through
+  a type that also carries builder-only state.
+
+## Traceability
+
+This ADR governs the application half of Epic
+[#635](https://github.com/leynos/wireframe/issues/635) and implements ADR 011's
+shared-root rule.
+
+Primary code surfaces:
+
+- `src/app/builder/core.rs`;
+- `src/app/builder/routing.rs`;
+- `src/app/builder/lifecycle.rs`;
+- `src/app/builder/protocol.rs`;
+- `src/app/inbound_handler.rs`;
+- `src/server/mod.rs`;
+- `src/server/runtime.rs`;
+- `src/server/runtime/accept.rs`;
+- `src/server/connection_spawner.rs`;
+- `examples/support/runtime_bootstrap.rs`.
+
+Related issues and decisions:
+
+- Epic [#635](https://github.com/leynos/wireframe/issues/635);
+- ADR 011 proposal [#636](https://github.com/leynos/wireframe/issues/636);
+- [ADR 010](adr-010-transport-frame-boundary-for-zero-copy.md), whose
+  packet/transport-frame boundary remains unchanged;
+- [#547](https://github.com/leynos/wireframe/issues/547), normal app
+  responses bypass configured protocol hooks;
+- [#549](https://github.com/leynos/wireframe/issues/549), teardown is
+  skipped after stream-processing errors;
+- [#598](https://github.com/leynos/wireframe/issues/598), public protocol
+  and message-assembler accessors lack direct coverage;
+- [#538](https://github.com/leynos/wireframe/issues/538), zero-copy
+  serializer output migration, which remains a separate concern.
+
+Implementation of this ADR is sequenced through:
+
+- [#641](https://github.com/leynos/wireframe/issues/641), `PreparedApp` and
+  one-time route/middleware preparation;
+- [#642](https://github.com/leynos/wireframe/issues/642), preparing the
+  application before server readiness;
+- [#643](https://github.com/leynos/wireframe/issues/643), the
+  connection-local runtime and centralized lifecycle finalization;
+- [#644](https://github.com/leynos/wireframe/issues/644), consolidated
+  protocol ownership and hook dispatch;
+- [#648](https://github.com/leynos/wireframe/issues/648), collapse of
+  nested application-owned sharing beneath `PreparedApp`.
+
+## Decision Drivers
+
+- Prepare immutable routing and middleware state once, before serving
+  traffic.
+- Make readiness mean that application preparation has succeeded.
+- Give each connection explicit ownership of connection-local state.
+- Preserve one clear shared ownership root for independent connection
+  tasks.
+- Surface application construction errors deterministically.
+- Avoid arbitrary per-worker state duplication on a multithreaded executor
+  where accept-loop tasks are not thread-affine.
+- Keep the migration reviewable and avoid coupling it to ADR 010 or the
+  zero-copy public API migration.
+
+## Options Considered
+
+### Option A: retain a fresh `WireframeApp` per connection
+
+Continue invoking `AppFactory::build` in the connection task and optimize
+individual fields in place.
+
+This preserves current runtime behaviour but repeats application construction,
+leaves startup readiness underspecified, and keeps the builder/template/runtime
+roles entangled.
+
+### Option B: prepare one application per accept-loop worker
+
+Invoke the factory once per configured worker and share that prepared app among
+connections accepted by the worker.
+
+This reduces per-connection construction, but accept-loop tasks are not pinned
+to executor threads. Per-worker application state therefore partitions state by
+an implementation detail rather than by a meaningful ownership boundary, and it
+duplicates route/middleware preparation `workers` times. The per-worker model
+suits actix-web, whose workers are single-threaded runtimes with thread-affine
+state; Wireframe's accept loops run on a shared multithreaded runtime, so the
+analogy does not transfer.
+
+### Option C: prepare one application template per server and create one runtime per connection (preferred)
+
+Invoke the application factory once during server startup, consume the
+resulting builder into an immutable prepared template, and share one
+`Arc<PreparedApp>` among independent connection tasks. Create connection-local
+runtime state after accept.
+
+This aligns preparation, readiness, sharing, and connection ownership. It
+matches the shape used across the ecosystem: tower's `MakeService` builds one
+factory whose cheap per-connection services derive from shared configuration,
+and hyper 1.x constructs a per-connection service value in the accept loop
+while routing/configuration state stays shared.
+
+### Option D: expose both per-server and per-connection application strategies immediately
+
+Add explicit strategy types or constructors and preserve both models as
+first-class APIs.
+
+This offers flexibility but doubles the lifecycle surface before the project
+has evidence that per-connection application construction is needed.
+Per-connection resources can already be created through the connection setup
+hook.
+
+| Topic                       | Option A: per connection | Option B: per worker | Option C: per server | Option D: both APIs |
+| --------------------------- | ------------------------ | -------------------- | -------------------- | ------------------- |
+| Preparation repeated        | Per connection           | Per worker           | Once                 | Depends on choice   |
+| Readiness meaning           | Undefined                | Partial              | Precise              | Ambiguous           |
+| Ownership boundary fidelity | Weak                     | Accidental           | Strong               | Mixed               |
+| Public API surface          | Unchanged                | New                  | Small change         | Doubled             |
+| Migration size              | None                     | Medium               | Medium               | Large               |
+
+_Table 1: Trade-offs for application preparation frequency._
+
+## Decision Outcome
+
+Adopt Option C.
+
+### 1. Separate the lifecycle phases
+
+Wireframe will distinguish the following concepts, whether initially public or
+crate-private:
+
+```text
+WireframeApp builder
+        │
+        │ prepare().await
+        ▼
+PreparedApp
+        │ Arc clone at independent connection-task boundary
+        ▼
+ConnectionRuntime
+```
+
+#### `WireframeApp`
+
+`WireframeApp` remains the fluent registration/builder surface. It owns mutable
+route and middleware registrations and is not used directly to process a stream
+after preparation.
+
+#### `PreparedApp`
+
+`PreparedApp` is immutable after construction. It owns by value or `Box`:
+
+- the prepared route table and completed middleware chains;
+- serializer and codec templates/configuration;
+- application data;
+- lifecycle callback definitions;
+- protocol and message-assembler implementations;
+- immutable fragmentation, memory-budget, timeout, and push configuration.
+
+The server owns one `Arc<PreparedApp>` and clones it once per independent
+connection task. Values that cannot escape independently should not add another
+`Arc` layer merely because the prepared root is shared.
+
+#### `ConnectionRuntime`
+
+`ConnectionRuntime` owns values whose lifetime is exactly one connection:
+
+- accepted/rewound stream and framed codec state;
+- connection setup state `C`;
+- `ConnectionContext` and protocol-hook invocation state;
+- inbound frame pipeline, deserialization failure count, fragment
+  reassembly, and message assembly;
+- outbound connection actor state, connection-local `Fragmenter`, queues,
+  and cancellation observations;
+- peer metadata and teardown guard.
+
+Connection-local resources are created through setup/runtime construction, not
+by rebuilding the entire application.
+
+### 2. Prepare before readiness
+
+`run_with_shutdown` will:
+
+1. evaluate `AppFactory` once;
+2. prepare routes and middleware chains;
+3. construct the shared `PreparedApp` root;
+4. spawn accept loops;
+5. send the readiness signal through the existing `ready_tx` oneshot
+   channel.
+
+Application build or preparation errors become `ServerError` variants and fail
+startup. No connection is accepted by a server whose application template
+failed to prepare.
+
+### 3. Treat `AppFactory` as a startup factory
+
+The existing `WireframeServer::new(factory)` surface may remain during
+migration, but the factory is evaluated once per server run rather than once
+per connection.
+
+The implementation issue must assess semver impact and choose one of:
+
+- document the new evaluation semantics as a bug/performance correction if
+  no supported contract promised per-connection invocation;
+- introduce a direct `WireframeServer::from_app(app)` or
+  `from_prepared_app` constructor and deprecate ambiguous factory semantics;
+- retain an explicitly named per-connection factory API only if a concrete
+  use case cannot be expressed through connection setup state.
+
+The final public API disposition must be recorded before this ADR is accepted.
+
+### 4. Build route chains exactly once
+
+Middleware transformation may remain asynchronous, so `prepare()` may be async.
+The resulting route map is owned directly by `PreparedApp`; no inner
+`Arc<HashMap<...>>` or per-connection `OnceCell` clone is required.
+
+### 5. Make lifecycle cleanup structural
+
+Once setup succeeds, teardown must run exactly once on every terminal path,
+including decode, protocol, transport, cancellation, and panic-recovery paths
+where execution can safely continue. Today, `handle_connection_result` returns
+early when stream processing fails and skips the teardown callback entirely.
+The connection runtime should use an explicit guard/finalization path rather
+than a clean-path-only tail call. This coordinates with
+[#549](https://github.com/leynos/wireframe/issues/549).
+
+### 6. Apply protocol hooks consistently
+
+The prepared protocol definition and connection-local hook context must cover
+normal app responses as well as actor-driven push/streaming output. This
+coordinates with [#547](https://github.com/leynos/wireframe/issues/547) while
+preserving ADR 010's packet-oriented hook decision.
+
+### 7. Unify examples with the production runtime
+
+Examples should stop maintaining a separate `Arc<WireframeApp>` bootstrap
+topology. They should exercise the same preparation and server runtime used by
+library consumers, unless an example deliberately demonstrates a lower-level
+API.
+
+## Consequences
+
+### Positive
+
+- Route and middleware preparation no longer repeats per connection.
+- Readiness acquires a precise meaning.
+- One `Arc<PreparedApp>` reflects one real shared ownership boundary.
+- Connection-local invariants become visible in a dedicated type.
+- Startup failures become deterministic and observable.
+- Lifecycle and protocol-hook fixes gain one structural home.
+- The generic server and examples share one topology.
+
+### Negative
+
+- Existing factory side effects or per-connection assumptions may change
+  behaviour.
+- `prepare()` introduces an explicit asynchronous startup phase.
+- `ServerError` grows application-build/preparation variants.
+- More internal types and transition code increase short-term refactor
+  size.
+- Tests that called `WireframeApp::handle_connection_result` directly may
+  need a preparation helper or lower-level harness.
+
+## Rejected Shortcuts
+
+- Keeping `WireframeApp` as all three phases and only changing
+  `OnceCell<Arc<_>>` to `OnceCell<_>`.
+- Building one template per worker without thread affinity or a
+  worker-local-state requirement.
+- Making the whole builder `Clone` and cloning it into every connection.
+- Moving connection-local mutable state into the shared prepared root
+  behind locks.
+
+## Migration Plan
+
+### Phase 1: introduce internal preparation types
+
+Add `PreparedApp` and `ConnectionRuntime` internally, with compatibility
+wrappers for current entry points
+([#641](https://github.com/leynos/wireframe/issues/641)).
+
+### Phase 2: move route and middleware preparation
+
+Consume handler and middleware registrations during preparation and remove
+per-connection route initialization
+([#641](https://github.com/leynos/wireframe/issues/641)).
+
+### Phase 3: switch server startup
+
+Evaluate and prepare the app before spawning accept loops and readiness
+notification. Thread one prepared root into connection tasks
+([#642](https://github.com/leynos/wireframe/issues/642)).
+
+### Phase 4: collapse nested ownership
+
+Replace application-owned `Arc` callback/assembler layers with direct or boxed
+ownership where they cannot escape independently
+([#648](https://github.com/leynos/wireframe/issues/648)). Consolidate protocol
+ownership under [#644](https://github.com/leynos/wireframe/issues/644).
+
+### Phase 5: settle public API and documentation
+
+Document factory evaluation semantics, update examples, add migration notes if
+required, and expose only the preparation/runtime APIs that downstream users
+genuinely need.
+
+## Verification
+
+- A counter-based test proves the app factory and middleware transforms run
+  once per server run, not once per connection.
+- Multiple simultaneous connections share the same prepared route table
+  without rebuilding it.
+- Readiness is not signalled before preparation completes.
+- Factory/preparation failure prevents acceptance and returns a typed
+  server error.
+- Setup/teardown runs exactly once across clean close and error paths.
+- Protocol `before_send` applies to ordinary responses and actor-driven
+  outputs according to ADR 010.
+- Existing handler ordering, codec, fragmentation, message assembly,
+  memory-budget, and shutdown tests continue to pass.
+- Connection-startup benchmarks compare the old and prepared paths.
+
+## Outstanding Decisions Before Acceptance
+
+- Whether `PreparedApp` and `ConnectionRuntime` remain internal or gain
+  public advanced APIs.
+- The exact public migration for `WireframeServer::new(factory)`.
+- Whether preparation consumes the builder irreversibly or supports a
+  separately cloneable reusable prepared template.
+- How testkit helpers expose preparation without making tests depend on
+  private internals.
+
+## References
+
+- Epic [#635](https://github.com/leynos/wireframe/issues/635)
+- ADR 011 proposal [#636](https://github.com/leynos/wireframe/issues/636)
+- [ADR 010: transport-frame boundary for the zero-copy migration](adr-010-transport-frame-boundary-for-zero-copy.md)
+- [#538](https://github.com/leynos/wireframe/issues/538)
+- [#547](https://github.com/leynos/wireframe/issues/547)
+- [#549](https://github.com/leynos/wireframe/issues/549)
+- [#598](https://github.com/leynos/wireframe/issues/598)
+- [tower `MakeService`](https://docs.rs/tower/latest/tower/trait.MakeService.html)
+- [hyper 1.x server guide](https://hyper.rs/guides/1/server/hello-world/)
+- [actix-web server model](https://actix.rs/docs/server/)

--- a/docs/adr-012-prepared-application-and-connection-runtime.md
+++ b/docs/adr-012-prepared-application-and-connection-runtime.md
@@ -197,8 +197,10 @@ crate-private:
 
 For screen readers: The following diagram shows the three lifecycle phases — the
 `WireframeApp` builder is consumed by `prepare().await` into a `PreparedApp`
-template, which is `Arc`-cloned at each independent connection-task boundary
-into a per-connection `ConnectionRuntime`.
+template; each independent connection task then receives its own clone of the
+shared `Arc<PreparedApp>` and constructs its own connection-local
+`ConnectionRuntime`. The `PreparedApp` remains shared; only the
+`ConnectionRuntime` is per-connection.
 
 ```text
 WireframeApp builder
@@ -206,7 +208,8 @@ WireframeApp builder
         │ prepare().await
         ▼
 PreparedApp
-        │ Arc clone at independent connection-task boundary
+        │ per connection: clone Arc<PreparedApp>,
+        │ construct connection-local runtime
         ▼
 ConnectionRuntime
 ```
@@ -348,18 +351,23 @@ The guard mechanism must be panic-aware. Teardown callbacks are async, so a
 `Drop`-based guard cannot run them during unwind. The terminal paths are
 classified explicitly, and each classification carries its own test:
 
-- **Handler panic, recovered.** The connection task's panic surfaces as a
-  task join error observed by the spawner (or an equivalent recovery point);
-  teardown runs exactly once on that path.
+- **Handler panic, recovered in-task.** Recovery must happen inside the
+  connection task, before the moved `ConnectionRuntime` becomes inaccessible —
+  for example by catching the unwind at the runtime boundary — because a
+  spawner observing a task join error no longer holds the runtime and cannot
+  run its teardown. Teardown runs exactly once on that path. Any panic not
+  recovered in-task falls into the abandoned-unwind classification below and is
+  an accepted, documented gap.
 - **Teardown-callback panic, isolated.** The guard disarms before invoking
   teardown, so a panic inside a teardown callback cannot re-trigger the guard,
   fire teardown twice, or poison later connections.
 - **Abandoned unwind.** Paths where no recovery point exists cannot run an
   async teardown; the implementation must enumerate them and record each as an
   accepted, documented gap rather than an implicit omission.
-- **`panic = "abort"` builds.** Unwind-dependent paths are vacuous; the
-  recovered-panic classification then applies only where the spawner observes
-  task failure without unwinding through the runtime.
+- **`panic = "abort"` builds.** An aborting panic terminates the process
+  immediately: there is no unwind, no join error, and nothing recoverable, so
+  the recovered classification is inapplicable and teardown cannot run. The
+  process-level abort is the accepted outcome.
 
 ### 6. Apply protocol hooks consistently
 
@@ -480,8 +488,7 @@ documentation obligations, delivered under
 - Connection-startup benchmarks compare the old and prepared paths.
 - A readiness waiter observes preparation failure promptly; preparation
   failure is distinguishable from bind failure.
-- A handler panic recovered through the task join path still runs teardown
-  exactly once.
+- A handler panic recovered in-task still runs teardown exactly once.
 - A panic inside a teardown callback does not run teardown twice or poison
   later connections.
 - Each abandoned-unwind path enumerated by the implementation is recorded

--- a/docs/adr-012-prepared-application-and-connection-runtime.md
+++ b/docs/adr-012-prepared-application-and-connection-runtime.md
@@ -143,8 +143,10 @@ runtime state after accept.
 This aligns preparation, readiness, sharing, and connection ownership. It
 matches the shape used across the ecosystem: tower's `MakeService` builds one
 factory whose cheap per-connection services derive from shared configuration,
-and hyper 1.x constructs a per-connection service value in the accept loop
-while routing/configuration state stays shared.
+hyper 1.x constructs a per-connection service value in the accept loop while
+routing/configuration state stays shared, and axum's `Router` is the closest
+structural precedent — a prepared, cheaply cloneable artefact built once and
+handed to every connection.
 
 ### Option D: expose both per-server and per-connection application strategies immediately
 
@@ -156,13 +158,27 @@ has evidence that per-connection application construction is needed.
 Per-connection resources can already be created through the connection setup
 hook.
 
-| Topic                       | Option A: per connection | Option B: per worker | Option C: per server | Option D: both APIs |
-| --------------------------- | ------------------------ | -------------------- | -------------------- | ------------------- |
-| Preparation repeated        | Per connection           | Per worker           | Once                 | Depends on choice   |
-| Readiness meaning           | Undefined                | Partial              | Precise              | Ambiguous           |
-| Ownership boundary fidelity | Weak                     | Accidental           | Strong               | Mixed               |
-| Public API surface          | Unchanged                | New                  | Small change         | Doubled             |
-| Migration size              | None                     | Medium               | Medium               | Large               |
+### Option E: prepare lazily on the first connection
+
+Wrap `PreparedApp` in an async `OnceCell` and prepare it inside the first
+accepted connection, keeping the existing factory API and synchronous startup
+untouched.
+
+This is the natural incremental step from the current
+`OnceCell<Arc<HashMap<...>>>` code and the smallest possible migration, with an
+identical steady-state sharing topology. It is rejected because it forfeits the
+readiness guarantee and deterministic startup failure: preparation errors
+surface on the first client's connection instead of at boot, and the first
+connection pays the preparation latency. Both directly contradict the readiness
+and deterministic-error decision drivers.
+
+| Topic                       | Option A: per connection | Option B: per worker | Option C: per server | Option D: both APIs | Option E: lazy first use |
+| --------------------------- | ------------------------ | -------------------- | -------------------- | ------------------- | ------------------------ |
+| Preparation repeated        | Per connection           | Per worker           | Once                 | Depends on choice   | Once                     |
+| Readiness meaning           | Undefined                | Partial              | Precise              | Ambiguous           | Undefined                |
+| Ownership boundary fidelity | Weak                     | Accidental           | Strong               | Mixed               | Strong                   |
+| Public API surface          | Unchanged                | New                  | Small change         | Doubled             | Unchanged                |
+| Migration size              | None                     | Medium               | Medium               | Large               | Small                    |
 
 _Table 1: Trade-offs for application preparation frequency._
 
@@ -186,11 +202,30 @@ PreparedApp
 ConnectionRuntime
 ```
 
+The split follows one uniform template-versus-instance rule: `PreparedApp` owns
+immutable definitions, configuration, and factories; `ConnectionRuntime` owns
+the per-connection mutable instances derived from them. Where the same domain
+appears in both lists below — protocol hooks, message assembly, fragmentation —
+the prepared side holds the definition and the runtime side holds the
+per-connection invocation or reassembly state, so each concrete responsibility
+has exactly one owner.
+
+`prepare()` consumes the builder by value and returns `PreparedApp`, making
+post-preparation route registration unrepresentable rather than a runtime
+error. This mirrors the sealed `Unbound`/`Bound` typestate that
+`WireframeServer` already uses. A reusable template is expressed as
+`Arc<PreparedApp>`, so no separately cloneable builder snapshot is needed.
+
 #### `WireframeApp`
 
 `WireframeApp` remains the fluent registration/builder surface. It owns mutable
 route and middleware registrations and is not used directly to process a stream
 after preparation.
+
+The builder deliberately keeps the `WireframeApp` name for compatibility even
+though `PreparedApp` becomes the actual application; Phase 5 should consider a
+`WireframeAppBuilder` alias so the vocabulary drift is acknowledged rather than
+silent.
 
 #### `PreparedApp`
 
@@ -200,7 +235,7 @@ after preparation.
 - serializer and codec templates/configuration;
 - application data;
 - lifecycle callback definitions;
-- protocol and message-assembler implementations;
+- protocol and message-assembler definitions;
 - immutable fragmentation, memory-budget, timeout, and push configuration.
 
 The server owns one `Arc<PreparedApp>` and clones it once per independent
@@ -215,7 +250,7 @@ connection task. Values that cannot escape independently should not add another
 - connection setup state `C`;
 - `ConnectionContext` and protocol-hook invocation state;
 - inbound frame pipeline, deserialization failure count, fragment
-  reassembly, and message assembly;
+  reassembly, and message-assembly instance state;
 - outbound connection actor state, connection-local `Fragmenter`, queues,
   and cancellation observations;
 - peer metadata and teardown guard.
@@ -234,9 +269,23 @@ by rebuilding the entire application.
 5. send the readiness signal through the existing `ready_tx` oneshot
    channel.
 
-Application build or preparation errors become `ServerError` variants and fail
-startup. No connection is accepted by a server whose application template
-failed to prepare.
+Application build or preparation errors become distinct `ServerError` variants
+— for example `ServerError::AppBuild` and `ServerError::Prepare`, with
+source-error chaining — so orchestration and rollback automation can
+distinguish preparation failure from `Bind` failure. On failure,
+`run_with_shutdown` returns the typed error and the readiness channel is
+resolved or observably closed rather than silently dropped, so a readiness
+waiter learns of the failure promptly instead of hanging.
+
+Preparation runs arbitrary user middleware transforms, so it must be
+observable: wrap `prepare()` in a tracing span, log its duration, and consider
+an optional preparation timeout mapped to a `ServerError` variant so a hung
+transform fails the deploy loudly instead of stalling readiness forever.
+
+No connection is accepted by a server whose application template failed to
+prepare. This guarantee should be structural, not merely tested: the
+accept-loop spawn takes the `Arc<PreparedApp>` by value, so an accept loop
+cannot exist before preparation has succeeded.
 
 ### 3. Treat `AppFactory` as a startup factory
 
@@ -252,6 +301,19 @@ The implementation issue must assess semver impact and choose one of:
   `from_prepared_app` constructor and deprecate ambiguous factory semantics;
 - retain an explicitly named per-connection factory API only if a concrete
   use case cannot be expressed through connection setup state.
+
+The disposition list must also cover the adjacent public surface the split
+invalidates:
+
+- `WireframeApp::handle_connection_result` and `handle_connection` are `pub`
+  and embody the builder/template/runtime hybrid being dissolved; they should
+  be deprecated on `WireframeApp` and re-homed on the `PreparedApp`/
+  `ConnectionRuntime` path, with removal acceptable pre-1.0 alongside a
+  migration note;
+- the `AppFactory` trait's `Clone` bound and its rustdoc contract ("build an
+  application instance for a new connection") become vestigial under per-server
+  evaluation and must be revised together with the `WireframeServer` rustdoc's
+  per-worker claim.
 
 The final public API disposition must be recorded before this ADR is accepted.
 
@@ -270,6 +332,14 @@ early when stream processing fails and skips the teardown callback entirely.
 The connection runtime should use an explicit guard/finalization path rather
 than a clean-path-only tail call. This coordinates with
 [#549](https://github.com/leynos/wireframe/issues/549).
+
+The guard mechanism must be panic-aware. Teardown callbacks are async, so a
+`Drop`-based guard cannot run them during unwind; the implementation must state
+which paths recover a panic (for example a task join error observed by the
+spawner) and run teardown, and which abandon it — noting that `panic = "abort"`
+builds make unwind paths vacuous. The guard disarms before invoking teardown,
+so a panic inside a teardown callback cannot re-trigger the guard or fire
+teardown twice.
 
 ### 6. Apply protocol hooks consistently
 
@@ -326,6 +396,18 @@ Add `PreparedApp` and `ConnectionRuntime` internally, with compatibility
 wrappers for current entry points
 ([#641](https://github.com/leynos/wireframe/issues/641)).
 
+This phase must also ship the test-harness replacement, because roughly fifteen
+test files and fixtures drive `WireframeApp::handle_connection_result` over
+duplex streams and Phase 1 restructures the type they depend on. Deliver a
+`wireframe_testing`/testkit drive helper (builder, then `prepare().await`, then
+a connection runtime over a duplex stream) alongside
+[#641](https://github.com/leynos/wireframe/issues/641), and migrate existing
+tests through one mechanical, documented substitution.
+
+Compatibility wrappers in this plan are internal scaffolding, not API: they are
+removed before this ADR flips to Accepted, verified at
+[#649](https://github.com/leynos/wireframe/issues/649) closure.
+
 ### Phase 2: move route and middleware preparation
 
 Consume handler and middleware registrations during preparation and remove
@@ -347,9 +429,19 @@ ownership under [#644](https://github.com/leynos/wireframe/issues/644).
 
 ### Phase 5: settle public API and documentation
 
-Document factory evaluation semantics, update examples, add migration notes if
-required, and expose only the preparation/runtime APIs that downstream users
-genuinely need.
+Document factory evaluation semantics, update examples, and expose only the
+preparation/runtime APIs that downstream users genuinely need. The concrete
+documentation obligations, delivered under
+[#649](https://github.com/leynos/wireframe/issues/649), are:
+
+- `docs/users-guide.md`: readiness semantics and factory evaluation
+  frequency;
+- `docs/developers-guide.md`: the ownership section, reproducing the
+  builder/template/runtime diagram from this ADR;
+- a versioned migration guide if `WireframeServer::new(factory)` semantics
+  change observably, following the existing
+  `docs/v0-2-0-to-v0-3-0-migration-guide.md` pattern;
+- the `WireframeAppBuilder` alias decision noted in section 1.
 
 ## Verification
 
@@ -366,16 +458,25 @@ genuinely need.
 - Existing handler ordering, codec, fragmentation, message assembly,
   memory-budget, and shutdown tests continue to pass.
 - Connection-startup benchmarks compare the old and prepared paths.
+- A readiness waiter observes preparation failure promptly; preparation
+  failure is distinguishable from bind failure.
+- A handler panic still runs teardown exactly once; a panic inside teardown
+  does not run teardown twice or poison later connections.
+- Preparation duration is visible in tracing output.
 
 ## Outstanding Decisions Before Acceptance
 
 - Whether `PreparedApp` and `ConnectionRuntime` remain internal or gain
   public advanced APIs.
-- The exact public migration for `WireframeServer::new(factory)`.
-- Whether preparation consumes the builder irreversibly or supports a
-  separately cloneable reusable prepared template.
+- The exact public migration for `WireframeServer::new(factory)`, including
+  the `handle_connection_result`/`handle_connection` and `AppFactory` bound
+  dispositions from section 3.
 - How testkit helpers expose preparation without making tests depend on
-  private internals.
+  private internals, given the Phase 1 drive-helper deliverable.
+
+The question of whether preparation consumes the builder irreversibly is
+resolved in section 1: `prepare()` consumes the builder, and reuse is expressed
+through `Arc<PreparedApp>`.
 
 ## References
 
@@ -389,3 +490,4 @@ genuinely need.
 - [tower `MakeService`](https://docs.rs/tower/latest/tower/trait.MakeService.html)
 - [hyper 1.x server guide](https://hyper.rs/guides/1/server/hello-world/)
 - [actix-web server model](https://actix.rs/docs/server/)
+- [axum `Router`](https://docs.rs/axum/latest/axum/struct.Router.html)

--- a/docs/adr-012-prepared-application-and-connection-runtime.md
+++ b/docs/adr-012-prepared-application-and-connection-runtime.md
@@ -4,11 +4,15 @@
 
 Proposed.
 
+First proposed on 2026-08-08 in issue
+[#637](https://github.com/leynos/wireframe/issues/637); imported and refined on
+2026-08-23 following design review.
+
 ## Date
 
-Proposed 2026-08-08. Imported and refined 2026-08-23.
+2026-08-23.
 
-## Context and Problem Statement
+## Context and problem statement
 
 `WireframeApp` currently represents three different lifecycle phases:
 
@@ -95,7 +99,7 @@ Implementation of this ADR is sequenced through:
 - [#648](https://github.com/leynos/wireframe/issues/648), collapse of
   nested application-owned sharing beneath `PreparedApp`.
 
-## Decision Drivers
+## Decision drivers
 
 - Prepare immutable routing and middleware state once, before serving
   traffic.
@@ -109,7 +113,7 @@ Implementation of this ADR is sequenced through:
 - Keep the migration reviewable and avoid coupling it to ADR 010 or the
   zero-copy public API migration.
 
-## Options Considered
+## Options considered
 
 ### Option A: retain a fresh `WireframeApp` per connection
 
@@ -182,7 +186,7 @@ and deterministic-error decision drivers.
 
 _Table 1: Trade-offs for application preparation frequency._
 
-## Decision Outcome
+## Decision outcome
 
 Adopt Option C.
 
@@ -190,6 +194,11 @@ Adopt Option C.
 
 Wireframe will distinguish the following concepts, whether initially public or
 crate-private:
+
+For screen readers: The following diagram shows the three lifecycle phases — the
+`WireframeApp` builder is consumed by `prepare().await` into a `PreparedApp`
+template, which is `Arc`-cloned at each independent connection-task boundary
+into a per-connection `ConnectionRuntime`.
 
 ```text
 WireframeApp builder
@@ -201,6 +210,8 @@ PreparedApp
         ▼
 ConnectionRuntime
 ```
+
+_Figure 1: Application lifecycle phases from builder to connection runtime._
 
 The split follows one uniform template-versus-instance rule: `PreparedApp` owns
 immutable definitions, configuration, and factories; `ConnectionRuntime` owns
@@ -334,12 +345,21 @@ than a clean-path-only tail call. This coordinates with
 [#549](https://github.com/leynos/wireframe/issues/549).
 
 The guard mechanism must be panic-aware. Teardown callbacks are async, so a
-`Drop`-based guard cannot run them during unwind; the implementation must state
-which paths recover a panic (for example a task join error observed by the
-spawner) and run teardown, and which abandon it — noting that `panic = "abort"`
-builds make unwind paths vacuous. The guard disarms before invoking teardown,
-so a panic inside a teardown callback cannot re-trigger the guard or fire
-teardown twice.
+`Drop`-based guard cannot run them during unwind. The terminal paths are
+classified explicitly, and each classification carries its own test:
+
+- **Handler panic, recovered.** The connection task's panic surfaces as a
+  task join error observed by the spawner (or an equivalent recovery point);
+  teardown runs exactly once on that path.
+- **Teardown-callback panic, isolated.** The guard disarms before invoking
+  teardown, so a panic inside a teardown callback cannot re-trigger the guard,
+  fire teardown twice, or poison later connections.
+- **Abandoned unwind.** Paths where no recovery point exists cannot run an
+  async teardown; the implementation must enumerate them and record each as an
+  accepted, documented gap rather than an implicit omission.
+- **`panic = "abort"` builds.** Unwind-dependent paths are vacuous; the
+  recovered-panic classification then applies only where the spawner observes
+  task failure without unwinding through the runtime.
 
 ### 6. Apply protocol hooks consistently
 
@@ -378,7 +398,7 @@ API.
 - Tests that called `WireframeApp::handle_connection_result` directly may
   need a preparation helper or lower-level harness.
 
-## Rejected Shortcuts
+## Rejected shortcuts
 
 - Keeping `WireframeApp` as all three phases and only changing
   `OnceCell<Arc<_>>` to `OnceCell<_>`.
@@ -388,7 +408,7 @@ API.
 - Moving connection-local mutable state into the shared prepared root
   behind locks.
 
-## Migration Plan
+## Migration plan
 
 ### Phase 1: introduce internal preparation types
 
@@ -460,11 +480,22 @@ documentation obligations, delivered under
 - Connection-startup benchmarks compare the old and prepared paths.
 - A readiness waiter observes preparation failure promptly; preparation
   failure is distinguishable from bind failure.
-- A handler panic still runs teardown exactly once; a panic inside teardown
-  does not run teardown twice or poison later connections.
+- A handler panic recovered through the task join path still runs teardown
+  exactly once.
+- A panic inside a teardown callback does not run teardown twice or poison
+  later connections.
+- Each abandoned-unwind path enumerated by the implementation is recorded
+  with a test or an explicit accepted-gap note.
 - Preparation duration is visible in tracing output.
+- Property-based or bounded-model coverage exercises the lifecycle
+  invariants — preparation runs once, readiness never precedes preparation, and
+  teardown fires exactly once — across generated interleavings of terminal
+  paths (clean close, decode error, transport error, cancellation, and panic),
+  using `proptest`, `loom`, or the bounded checkers described in
+  [formal-verification-methods-in-wireframe.md](formal-verification-methods-in-wireframe.md),
+  mirroring ADR 013's state-machine verification.
 
-## Outstanding Decisions Before Acceptance
+## Outstanding decisions before acceptance
 
 - Whether `PreparedApp` and `ConnectionRuntime` remain internal or gain
   public advanced APIs.

--- a/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
+++ b/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
@@ -1,0 +1,445 @@
+# Architectural decision record (ADR) 013: single-owner client-pool scheduler and slot graph
+
+## Status
+
+Proposed.
+
+## Date
+
+Proposed 2026-08-08. Imported and refined 2026-08-23.
+
+## Context and Problem Statement
+
+The client pool has one conceptual scheduler, one fixed set of physical socket
+slots, and many logical handles and leases. Its current ownership graph is
+substantially more distributed. `WireframeClientPool` wraps one
+`Arc<ClientPoolInner>` shaped as:
+
+```text
+Arc<ClientPoolInner>
+  ├── Arc<[Arc<PoolSlot>]>
+  │       └── Arc<Semaphore>
+  └── Arc<PoolScheduler>
+          ├── Mutex<SchedulerState>
+          ├── AtomicBool service guard
+          └── spawn-on-demand service tasks
+```
+
+This creates several costs and reasoning hazards:
+
+- `ordered_slots()` clones every `Arc<PoolSlot>` for each acquisition;
+- boxed permit futures default to `'static` and therefore own those slot
+  clones even though the race is scoped to one acquisition;
+- a lease owns both an `Arc<PoolSlot>` and optionally an
+  `Arc<ClientPoolInner>` for release notification;
+- dropping a lease can clone the pool and scheduler roots and spawn
+  `service_waiters` even when the waiter queue is empty;
+- fairness state, restart logic, waiter cancellation, shutdown, and capacity
+  notification are divided between a mutex, atomics, callers, and transient
+  tasks;
+- the current model makes race recovery difficult enough that mutation
+  survivors covering shutdown and slot rotation are accepted as untested
+  interleavings ([#593](https://github.com/leynos/wireframe/issues/593)), and
+  scheduler bookkeeping relies on `std::sync::Mutex` poison recovery
+  ([#539](https://github.com/leynos/wireframe/issues/539));
+- [#550](https://github.com/leynos/wireframe/issues/550) requires bounded
+  waiter admission, which adds another invariant to distributed scheduler state.
+
+The scheduler is already actor-shaped in behaviour: callers submit requests,
+one authority orders them, and replies return through oneshot channels. Its
+ownership model should make that authority explicit.
+
+## Prior Art
+
+The mainstream Rust connection pools all avoid a central scheduler task: sqlx
+gates acquisition with a fairness-configurable semaphore and bounds waiting by
+an acquire timeout;[^1] deadpool advertises "no background task" as a feature
+and admits callers through a `tokio::sync::Semaphore`;[^2] bb8 uses lock-based
+state with a FIFO/LIFO `QueueStrategy`.[^3] None of them, however, provides
+Wireframe's contract of per-logical-handle round-robin fairness across a fixed
+slot set, and none needs a single admission point for bounded waiter counts.
+Those requirements are what motivate a central authority here, and the current
+spawn-on-demand servicing already pays for one without gaining its benefits.
+
+The persistent-actor shape follows the pattern described by Alice Ryhl: one
+task exclusively owns the state, commands arrive through a bounded mailbox with
+oneshot replies, mailbox closure is the shutdown signal, and cycles between the
+actor and its handles must be avoided.[^4] A bounded mailbox also gives
+admission control a natural home, which the semaphore-only pools lack. sqlx's
+history is a caution for the waiter queue: its early list-of-waiters design
+leaked entries when acquisitions were cancelled, and the fix was RAII-based
+cancel safety rather than explicit list removal — the same discipline the
+scheduler actor must apply when pruning abandoned oneshot receivers.[^1]
+
+## Traceability
+
+This ADR governs the client-pool half of Epic
+[#635](https://github.com/leynos/wireframe/issues/635) and implements ADR 011's
+single-owner coordination rule.
+
+Primary code surfaces:
+
+- `src/client/pool/client_pool.rs`;
+- `src/client/pool/scheduler.rs`;
+- `src/client/pool/handle.rs`;
+- `src/client/pool/lease.rs`;
+- `src/client/pool/slot.rs`;
+- `src/client/pool/policy.rs`;
+- `src/client/pool/sync.rs`.
+
+Related issues:
+
+- Epic [#635](https://github.com/leynos/wireframe/issues/635);
+- ADR 011 proposal [#636](https://github.com/leynos/wireframe/issues/636);
+- [#535](https://github.com/leynos/wireframe/issues/535), scheduler
+  state-transition simplification;
+- [#539](https://github.com/leynos/wireframe/issues/539), pool
+  poison-recovery integration coverage;
+- [#548](https://github.com/leynos/wireframe/issues/548), cancellation can
+  return a dirty socket;
+- [#550](https://github.com/leynos/wireframe/issues/550), blocked waiter
+  admission is unbounded;
+- [#593](https://github.com/leynos/wireframe/issues/593), shutdown and
+  slot-rotation mutation survivors.
+
+Implementation of this ADR is sequenced through:
+
+- [#645](https://github.com/leynos/wireframe/issues/645), `PoolCore` and
+  index-based pooled leases;
+- [#646](https://github.com/leynos/wireframe/issues/646), borrowed pool-slot
+  permit races without per-slot `Arc` cloning;
+- [#647](https://github.com/leynos/wireframe/issues/647), persistent
+  scheduler actor replacing spawn-on-demand servicing.
+
+## Decision Drivers
+
+- Give scheduler invariants one owner.
+- Eliminate scheduler task creation from the acquire/drop hot path.
+- Avoid O(pool-size) slot refcount operations per acquisition.
+- Preserve FIFO and round-robin fairness semantics.
+- Integrate bounded waiter admission and cancellation handling.
+- Keep pool shutdown deterministic and awaitable.
+- Avoid strong-reference cycles between the scheduler task and public pool
+  handles.
+- Preserve `OwnedSemaphorePermit` where a permit must outlive a borrowed
+  acquisition future.
+
+## Options Considered
+
+### Option A: retain the current mutex and spawn-on-demand service model
+
+Add an empty-queue fast path before `kick`, lifetime-parameterize permit
+futures, and remove nested slot Arcs independently.
+
+This can remove much of the overhead with smaller changes, but scheduler
+ownership remains distributed between a mutex, atomics, lease drops, and
+transient tasks. Adding bounded waiters and robust cancellation would increase
+that coordination surface.
+
+### Option B: use a persistent scheduler actor with command/reply messages (preferred)
+
+Run one long-lived task per pool. It owns `SchedulerState`, waiter queues,
+fairness rotation, admission counts, and grant sequencing. Pool handles send
+commands; the scheduler returns leases or errors through oneshot replies.
+
+Store physical slots by value behind one shared pool-core root. Leases identify
+a slot by index rather than owning a second slot Arc.
+
+### Option C: remove the central scheduler and let acquisitions race permits directly
+
+Each caller races slot permits and applies local rotation. This minimizes
+central machinery but cannot preserve logical-handle fairness without
+rebuilding shared coordination elsewhere.
+
+### Option D: use an async mutex around scheduler state without service tasks
+
+Each acquisition locks state, enqueues, and attempts to grant work directly.
+
+This removes transient task spawning but lets arbitrary caller tasks become
+scheduler executors. Cancellation and fairness transitions still occur under
+distributed ownership, and lock hold times become more delicate.
+
+| Topic                        | Option A: incremental | Option B: scheduler actor | Option C: no scheduler | Option D: async mutex |
+| ---------------------------- | --------------------- | ------------------------- | ---------------------- | --------------------- |
+| Single ownership of state    | Weak                  | Strong                    | None                   | Weak                  |
+| Hot-path task spawning       | Reduced               | Eliminated                | Eliminated             | Eliminated            |
+| Fairness preservation        | Good                  | Good                      | Poor                   | Good                  |
+| Bounded-admission fit (#550) | Awkward               | Natural                   | Poor                   | Awkward               |
+| Change size                  | Small                 | Large                     | Medium                 | Medium                |
+
+_Table 1: Trade-offs for the client-pool scheduler ownership model._
+
+## Decision Outcome
+
+Adopt Option B.
+
+### 1. One persistent scheduler task per pool
+
+Creating a pool starts one scheduler task. The task owns:
+
+- FIFO and round-robin waiter queues;
+- logical handle bookkeeping;
+- fairness rotation state;
+- bounded-waiter admission state;
+- whether a slot-permit acquisition is currently pending;
+- shutdown and drain transitions.
+
+No lease drop or acquire call spawns an additional scheduler service task.
+
+### 2. Commands define the scheduler protocol
+
+The exact enum may evolve, but the protocol must cover the following events:
+
+```rust,no_run
+Acquire {
+    handle_id: u64,
+    reply: oneshot::Sender<Result<PooledClientLease<...>, ClientError>>,
+}
+DeregisterHandle {
+    handle_id: u64,
+}
+CapacityAvailable
+Shutdown {
+    reply: oneshot::Sender<()>,
+}
+```
+
+Logical handle IDs may still come from an atomic counter in the public handle
+factory so `WireframeClientPool::handle()` remains synchronous. The actor
+treats the first acquire for an ID as registration if necessary, and
+deregistration remains idempotent. This avoids requiring a synchronous method
+to await a registration acknowledgement.
+
+The implementation must document message-order assumptions and ensure a handle
+cannot be deregistered before its already-submitted acquire command is observed.
+
+### 3. Separate cloneable control from shared slot storage
+
+Avoid a task/root cycle by separating:
+
+- a cloneable scheduler command handle, whose sender keeps the actor's
+  mailbox alive;
+- an `Arc<PoolCore>` containing fixed slot storage and shared
+  shutdown/connection resources;
+- the scheduler task's receiver and owned scheduler state.
+
+`PoolCore` must not own the command sender if the scheduler task owns
+`Arc<PoolCore>`. Dropping the final public sender then closes the mailbox,
+allowing the task to exit and release its core reference.
+
+### 4. Store slots by value and identify them by index
+
+Replace nested slot ownership conceptually shaped as:
+
+```rust,no_run
+Arc<[Arc<PoolSlot>]>
+```
+
+with:
+
+```rust,no_run
+Arc<PoolCore> {
+    slots: Box<[PoolSlot]>,
+    // ...
+}
+```
+
+A lease owns:
+
+```rust,no_run
+Arc<PoolCore>
+slot_index: usize
+OwnedSemaphorePermit
+```
+
+The core keeps every slot alive for the lease lifetime, so a separate
+`Arc<PoolSlot>` is unnecessary.
+
+The `Arc<Semaphore>` inside a slot may remain because `OwnedSemaphorePermit`
+genuinely owns semaphore capacity independently of the permit-acquisition
+future.
+
+### 5. Race borrowed slot futures
+
+Permit acquisition is scope-bound to the scheduler's current grant attempt. Use
+lifetime-parameterized futures, `FuturesUnordered`, or an equivalent scoped
+collection that borrows `PoolCore::slots` and returns
+`(slot_index, OwnedSemaphorePermit)`.
+
+Do not clone every slot merely to default trait-object futures to `'static`.
+
+Rotation should operate on indices or an iterator order rather than allocating
+a fresh `Vec<Arc<PoolSlot>>`.
+
+### 6. Integrate bounded waiter admission
+
+The actor is the sole admission point for
+[#550](https://github.com/leynos/wireframe/issues/550). It will enforce
+configured waiter capacity and/or acquisition deadlines and return a typed
+error when admission fails.
+
+Admission counts must include queued requests whose oneshot receivers have not
+yet been observed as cancelled. Cancelled receivers should be pruned promptly
+enough that abandoned requests do not consume capacity indefinitely.
+
+### 7. Preserve cancellation safety of physical sockets
+
+This ADR does not resolve
+[#548](https://github.com/leynos/wireframe/issues/548) by itself. Lease and
+checkout operations must retain or strengthen the rule that cancelling an
+in-flight operation invalidates or re-synchronizes the physical socket before
+reuse.
+
+The scheduler refactor must not treat release of admission capacity as proof
+that the socket is clean.
+
+### 8. Make shutdown awaitable
+
+`WireframeClientPool::close` sends `Shutdown`, rejects new acquisitions,
+resolves queued waiters with `ClientError::disconnected`, waits for the
+scheduler acknowledgement/task completion, then releases pool resources.
+
+Dropping the final pool/control handle without explicit close must also let the
+actor terminate when its mailbox closes.
+
+## Consequences
+
+### Positive
+
+- Scheduler invariants have one owner and one serial event stream.
+- Uncontended lease drop no longer spawns a task.
+- Acquisition avoids O(pool-size) slot Arc clones.
+- Waiter admission, cancellation, fairness, and shutdown live in one state
+  machine.
+- `std::sync::Mutex` poison recovery is removed from scheduler state if no
+  other caller shares it.
+- Loom/state-machine testing can target a command protocol rather than
+  incidental lock interleavings.
+
+### Negative
+
+- Every pool owns one long-lived Tokio task and mailbox.
+- Acquire and capacity events incur channel traffic.
+- `Drop` paths can only send non-blocking commands; closed/full mailbox
+  handling must be defined.
+- Splitting pool core and scheduler control introduces more internal types.
+- A scheduler actor can become a throughput bottleneck if it performs socket
+  I/O rather than only admission bookkeeping.
+
+## Invariants
+
+The implementation must maintain:
+
+1. At most the configured number of permits is granted per slot.
+2. Every granted permit belongs to exactly one live lease until drop.
+3. FIFO policy preserves request arrival order among admitted live waiters.
+4. Round-robin policy gives each active logical handle turns according to
+   the existing contract.
+5. Cancelled or deregistered waiters receive no later lease.
+6. Shutdown resolves every queued reply and terminates the task.
+7. No strong-reference cycle keeps the pool alive after all public handles
+   are gone.
+8. Capacity notification is idempotent and cannot create an extra permit.
+9. A dirty/cancelled socket is never made reusable merely because its lease
+   was dropped.
+
+## Rejected Shortcuts
+
+- Keeping `PoolSlot` behind `Arc` solely because permit futures were boxed
+  as `'static` trait objects.
+- Spawning one task per capacity notification with an empty-queue check as
+  the final architecture.
+- Letting the scheduler actor perform user request/response I/O.
+- Using an unbounded mailbox without separately enforcing
+  [#550](https://github.com/leynos/wireframe/issues/550)'s waiter admission
+  limit.
+- Detaching the scheduler task without an explicit shutdown/drain protocol.
+
+## Migration Plan
+
+### Phase 1: characterize behaviour
+
+Land the pool baseline/verification issue
+([#639](https://github.com/leynos/wireframe/issues/639)) and existing
+[#593](https://github.com/leynos/wireframe/issues/593) tests before changing
+the scheduler topology.
+
+### Phase 2: introduce pool core and index-based leases
+
+Remove the nested slot Arc layer while retaining current scheduler behaviour
+([#645](https://github.com/leynos/wireframe/issues/645)).
+
+### Phase 3: add actor command protocol
+
+Move waiter queues, fairness, admission, and shutdown state into the long-lived
+task ([#647](https://github.com/leynos/wireframe/issues/647)). Keep
+compatibility wrappers around existing `PoolHandle` and pool APIs.
+
+### Phase 4: use scoped permit races
+
+Remove `ordered_slots()` Arc cloning and `'static` boxed slot futures
+([#646](https://github.com/leynos/wireframe/issues/646)).
+
+### Phase 5: integrate existing safety work
+
+Complete or coordinate the following, plus any remaining useful scope from
+[#535](https://github.com/leynos/wireframe/issues/535) and
+[#539](https://github.com/leynos/wireframe/issues/539):
+
+- [#548](https://github.com/leynos/wireframe/issues/548);
+- [#550](https://github.com/leynos/wireframe/issues/550);
+- [#593](https://github.com/leynos/wireframe/issues/593).
+
+## Verification
+
+- Uncontended acquire/drop creates no scheduler task after pool
+  construction.
+- Pool task count remains constant under repeated acquisitions.
+- Pool sizes greater than one rotate/grant across slots as configured.
+- FIFO and round-robin behavioural tests preserve ordering.
+- Saturated pools enforce waiter bounds and acquisition timeouts.
+- Dropped acquire futures are pruned and do not receive leases.
+- Shutdown resolves blocked waiters promptly and the actor terminates.
+- Dropping all public handles without `close` releases the pool core.
+- Loom or deterministic state-machine tests cover enqueue, capacity,
+  cancellation, deregistration, and shutdown races. No loom coverage exists for
+  the pool today; the only loom suite exercises the push queues.
+- Criterion/allocation benchmarks compare uncontended and contended
+  acquire/drop before and after.
+
+## Outstanding Decisions Before Acceptance
+
+- Bounded versus unbounded internal command mailbox; waiter admission must
+  remain bounded either way.
+- Exact typed error(s) for waiter rejection and acquire timeout.
+- Whether explicit `close` waits on a stored `JoinHandle`, oneshot
+  acknowledgement, or both.
+- How to preserve strict command ordering across cloned scheduler senders
+  and synchronous `handle()` creation.
+- Whether [#535](https://github.com/leynos/wireframe/issues/535) is closed
+  as superseded or retained for smaller transition helpers inside the actor.
+- Whether [#539](https://github.com/leynos/wireframe/issues/539) remains
+  relevant once scheduler mutex poison recovery disappears.
+
+## References
+
+- Epic [#635](https://github.com/leynos/wireframe/issues/635)
+- [ADR 011: runtime ownership and task-lifetime boundaries](adr-011-runtime-ownership-and-task-lifetime-boundaries.md)
+- [#535](https://github.com/leynos/wireframe/issues/535)
+- [#539](https://github.com/leynos/wireframe/issues/539)
+- [#548](https://github.com/leynos/wireframe/issues/548)
+- [#550](https://github.com/leynos/wireframe/issues/550)
+- [#593](https://github.com/leynos/wireframe/issues/593)
+
+[^1]: [sqlx pool internals](https://github.com/launchbadge/sqlx/blob/main/sqlx-core/src/pool/inner.rs),
+    semaphore-gated acquisition with `acquire_timeout` and RAII
+    `DecrementSizeGuard` cancel safety.
+
+[^2]: [deadpool](https://docs.rs/deadpool/latest/deadpool/), which performs
+    no background actions and admits callers through a semaphore.
+
+[^3]: [bb8](https://docs.rs/bb8/latest/bb8/), lock-based pooling with a
+    configurable `QueueStrategy`.
+
+[^4]: Alice Ryhl,
+    [Actors with Tokio](https://ryhl.io/blog/actors-with-tokio/).

--- a/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
+++ b/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
@@ -4,16 +4,26 @@
 
 Proposed.
 
+First proposed on 2026-08-08 in issue
+[#638](https://github.com/leynos/wireframe/issues/638); imported and refined on
+2026-08-23 following design review.
+
 ## Date
 
-Proposed 2026-08-08. Imported and refined 2026-08-23.
+2026-08-23.
 
-## Context and Problem Statement
+## Context and problem statement
 
 The client pool has one conceptual scheduler, one fixed set of physical socket
 slots, and many logical handles and leases. Its current ownership graph is
 substantially more distributed. `WireframeClientPool` wraps one
 `Arc<ClientPoolInner>` shaped as:
+
+For screen readers: The following tree shows the current ownership graph —
+`Arc<ClientPoolInner>` holds a shared slice of `Arc<PoolSlot>` values, each
+containing an `Arc<Semaphore>`, alongside an `Arc<PoolScheduler>` combining a
+`Mutex<SchedulerState>`, an `AtomicBool` service guard, and spawn-on-demand
+service tasks.
 
 ```text
 Arc<ClientPoolInner>
@@ -24,6 +34,8 @@ Arc<ClientPoolInner>
           ├── AtomicBool service guard
           └── spawn-on-demand service tasks
 ```
+
+_Figure 1: Current client-pool ownership graph._
 
 This creates several costs and reasoning hazards:
 
@@ -49,7 +61,7 @@ The scheduler is already actor-shaped in behaviour: callers submit requests,
 one authority orders them, and replies return through oneshot channels. Its
 ownership model should make that authority explicit.
 
-## Prior Art
+## Prior art
 
 The mainstream Rust connection pools all avoid a central scheduler task: sqlx
 gates acquisition with a fairness-configurable semaphore and bounds waiting by
@@ -118,7 +130,7 @@ Implementation of this ADR is sequenced through:
 - [#647](https://github.com/leynos/wireframe/issues/647), persistent
   scheduler actor replacing spawn-on-demand servicing.
 
-## Decision Drivers
+## Decision drivers
 
 - Give scheduler invariants one owner.
 - Eliminate scheduler task creation from the acquire/drop hot path.
@@ -131,7 +143,7 @@ Implementation of this ADR is sequenced through:
 - Preserve `OwnedSemaphorePermit` where a permit must outlive a borrowed
   acquisition future.
 
-## Options Considered
+## Options considered
 
 ### Option A: retain the current mutex and spawn-on-demand service model
 
@@ -192,7 +204,7 @@ should be re-evaluated first.
 
 _Table 1: Trade-offs for the client-pool scheduler ownership model._
 
-## Decision Outcome
+## Decision outcome
 
 Adopt Option B.
 
@@ -408,8 +420,12 @@ direction.
 
 The design requires:
 
-- the scheduler task's `JoinHandle` is retained (by `PoolCore` or the close
-  path), so the panic is observed rather than swallowed;
+- the scheduler task's `JoinHandle` is retained only by a non-shared close
+  owner (for example inside `WireframeClientPool`), never by `PoolCore`: the
+  task itself holds `Arc<PoolCore>`, so storing the handle in the shared core
+  would blur section 4's cycle-avoidance rule and risk retaining the core;
+  panic observation and `SchedulerFailed` reporting flow through that close
+  owner;
 - abnormal termination maps to a dedicated error — for example
   `ClientError::SchedulerFailed` — distinct from `PoolClosed`, so callers and
   operators can tell a crash from a clean shutdown;
@@ -468,7 +484,7 @@ The implementation must maintain:
     degrades to delayed cleanup via grant-sweep pruning, never an unbounded
     leak.
 
-## Rejected Shortcuts
+## Rejected shortcuts
 
 - Keeping `PoolSlot` behind `Arc` solely because permit futures were boxed
   as `'static` trait objects.
@@ -480,7 +496,7 @@ The implementation must maintain:
   limit.
 - Detaching the scheduler task without an explicit shutdown/drain protocol.
 
-## Migration Plan
+## Migration plan
 
 ### Phase 1: characterize behaviour
 
@@ -520,15 +536,16 @@ Complete or coordinate the following, plus any remaining useful scope from
 
 ## Verification
 
-- Uncontended acquire/drop creates no scheduler task after pool
-  construction.
+- Uncontended acquire/drop creates no additional scheduler task after pool
+  construction; the pool retains exactly one persistent scheduler task.
 - Pool task count remains constant under repeated acquisitions.
 - Pool sizes greater than one rotate/grant across slots as configured.
 - FIFO and round-robin behavioural tests preserve ordering.
 - Saturated pools enforce waiter bounds and acquisition timeouts.
 - Dropped acquire futures are pruned and do not receive leases.
 - Shutdown resolves blocked waiters promptly and the actor terminates.
-- Dropping all public handles without `close` releases the pool core.
+- Dropping all public handles without `close` releases the pool core,
+  including with the `JoinHandle` held by the non-shared close owner.
 - Loom or deterministic state-machine tests cover enqueue, capacity,
   cancellation, deregistration, and shutdown races, naming at minimum: the
   pending-flag RAII clear when a permit race is dropped mid-`select!`, and a
@@ -547,14 +564,14 @@ Complete or coordinate the following, plus any remaining useful scope from
   admission rejections, and scheduler-task liveness, so "is the actor alive and
   is the queue draining?" is answerable without a debugger.
 
-## Outstanding Decisions Before Acceptance
+## Outstanding decisions before acceptance
 
 - Bounded versus unbounded internal command mailbox; waiter admission must
   remain bounded either way, and `Shutdown` delivery must remain guaranteed
   regardless of the choice.
 - Whether explicit `close` waits on the stored `JoinHandle`, the oneshot
   acknowledgement, or both; section 10 requires the `JoinHandle` to be retained
-  in any case.
+  by a non-shared close owner in any case.
 - Whether [#535](https://github.com/leynos/wireframe/issues/535) is closed
   as superseded or retained for smaller transition helpers inside the actor.
 

--- a/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
+++ b/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
@@ -58,7 +58,14 @@ and admits callers through a `tokio::sync::Semaphore`;[^2] bb8 uses lock-based
 state with a FIFO/LIFO `QueueStrategy`.[^3] None of them, however, provides
 Wireframe's contract of per-logical-handle round-robin fairness across a fixed
 slot set, and none needs a single admission point for bounded waiter counts.
-Those requirements are what motivate a central authority here, and the current
+That fairness contract is not axiomatic: it is recorded in the client design
+document's scheduling model
+([`wireframe-client-design.md`](wireframe-client-design.md)), which makes
+`PoolFairnessPolicy::RoundRobin` the default so stable logical sessions take
+turns under repeated contention, and it is exercised by the
+`client_pool_handle` behavioural suite
+(`tests/features/client_pool_handle.feature` and its fixtures). Those
+requirements are what motivate a central authority here, and the current
 spawn-on-demand servicing already pays for one without gaining its benefits.
 
 The persistent-actor shape follows the pattern described by Alice Ryhl: one
@@ -159,13 +166,29 @@ This removes transient task spawning but lets arbitrary caller tasks become
 scheduler executors. Cancellation and fairness transitions still occur under
 distributed ownership, and lock hold times become more delicate.
 
-| Topic                        | Option A: incremental | Option B: scheduler actor | Option C: no scheduler | Option D: async mutex |
-| ---------------------------- | --------------------- | ------------------------- | ---------------------- | --------------------- |
-| Single ownership of state    | Weak                  | Strong                    | None                   | Weak                  |
-| Hot-path task spawning       | Reduced               | Eliminated                | Eliminated             | Eliminated            |
-| Fairness preservation        | Good                  | Good                      | Poor                   | Good                  |
-| Bounded-admission fit (#550) | Awkward               | Natural                   | Poor                   | Awkward               |
-| Change size                  | Small                 | Large                     | Medium                 | Medium                |
+### Option E: semaphore-gated admission with a rotation lock and no service tasks
+
+Adopt the sqlx/deadpool shape: one pool-wide fair `tokio::sync::Semaphore` for
+capacity, an acquire timeout plus a bounded admission count for
+[#550](https://github.com/leynos/wireframe/issues/550), a small synchronous
+mutex touched only for slot rotation, and RAII permit drop as the entire
+release path.
+
+This eliminates tasks, mailboxes, shutdown protocols, and command-ordering
+hazards, and it matches three production-proven pools. It is rejected because
+it cannot preserve the per-logical-handle round-robin contract evidenced above
+— fairness degrades to semaphore FIFO with best-effort rotation — and because
+[#550](https://github.com/leynos/wireframe/issues/550) needs a typed admission
+rejection, not only a timeout. If that contract were ever relaxed, this option
+should be re-evaluated first.
+
+| Topic                        | Option A: incremental | Option B: scheduler actor | Option C: no scheduler | Option D: async mutex | Option E: semaphore only |
+| ---------------------------- | --------------------- | ------------------------- | ---------------------- | --------------------- | ------------------------ |
+| Single ownership of state    | Weak                  | Strong                    | None                   | Weak                  | Medium                   |
+| Hot-path task spawning       | Reduced               | Eliminated                | Eliminated             | Eliminated            | Eliminated               |
+| Fairness preservation        | Good                  | Good                      | Poor                   | Good                  | Partial                  |
+| Bounded-admission fit (#550) | Awkward               | Natural                   | Poor                   | Awkward               | Timeout-only             |
+| Change size                  | Small                 | Large                     | Medium                 | Medium                | Medium                   |
 
 _Table 1: Trade-offs for the client-pool scheduler ownership model._
 
@@ -186,9 +209,26 @@ Creating a pool starts one scheduler task. The task owns:
 
 No lease drop or acquire call spawns an additional scheduler service task.
 
+The actor loop must remain responsive while a grant is pending: it `select!`s
+over its mailbox and any pending permit race, performs O(1) bookkeeping per
+event, and no command handler awaits unboundedly inline. The
+pending-acquisition flag is cleared through RAII so that a permit race dropped
+mid-`select!` (by shutdown or command handling) cannot leave the flag stuck and
+wedge granting. A permit won for a waiter whose reply channel has already
+closed is dropped and immediately re-enters the grant loop.
+
+Replacing the current inline mutex-plus-`try_acquire` acquisition with a
+command/reply round trip regresses the uncontended path from sub-microsecond to
+microsecond-class latency. The implementation must either preserve an
+uncontended fast path that cannot violate the fairness invariants, or
+demonstrate through the named uncontended benchmark in the Verification section
+that the actor round trip meets an explicitly stated latency budget recorded in
+[#647](https://github.com/leynos/wireframe/issues/647).
+
 ### 2. Commands define the scheduler protocol
 
-The exact enum may evolve, but the protocol must cover the following events:
+The command enum is crate-private, which is what licenses its evolution. The
+exact shape may change, but the protocol must cover the following events:
 
 ```rust,no_run
 Acquire {
@@ -198,11 +238,13 @@ Acquire {
 DeregisterHandle {
     handle_id: u64,
 }
-CapacityAvailable
 Shutdown {
     reply: oneshot::Sender<()>,
 }
 ```
+
+Capacity release is deliberately absent from the command set; section 3 defines
+it as a level-triggered signal outside the mailbox.
 
 Logical handle IDs may still come from an atomic counter in the public handle
 factory so `WireframeClientPool::handle()` remains synchronous. The actor
@@ -210,10 +252,34 @@ treats the first acquire for an ID as registration if necessary, and
 deregistration remains idempotent. This avoids requiring a synchronous method
 to await a registration acknowledgement.
 
-The implementation must document message-order assumptions and ensure a handle
-cannot be deregistered before its already-submitted acquire command is observed.
+Message ordering is pinned rather than left open: each `PoolHandle` owns its
+own clone of the command sender, so the channel's per-sender FIFO guarantee
+ensures a handle's `DeregisterHandle` (sent from its `Drop`) is observed after
+any acquire command that handle already submitted. Deregistration is
+loss-tolerant: `Drop` may only `try_send`, so a discarded `DeregisterHandle`
+must degrade to delayed cleanup, not a leak — during grant sweeps the actor
+prunes handles whose waiters' reply channels are all closed, and handle
+bookkeeping must not grow without bound under handle churn.
 
-### 3. Separate cloneable control from shared slot storage
+### 3. Observe capacity level-triggered, outside the mailbox
+
+An earlier draft routed capacity release through a `CapacityAvailable` command,
+but under this ADR's own ownership rules no declared owner could send it: the
+lease owns no command sender (section 5), and `PoolCore` must not own one
+(section 4). Giving the lease a sender would reintroduce the lease-to-scheduler
+back-edge that the current `release_inner` pointer represents and this ADR
+removes.
+
+Capacity signalling is therefore level-triggered and lives outside the bounded
+command mailbox. A lease drop releases only its `OwnedSemaphorePermit`; the
+actor's pending permit race observes released slot-semaphore capacity directly,
+and the actor re-checks actual capacity whenever it processes any command or
+completes a grant. A missed edge can delay a grant, never prevent one: a
+released permit is always eventually observed. This satisfies the idempotency
+invariant by construction — a level-triggered check cannot mint an extra permit
+— and removes the edge-triggered lost-wakeup failure mode entirely.
+
+### 4. Separate cloneable control from shared slot storage
 
 Avoid a task/root cycle by separating:
 
@@ -227,7 +293,7 @@ Avoid a task/root cycle by separating:
 `Arc<PoolCore>`. Dropping the final public sender then closes the mailbox,
 allowing the task to exit and release its core reference.
 
-### 4. Store slots by value and identify them by index
+### 5. Store slots by value and identify them by index
 
 Replace nested slot ownership conceptually shaped as:
 
@@ -259,19 +325,24 @@ The `Arc<Semaphore>` inside a slot may remain because `OwnedSemaphorePermit`
 genuinely owns semaphore capacity independently of the permit-acquisition
 future.
 
-### 5. Race borrowed slot futures
+### 6. Race slot permits without per-slot cloning
 
-Permit acquisition is scope-bound to the scheduler's current grant attempt. Use
-lifetime-parameterized futures, `FuturesUnordered`, or an equivalent scoped
-collection that borrows `PoolCore::slots` and returns
-`(slot_index, OwnedSemaphorePermit)`.
+The requirement is that a grant attempt performs no per-slot `Arc<PoolSlot>`
+cloning and no `Vec` allocation per rotation; rotation operates on indices or
+an iterator order.
+
+Two compliant implementations exist. Because section 5 retains `Arc<Semaphore>`
+per slot, `Semaphore::acquire_owned` already yields `'static` permit futures at
+one refcount operation per raced slot, which satisfies the requirement
+directly. Alternatively, futures may borrow `PoolCore::slots` through
+`FuturesUnordered` or an equivalent scoped collection returning
+`(slot_index, OwnedSemaphorePermit)` — noting the real constraint that a
+self-referential borrow cannot be stored in the actor's own state and must live
+in a loop-scoped binding.
 
 Do not clone every slot merely to default trait-object futures to `'static`.
 
-Rotation should operate on indices or an iterator order rather than allocating
-a fresh `Vec<Arc<PoolSlot>>`.
-
-### 6. Integrate bounded waiter admission
+### 7. Integrate bounded waiter admission
 
 The actor is the sole admission point for
 [#550](https://github.com/leynos/wireframe/issues/550). It will enforce
@@ -279,10 +350,19 @@ configured waiter capacity and/or acquisition deadlines and return a typed
 error when admission fails.
 
 Admission counts must include queued requests whose oneshot receivers have not
-yet been observed as cancelled. Cancelled receivers should be pruned promptly
-enough that abandoned requests do not consume capacity indefinitely.
+yet been observed as cancelled. Cancelled receivers are pruned on every grant
+attempt and at admission-check time, so abandoned requests do not consume
+capacity indefinitely. Waiter deadlines are mandatory, not optional: a
+saturated pool must reject or time out waiters rather than queue them
+unboundedly.
 
-### 7. Preserve cancellation safety of physical sockets
+Admission rejection and timeout use dedicated typed errors — for example
+`ClientError::PoolSaturated { limit }` and `ClientError::AcquireTimeout` —
+neither of which reports `should_recycle_connection() == true`, since no socket
+was involved. `ClientError` gains `#[non_exhaustive]` before these variants
+land, which is cheap at 0.3.0 and painful later.
+
+### 8. Preserve cancellation safety of physical sockets
 
 This ADR does not resolve
 [#548](https://github.com/leynos/wireframe/issues/548) by itself. Lease and
@@ -293,14 +373,51 @@ reuse.
 The scheduler refactor must not treat release of admission capacity as proof
 that the socket is clean.
 
-### 8. Make shutdown awaitable
+### 9. Make shutdown awaitable
 
-`WireframeClientPool::close` sends `Shutdown`, rejects new acquisitions,
-resolves queued waiters with `ClientError::disconnected`, waits for the
-scheduler acknowledgement/task completion, then releases pool resources.
+`WireframeClientPool::close` delivers `Shutdown`, waits for the scheduler
+acknowledgement and task completion, then releases pool resources. `Shutdown`
+delivery must be guaranteed non-blocking — reserved mailbox capacity, a
+dedicated channel, or a `CancellationToken` — so a saturated pool cannot
+deadlock its own shutdown.
 
-Dropping the final pool/control handle without explicit close must also let the
-actor terminate when its mailbox closes.
+On observing `Shutdown`, the actor enters a draining state: mailbox order is
+the fence, and every command observed after `Shutdown` — including acquisitions
+submitted through still-live cloned senders — is resolved with a dedicated
+`ClientError::PoolClosed` variant. Queued waiters are resolved with the same
+error. `PoolClosed` is distinct from `ClientError::disconnected()`, which
+reports a transport-level peer close and wrongly classifies as recyclable;
+`PoolClosed` reports `should_recycle_connection() == false` and lets callers
+programmatically distinguish "pool closed, retry elsewhere" from a real peer
+failure.
+
+`close` waits for the actor and queued waiters, not for outstanding leases.
+After actor termination by either route — explicit `Shutdown` or mailbox
+closure when the final public sender drops — outstanding leases remain valid;
+their permit releases require no scheduler observation, which is coherent
+because capacity observation is level-triggered (section 3).
+
+### 10. Detect and report scheduler failure
+
+Centralizing scheduler state also centralizes its failure, and removing
+`std::sync::Mutex` poison recovery removes the one existing loud panic
+tripwire. Actor-termination detection explicitly replaces poison recovery as
+the panic-signalling mechanism, and
+[#539](https://github.com/leynos/wireframe/issues/539) is resolved in that
+direction.
+
+The design requires:
+
+- the scheduler task's `JoinHandle` is retained (by `PoolCore` or the close
+  path), so the panic is observed rather than swallowed;
+- abnormal termination maps to a dedicated error — for example
+  `ClientError::SchedulerFailed` — distinct from `PoolClosed`, so callers and
+  operators can tell a crash from a clean shutdown;
+- abnormal termination emits an error-level structured log event and a
+  metric carrying the pool identity;
+- the failure policy is fail-pool-permanently: subsequent acquisitions
+  return `SchedulerFailed`, and automatic actor restart is out of scope for
+  this ADR.
 
 ## Consequences
 
@@ -319,12 +436,15 @@ actor terminate when its mailbox closes.
 ### Negative
 
 - Every pool owns one long-lived Tokio task and mailbox.
-- Acquire and capacity events incur channel traffic.
-- `Drop` paths can only send non-blocking commands; closed/full mailbox
-  handling must be defined.
+- Acquire events incur channel traffic, and the uncontended path regresses
+  unless the fast path or latency budget in section 1 is honoured.
+- `Drop` paths can only send non-blocking commands; sections 2 and 3 define
+  the loss-tolerant behaviour this forces.
 - Splitting pool core and scheduler control introduces more internal types.
 - A scheduler actor can become a throughput bottleneck if it performs socket
   I/O rather than only admission bookkeeping.
+- The actor is a new single point of failure; section 10 defines its
+  detection and failure policy.
 
 ## Invariants
 
@@ -339,9 +459,14 @@ The implementation must maintain:
 6. Shutdown resolves every queued reply and terminates the task.
 7. No strong-reference cycle keeps the pool alive after all public handles
    are gone.
-8. Capacity notification is idempotent and cannot create an extra permit.
+8. Capacity observation is idempotent and cannot create an extra permit.
 9. A dirty/cancelled socket is never made reusable merely because its lease
    was dropped.
+10. A released permit is always eventually observed; a lost edge delays a
+    grant but never prevents one.
+11. Scheduler handle bookkeeping is bounded: a lost `DeregisterHandle`
+    degrades to delayed cleanup via grant-sweep pruning, never an unbounded
+    leak.
 
 ## Rejected Shortcuts
 
@@ -373,12 +498,15 @@ Remove the nested slot Arc layer while retaining current scheduler behaviour
 
 Move waiter queues, fairness, admission, and shutdown state into the long-lived
 task ([#647](https://github.com/leynos/wireframe/issues/647)). Keep
-compatibility wrappers around existing `PoolHandle` and pool APIs.
+compatibility wrappers around existing `PoolHandle` and pool APIs; the wrappers
+are internal scaffolding removed before this ADR flips to Accepted.
 
 ### Phase 4: use scoped permit races
 
 Remove `ordered_slots()` Arc cloning and `'static` boxed slot futures
-([#646](https://github.com/leynos/wireframe/issues/646)).
+([#646](https://github.com/leynos/wireframe/issues/646)). The permit-race
+rework deliberately follows the actor phase so the races are written once
+against the actor's grant loop rather than twice.
 
 ### Phase 5: integrate existing safety work
 
@@ -402,24 +530,39 @@ Complete or coordinate the following, plus any remaining useful scope from
 - Shutdown resolves blocked waiters promptly and the actor terminates.
 - Dropping all public handles without `close` releases the pool core.
 - Loom or deterministic state-machine tests cover enqueue, capacity,
-  cancellation, deregistration, and shutdown races. No loom coverage exists for
-  the pool today; the only loom suite exercises the push queues.
+  cancellation, deregistration, and shutdown races, naming at minimum: the
+  pending-flag RAII clear when a permit race is dropped mid-`select!`, and a
+  permit won exactly as its waiter's receiver drops. No loom coverage exists
+  for the pool today; the only loom suite exercises the push queues.
+- A panic injected into the scheduler task surfaces as `SchedulerFailed`
+  with the required log event and metric, not as a silent hang or a clean
+  `PoolClosed`.
+- Filling the mailbox with acquisitions and then dropping leases still
+  grants: no lost-wakeup wedge.
 - Criterion/allocation benchmarks compare uncontended and contended
-  acquire/drop before and after.
+  acquire/drop before and after, explicitly naming uncontended single-caller
+  acquire/drop latency, where the actor design is most likely to regress
+  against the mutex.
+- Day-two observability exists: per-pool gauges/counters for queued waiters,
+  admission rejections, and scheduler-task liveness, so "is the actor alive and
+  is the queue draining?" is answerable without a debugger.
 
 ## Outstanding Decisions Before Acceptance
 
 - Bounded versus unbounded internal command mailbox; waiter admission must
-  remain bounded either way.
-- Exact typed error(s) for waiter rejection and acquire timeout.
-- Whether explicit `close` waits on a stored `JoinHandle`, oneshot
-  acknowledgement, or both.
-- How to preserve strict command ordering across cloned scheduler senders
-  and synchronous `handle()` creation.
+  remain bounded either way, and `Shutdown` delivery must remain guaranteed
+  regardless of the choice.
+- Whether explicit `close` waits on the stored `JoinHandle`, the oneshot
+  acknowledgement, or both; section 10 requires the `JoinHandle` to be retained
+  in any case.
 - Whether [#535](https://github.com/leynos/wireframe/issues/535) is closed
   as superseded or retained for smaller transition helpers inside the actor.
-- Whether [#539](https://github.com/leynos/wireframe/issues/539) remains
-  relevant once scheduler mutex poison recovery disappears.
+
+The following earlier open questions are now resolved in the text: waiter
+rejection and timeout errors are named in section 7; command ordering across
+cloned senders is pinned in section 2 (per-handle sender clones);
+[#539](https://github.com/leynos/wireframe/issues/539) is resolved by section
+10, with actor-termination detection replacing poison recovery.
 
 ## References
 

--- a/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
+++ b/docs/adr-013-client-pool-scheduler-and-slot-ownership.md
@@ -425,7 +425,9 @@ The design requires:
   task itself holds `Arc<PoolCore>`, so storing the handle in the shared core
   would blur section 4's cycle-avoidance rule and risk retaining the core;
   panic observation and `SchedulerFailed` reporting flow through that close
-  owner;
+  owner, and the close owner's shutdown sequence is: drop the final command
+  sender, then await the `JoinHandle` before dropping it, so mailbox closure
+  deterministically terminates the actor rather than detaching it;
 - abnormal termination maps to a dedicated error — for example
   `ClientError::SchedulerFailed` — distinct from `PoolClosed`, so callers and
   operators can tell a crash from a clean shutdown;
@@ -544,8 +546,8 @@ Complete or coordinate the following, plus any remaining useful scope from
 - Saturated pools enforce waiter bounds and acquisition timeouts.
 - Dropped acquire futures are pruned and do not receive leases.
 - Shutdown resolves blocked waiters promptly and the actor terminates.
-- Dropping all public handles without `close` releases the pool core,
-  including with the `JoinHandle` held by the non-shared close owner.
+- Dropping all public handles without `close` eventually releases the pool
+  core, including with the `JoinHandle` held by the non-shared close owner.
 - Loom or deterministic state-machine tests cover enqueue, capacity,
   cancellation, deregistration, and shutdown races, naming at minimum: the
   pending-flag RAII clear when a permit race is dropped mid-`select!`, and a
@@ -569,9 +571,10 @@ Complete or coordinate the following, plus any remaining useful scope from
 - Bounded versus unbounded internal command mailbox; waiter admission must
   remain bounded either way, and `Shutdown` delivery must remain guaranteed
   regardless of the choice.
-- Whether explicit `close` waits on the stored `JoinHandle`, the oneshot
-  acknowledgement, or both; section 10 requires the `JoinHandle` to be retained
-  by a non-shared close owner in any case.
+- Whether explicit `close` also waits on the oneshot acknowledgement in
+  addition to awaiting the stored `JoinHandle`; section 10 requires the
+  non-shared close owner to drop the final command sender and await the
+  `JoinHandle` in any case.
 - Whether [#535](https://github.com/leynos/wireframe/issues/535) is closed
   as superseded or retained for smaller transition helpers inside the actor.
 

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -50,6 +50,15 @@ reference when navigating the project's design and architecture material.
   Rollout policy for owned-byte compatibility during migration.
 - [ADR 010: transport frame boundary for zero-copy](adr-010-transport-frame-boundary-for-zero-copy.md)
   Accepted actor and codec-driver boundary for zero-copy transport framing.
+- [ADR 011: runtime ownership and task-lifetime boundaries](adr-011-runtime-ownership-and-task-lifetime-boundaries.md)
+  Proposed policy for aligning `Arc`, spawning, and borrowing with real runtime
+  lifetimes.
+- [ADR 012: prepared application templates and connection-local runtimes](adr-012-prepared-application-and-connection-runtime.md)
+  Proposed separation of the application builder, prepared template, and
+  connection runtime.
+- [ADR 013: single-owner client-pool scheduler and slot graph](adr-013-client-pool-scheduler-and-slot-ownership.md)
+  Proposed persistent scheduler actor and index-based slot ownership for the
+  client pool.
 
 ## Execution plans
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -51,6 +51,25 @@ packet-oriented and run before serialization. The known gap is narrower:
 `before_send` does not yet fire for app-router responses routed through
 `FramePipeline`; roadmap item `11.2.1` owns that closure.
 
+## Runtime ownership model
+
+Three proposed decision records govern runtime ownership and task-lifetime
+boundaries for Epic 635:
+
+- [ADR 011](adr-011-runtime-ownership-and-task-lifetime-boundaries.md)
+  defines ownership rules R1-R7 (shared roots, borrowed handles, sole-owner
+  moves, and actor coordination) with mechanical lint enforcement for the
+  grep-able rules.
+- [ADR 012](adr-012-prepared-application-and-connection-runtime.md) splits
+  `WireframeApp` into a registration builder, an immutable `PreparedApp`
+  template shared by connection tasks, and a per-connection `ConnectionRuntime`.
+- [ADR 013](adr-013-client-pool-scheduler-and-slot-ownership.md) gives the
+  client-pool scheduler a single persistent owner task and index-based slot
+  leases beneath one `PoolCore` root.
+
+These records are proposed, not yet accepted; the review checklist derived from
+ADR 011's rules lands with their implementation epic.
+
 ## Allowed aliases and prohibited mixing
 
 | Canonical term | Allowed aliases                     | Avoid in the same context                 |
@@ -439,64 +458,63 @@ Add new scenarios by:
 
 ### Fallible test helpers and server-task results
 
-Two distinct `TestResult` aliases exist in the codebase; do not assume they
-are the same type.
+Two distinct `TestResult` aliases exist in the codebase; do not assume they are
+the same type.
 
 - `wireframe::testkit::result::TestResult<T = ()>` (re-exported as
-  `wireframe_testing::TestResult`) is `Result<T, TestError>`, where
-  `TestError` (`src/testkit/result.rs`) collects the typed errors produced
-  across the root crate, client and server runtimes, push queues, codecs, and
-  fragmentation. Use it for any helper that crosses those boundaries, and in
-  BDD fixtures and steps that import it from `wireframe_testing`.
-- A module-local `TestResult<T = ()> = Result<T, Box<dyn Error + Send +
-  Sync>>` is scoped to individual test modules, for example
+  `wireframe_testing::TestResult`) is `Result<T, TestError>`, where `TestError`
+  (`src/testkit/result.rs`) collects the typed errors produced across the root
+  crate, client and server runtimes, push queues, codecs, and fragmentation.
+  Use it for any helper that crosses those boundaries, and in BDD fixtures and
+  steps that import it from `wireframe_testing`.
+- A module-local `TestResult<T = ()> = Result<T, Box<dyn Error + Send + Sync>>`
+  is scoped to individual test modules, for example
   `src/client/tests/helpers.rs` and the corresponding aliases in
   `src/fragment/tests/`. Use it where a helper only needs to erase the error
   type for `?`-propagation within that module and gains nothing from
   `TestError`'s typed variants.
 
 For the in-process server/client pair harness, which also returns
-`wireframe_testing::TestResult`, see the ["In-process server/client pair
-harness"](wireframe-testing-crate.md#in-process-serverclient-pair-harness)
+`wireframe_testing::TestResult`, see the
+["In-process server/client pair harness"](wireframe-testing-crate.md#in-process-serverclient-pair-harness)
 section of `docs/wireframe-testing-crate.md`.
 
-**Fixtures and helpers are not tests.** A fixture or helper arranges state,
-and arrangement can fail, so it returns `Result` and propagates failures with
-`?`. Only a test body unwraps or asserts, because there a failure becomes
-the test's verdict. The whitaker `no_expect_outside_tests` lint enforces
-this rule, but it cannot see through proc-macro expansion, so an `rstest`
-`#[fixture]` function counts as non-test code even though it exists only to
-support tests.
+**Fixtures and helpers are not tests.** A fixture or helper arranges state, and
+arrangement can fail, so it returns `Result` and propagates failures with `?`.
+Only a test body unwraps or asserts, because there a failure becomes the test's
+verdict. The whitaker `no_expect_outside_tests` lint enforces this rule, but it
+cannot see through proc-macro expansion, so an `rstest` `#[fixture]` function
+counts as non-test code even though it exists only to support tests.
 
 **The `finish_server` convention.** A fixture that spawns a server as a
-`JoinHandle<TestResult>` exposes an `async fn finish_server(&mut self) ->
-TestResult` that takes the handle and propagates both the `JoinError` and the
-inner error with `handle.await??`. `Drop` remains an abort-only fallback for
-scenarios that fail or are interrupted before calling `finish_server`, so a
-server-side failure is never silently discarded on the happy path. See
-`ClientLifecycleWorld::finish_server` in `tests/fixtures/client_lifecycle.rs`
-and the precedent in `tests/fixtures/client_preamble.rs`.
+`JoinHandle<TestResult>` exposes an
+`async fn finish_server(&mut self) -> TestResult` that takes the handle and
+propagates both the `JoinError` and the inner error with `handle.await??`.
+`Drop` remains an abort-only fallback for scenarios that fail or are
+interrupted before calling `finish_server`, so a server-side failure is never
+silently discarded on the happy path. See `ClientLifecycleWorld::finish_server`
+in `tests/fixtures/client_lifecycle.rs` and the precedent in
+`tests/fixtures/client_preamble.rs`.
 
 **The server-task cleanup contract**, as implemented by
-`run_hook_test_with_server` in `src/client/tests/request_hooks_support.rs`:
-on success the client is dropped first so the serve loop ends, then the
-server task is joined and its result propagated; on failure the task is
-aborted and reaped instead, because the client may never have connected and
-the server may be parked in `accept`, where joining would hang rather than
-report the original failure. The rule: **await the server handle on the
-success path; reserve `abort` for the failure path where the aborted task's
-result is explicitly discarded.**
+`run_hook_test_with_server` in `src/client/tests/request_hooks_support.rs`: on
+success the client is dropped first so the serve loop ends, then the server
+task is joined and its result propagated; on failure the task is aborted and
+reaped instead, because the client may never have connected and the server may
+be parked in `accept`, where joining would hang rather than report the original
+failure. The rule: **await the server handle on the success path; reserve
+`abort` for the failure path where the aborted task's result is explicitly
+discarded.**
 
-**Loopback server helpers** in `src/client/tests/helpers.rs` —
-`bind_loopback`, `spawn_listener`, `spawn_frame_server`, and
-`is_expected_disconnect` — provide the building blocks for spawning a
-listener and driving a length-delimited frame loop. `is_expected_disconnect`
-classifies I/O errors observed while serving: an ordinary peer disconnect
-(`UnexpectedEof`, `ConnectionReset`, `ConnectionAborted`, or `BrokenPipe`)
-ends the serve loop normally, because a client that finishes its work and
-drops its connection produces exactly one of those kinds. Every other I/O
-error is returned from the task instead, so it surfaces when the caller
-joins the handle.
+**Loopback server helpers** in `src/client/tests/helpers.rs` — `bind_loopback`,
+`spawn_listener`, `spawn_frame_server`, and `is_expected_disconnect` — provide
+the building blocks for spawning a listener and driving a length-delimited
+frame loop. `is_expected_disconnect` classifies I/O errors observed while
+serving: an ordinary peer disconnect (`UnexpectedEof`, `ConnectionReset`,
+`ConnectionAborted`, or `BrokenPipe`) ends the serve loop normally, because a
+client that finishes its work and drops its connection produces exactly one of
+those kinds. Every other I/O error is returned from the task instead, so it
+surfaces when the caller joins the handle.
 
 ### `LoggerHandle::Default` and `ObservabilityHandle::Default`
 
@@ -517,10 +535,10 @@ stay within that tool's grammar. Phases are level-2 headings
 (`## 9. Phase title`), steps are level-3 headings (`### 9.2. Step title`), and
 tasks are numbered checklist items (`- [ ] 9.2.1. Task title`).
 
-That grammar rejects footnote references, failing with `unsupported inline
-node footnoteReference`. Roadmap references must therefore use inline links
-instead of the GitHub-flavoured `[^1]` footnotes used elsewhere in the
-documentation set: cite a target either as a parenthetical
+That grammar rejects footnote references, failing with
+`unsupported inline node footnoteReference`. Roadmap references must therefore
+use inline links instead of the GitHub-flavoured `[^1]` footnotes used
+elsewhere in the documentation set: cite a target either as a parenthetical
 `(see [target](path))` or by linking an existing phrase. This is a scoped
 exception to the footnote rule recorded in the
 [documentation style guide](documentation-style-guide.md).

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -481,7 +481,7 @@ section of `docs/wireframe-testing-crate.md`.
 
 **Fixtures and helpers are not tests.** A fixture or helper arranges state, and
 arrangement can fail, so it returns `Result` and propagates failures with `?`.
-Only a test body unwraps or asserts, because there a failure becomes the test's
+Only a test body unwraps or asserts, because a failure there becomes the test's
 verdict. The whitaker `no_expect_outside_tests` lint enforces this rule, but it
 cannot see through proc-macro expansion, so an `rstest` `#[fixture]` function
 counts as non-test code even though it exists only to support tests.


### PR DESCRIPTION
## Summary

This branch imports the three runtime-ownership architectural decision
records proposed in issues #636, #637, and #638, and refines them following
repository reconnaissance, prior-art research, and a six-lens expert design
review. All three ADRs remain in `Proposed` status; acceptance is deferred to
the implementation epic.

Closes #636. Closes #637. Closes #638.

- [ADR 011](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md)
  records the runtime ownership and task-lifetime policy for Epic #635. The
  refinement adopts mechanical lint enforcement alongside the shared-root
  rules (the repository already runs a Dylint suite), assigns the rules
  stable identifiers R1-R7 with a single litmus question, annotates each
  observed in-tree instance with its frequency class, and scopes the
  no-behaviour-change verification to externally contracted behaviour.
- [ADR 012](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/adr-012-prepared-application-and-connection-runtime.md)
  records the `WireframeApp` builder, `PreparedApp` template, and
  `ConnectionRuntime` split. The refinement corrects the description against
  the code (exact type names, the `ready_tx` oneshot, the two-variant
  `ServerError`), adds the lazy-preparation rejected option and axum prior
  art, makes `prepare()` a consuming typestate transition, extends the
  public-API disposition to `handle_connection_result` and the `AppFactory`
  `Clone` bound, specifies readiness-failure observability and panic-aware
  teardown, and promotes the test-harness replacement to a Phase 1
  deliverable with a compatibility-wrapper sunset.
- [ADR 013](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/adr-013-client-pool-scheduler-and-slot-ownership.md)
  records the single-owner client-pool scheduler and slot graph. The
  refinement resolves a structural flaw found in review — the
  `CapacityAvailable` command had no owner able to send it under the ADR's
  own rules — by making capacity observation level-triggered outside the
  mailbox; it also adds the semaphore-only rejected option with evidence for
  the round-robin fairness contract, pins command ordering to per-handle
  sender clones, defines the `PoolClosed`/`PoolSaturated`/`AcquireTimeout`/
  `SchedulerFailed` error taxonomy with `#[non_exhaustive]` on
  `ClientError`, and specifies scheduler-failure detection as the
  replacement for mutex poison recovery.

Each ADR threads the follow-on implementation issues (#639-#649) through its
traceability and migration sections.

## Review walkthrough

- Start with
  [docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md#L177)
  at the Decision Outcome: rules R1-R7 are the policy the other two ADRs
  instantiate.
- Then review
  [docs/adr-012-prepared-application-and-connection-runtime.md](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/adr-012-prepared-application-and-connection-runtime.md#L196)
  from the Decision Outcome: the lifecycle split, the template-versus-
  instance rule, and the readiness and teardown specifications.
- Continue with
  [docs/adr-013-client-pool-scheduler-and-slot-ownership.md](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/adr-013-client-pool-scheduler-and-slot-ownership.md#L221)
  from the Decision Outcome, particularly section 3 (level-triggered
  capacity) and section 10 (scheduler failure), which are the two largest
  departures from the issue text.
- Finish with
  [docs/contents.md](https://github.com/leynos/wireframe/blob/runtime-ownership-adrs/docs/contents.md#L51)
  for the index entries.

## Validation

- `make markdownlint` (includes the en-GB-oxendict spelling gate): pass, 0
  errors across 113 files.
- `make nixie` (Mermaid validation): pass; the new files contain no
  diagrams.
- Cargo gates were not run: the branch is docs-only.

## Notes

- Factual claims in the issue bodies were verified against the tree by
  read-only reconnaissance agents before import; corrections landed in the
  first commit (for example, `src/client/pool/policy.rs` added to ADR 013's
  file list, and the mutation-survivor citation attributed to #593/#539 as
  issues rather than code comments).
- The design review ran six specialist lenses (structure, alternatives,
  scaling, contracts, failure modes, and long-term viability) plus a
  pre-mortem; every red and amber finding is addressed in the second
  commit, and open questions that genuinely remain are recorded in each
  ADR's outstanding-decisions section.
- Prior-art references (Tokio guidance, the Tokio actor pattern, sqlx,
  deadpool, bb8, tower, hyper, actix-web, and axum) were checked against
  fetched documentation rather than recalled from memory.

## References

- Lody session: <https://lody.ai/leynos/sessions/5188056e-9a98-4b98-b60c-7b49fe2d455f>

## Summary by Sourcery

Import and refine the proposed runtime-ownership architecture decisions for application lifecycles, connection runtimes, and client-pool scheduling.

Enhancements:
- Define a proposed runtime ownership policy covering task lifetimes, shared roots, borrowing, sole ownership, and actor-based coordination.
- Specify a proposed application lifecycle split between the builder, a server-prepared application template, and connection-local runtimes, including startup preparation and lifecycle guarantees.
- Specify a proposed single-owner client-pool scheduler with persistent task ownership, bounded admission, explicit shutdown and failure handling, and index-based slot leases.

Documentation:
- Add ADRs 011–013 and index them in the documentation contents.
- Document the proposed runtime ownership model and its relationship to the implementation roadmap in the developer guide.