### PR TITLE
Plan: Capture Vec<u8> migration baselines for the default codec path (10.2.1)

### DIFF
--- a/docs/execplans/10-2-1-capture-baselines.md
+++ b/docs/execplans/10-2-1-capture-baselines.md
@@ -1,0 +1,1228 @@
+# 10.2.1 Capture allocation, copied-byte, throughput, and latency baselines
+
+This execution plan (ExecPlan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises and discoveries`,
+`Decision log`, `Outcomes and retrospective`, `Conformance basis`, and
+`Verification plan` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+No `PLANS.md` exists in this repository as of 2026-08-23.
+
+## Purpose / big picture
+
+Roadmap item `10.2.1` is the measurement gate that the rest of the
+`Frame = Vec<u8>` migration depends on. Items `10.2.2`, `11.1.2`, `11.2.3`, and
+`13.2.1` all compare later work against numbers that do not exist yet. Without
+those numbers, "remove the final default-path copy" is an assertion nobody can
+falsify.
+
+This plan produces a reproducible baseline for four stages of the default
+codec path — inbound decode, middleware pass-through, request hooks, and
+outbound encode — across four metrics: allocation events, allocated bytes,
+copied bytes, and throughput with latency.
+
+After this work, a maintainer can observe success by running two commands and
+reading one document:
+
+```bash
+make baseline           # deterministic counters; prints a table, passes tests
+make baseline-copy      # Valgrind copy profile; prints copied-byte totals
+```
+
+and then reading `docs/frame-vec-u8-baseline.md`, which records:
+
+- For each of the four stages, at both payload classes, the exact number of
+  allocation events and allocated bytes, reproducible bit-for-bit on any
+  machine.
+- For each stage at the large payload class, the number of bytes copied
+  through `memcpy`-family calls.
+- Indicative throughput and latency figures with a recorded hardware and
+  toolchain stamp, plus an explicit statement that these figures are
+  machine-dependent and must be re-measured, not compared across machines.
+- A named, falsifiable claim about where the default path copies payload
+  bytes today, so that item `11.1.2` has something concrete to remove and
+  item `11.2.3` has something concrete to guard.
+
+The baseline is not merely written down. The deterministic counters are
+rendered into an `insta` snapshot and asserted by a test, and a further test
+asserts that the table embedded in `docs/frame-vec-u8-baseline.md` is
+byte-identical to the rendered report. A baseline that silently drifts away
+from the code it describes is worse than no baseline, so the plan makes drift
+a test failure.
+
+## Context and orientation
+
+This section assumes no prior knowledge of the repository.
+
+### What wireframe is
+
+`wireframe` is a Rust library for building servers and clients that speak
+custom binary protocols. A server application is a
+`WireframeApp<S, C, E, F>` where `S` is a serializer, `E` is a packet
+(envelope) type, and `F` is a frame codec. The default instantiation, declared
+at `src/app/builder/core.rs:29-34`, is:
+
+```rust
+WireframeApp<BincodeSerializer, (), Envelope, LengthDelimitedFrameCodec>
+```
+
+Its `Default` implementation (`src/app/builder/core.rs:52-80`) leaves
+`middleware` empty and `protocol`, `fragmentation`, and `message_assembler`
+all `None`. On the default path, therefore, middleware, protocol hooks,
+fragmentation, and reassembly are inert. Only decode, dispatch, and encode do
+real work. Throughout this plan, "the default codec path" means exactly this
+configuration.
+
+### The four stages, precisely
+
+**Inbound decode.** `WireframeApp::process_stream`
+(`src/app/inbound_handler.rs:158-226`) wraps the transport in a
+`tokio_util::codec::Framed` built from `CombinedCodec`
+(`src/app/combined_codec.rs:8-18`). Each frame reaches `handle_frame`
+(`src/app/inbound_handler.rs:228-276`), then
+`build_dispatchable_envelope` (`:278-322`), which calls
+`parse_envelope` (`:74-95`). That in turn calls `BincodeSerializer::parse`
+(`src/serializer.rs:150-157`), which calls `Envelope::from_bytes`, resolving
+to the blanket `Message::from_bytes` (`src/message.rs:106-111`) and finally
+into `bincode`. The `Vec<u8>` allocation that becomes `Envelope.payload` is
+made inside `bincode`, not inside `wireframe`. It is observable only through
+allocator instrumentation, never through a `wireframe`-owned copy call.
+
+**Middleware pass-through.** `frame_handling::forward_response`
+(`src/app/frame_handling/response.rs:29-63`) builds
+`ServiceRequest::new(env.payload, env.correlation_id)` at line 41 and calls
+`service.call(request)` at line 42. `ServiceRequest`
+(`src/middleware.rs:39-76`) holds a `FrameContainer<Vec<u8>>`.
+`RouteService::call` (`src/middleware.rs:315-339`) rebuilds the packet with
+`E::from_parts(PacketParts::new(id, correlation_id, req.into_inner()))`. Every
+step here is a move. `WireframeApp::build_chains`
+(`src/app/inbound_handler.rs:146-156`) iterates the middleware vector in
+reverse; on the default path that vector is empty and the loop body never
+executes.
+
+**Request hooks.** These are the client-side hooks in `src/client/hooks.rs`:
+`BeforeSendHook = Arc<dyn Fn(&mut Vec<u8>) + Send + Sync>` (line 152) and
+`AfterReceiveHook = Arc<dyn Fn(&mut BytesMut) + Send + Sync>` (line 176),
+collected in `RequestHooks` (lines 184-189) and invoked by
+`invoke_before_send_hooks` and `invoke_after_receive_hooks`
+(`src/client/messaging.rs:335-346`) from `src/client/send_pipeline.rs:41` and
+`src/client/messaging.rs:295`.
+
+The server-side `WireframeProtocol::before_send` hooks in `src/hooks.rs` are a
+different mechanism. On the default path `protocol` is `None`, so
+`ProtocolHooks::before_send` (`src/hooks.rs:172-177`) is a no-op. They are out
+of scope; see `Decision log` entry D-4.
+
+**Outbound encode.** `encode_message_frame`
+(`src/app/outbound_encoding.rs:22-38`) is the whole of it:
+
+```rust
+let bytes = serializer.serialize(msg).map_err(SendError::Serialize)?;
+// Keep this bridge behaviour-preserving until issue #538 changes the
+// public serializer contract to return a Bytes-native container.
+let frame = codec.wrap_payload(Bytes::from(bytes));
+```
+
+It is called from `send_envelope` (`src/app/codec_driver.rs:120-152`, line
+132) and `flush_pipeline_output` (`:164-180`). ADR-010
+(`docs/adr-010-transport-frame-boundary-for-zero-copy.md:196-206`) confirms
+this is the sole production caller of `FrameCodec::wrap_payload`.
+
+### A correction the baseline must record
+
+The roadmap and ADRs describe a "final default-path `Vec<u8>` copy between
+serialization and `FrameCodec::wrap_payload`". Read literally, that phrase
+names two operations that are both free on the default codec:
+
+- `Bytes::from(Vec<u8>)` at `src/app/outbound_encoding.rs:36` takes ownership
+  of the vector's buffer. It does not copy.
+- `LengthDelimitedFrameCodec::wrap_payload` (`src/codec.rs:260-285`) is the
+  identity function; `type Frame = Bytes` and the payload is returned
+  unchanged.
+
+The real cost is one step earlier: `Serializer::serialize`
+(`src/serializer.rs:61-113`) returns `Vec<u8>`, so `bincode` must allocate a
+fresh vector and copy the envelope payload into it. That allocation and that
+copy are what item `11.1.2` must remove, by giving the serializer a
+`Bytes`-native output contract. The baseline must therefore attribute the
+outbound cost to `Serializer::serialize`, not to `Bytes::from` or
+`wrap_payload`, or item `11.1.2` will be measured against the wrong number.
+
+The same asymmetry appears inbound: `FrameCodec::frame_payload_bytes` has a
+default body of `Bytes::copy_from_slice` (`src/codec.rs:90`), which copies,
+but `LengthDelimitedFrameCodec` overrides it with `frame.clone()`
+(`src/codec.rs:260-285`), a reference-count bump. The default path does not
+pay that copy; a protocol-native codec that does not override the method
+would.
+
+### What already exists
+
+Roadmap item `9.6.1` (see `docs/execplans/9-6-1-codec-performance-benchmarks.md`,
+status COMPLETE) built codec-level benchmarks:
+
+- `benches/codec_performance.rs` defines the Criterion groups `codec/encode`,
+  `codec/decode`, and `codec/fragmentation_overhead`.
+- `benches/codec_performance_alloc.rs` defines the group `codec/allocations`
+  and contains a private `CountingAllocator` (lines 34-77) installed as
+  `#[global_allocator]`.
+- `wireframe_testing/src/codec_benchmarks/` holds the shared support code:
+  `SMALL_PAYLOAD_BYTES = 32`, `LARGE_PAYLOAD_BYTES = 64 * 1024`,
+  `VALIDATION_ITERATIONS = 16`, `payload_for_class`, `CodecUnderTest`,
+  `PayloadClass`, `BenchmarkWorkload`, `benchmark_workloads`, `measure_encode`,
+  `measure_decode`, `Measurement`, `MeasurementExt`, `AllocationBaseline`, and
+  `allocation_label`.
+- `make bench-codec` (`Makefile:66-67`) runs both bench binaries with
+  `--features test-support`.
+
+Three gaps matter for this item. First, the existing coverage stops at the
+codec boundary: there is nothing for middleware, hooks, or the
+serializer-to-codec bridge. Second, `CountingAllocator` counts allocation
+*events* only — it never reads `layout.size()`, so it cannot report bytes —
+and it uses process-global atomics, which is why its own documentation
+(lines 79-84) calls it a "noisy relative baseline". Third, nothing anywhere in
+the repository measures copied bytes, and no document defines what a "copied
+byte" is.
+
+### Terms defined
+
+- **Allocation event**: one call into the global allocator's `alloc`,
+  `alloc_zeroed`, or `realloc` entry point.
+- **Allocated bytes**: the sum of `Layout::size()` over allocation events. For
+  `realloc`, the new size.
+- **Copied byte**: a byte written to a second location by a `memcpy`,
+  `memmove`, `strcpy`, or `bcopy` call while an equivalent live copy exists.
+  This is the operational definition adopted by this plan; see `Decision log`
+  entry D-2 and ADR-011.
+- **Payload class**: `Small` (32 bytes) or `Large` (65,536 bytes), as already
+  defined in `wireframe_testing::codec_benchmarks`.
+- **Probe**: a deterministic, in-process function that drives one production
+  stage exactly once for one payload class, with no transport and no runtime
+  scheduling.
+- **Deterministic counter**: a measurement that yields an identical value on
+  every machine and every run. Allocation events, allocated bytes, and copied
+  bytes are deterministic counters. Throughput and latency are not.
+
+## Conformance basis
+
+There is no Terms of Reference document in this repository. The upstream
+artefacts are:
+
+- `docs/roadmap.md` section 10.2, item `10.2.1` (lines 470-481), revision as at
+  commit `d77dd76`.
+- `docs/adr-008-zero-copy-public-byte-container.md` (Accepted). The binding
+  technical requirement is line 85-86: "The default codec path must be able to
+  move from serialization to `wrap_payload` without materializing a fresh
+  `Vec<u8>`." Its non-goal at line 181 explicitly declines to guarantee zero
+  allocation for mutation paths, so the baseline must separate read-only from
+  mutating hook shapes.
+- `docs/adr-009-vec-u8-migration-rollout.md` (Accepted). Line 270-272 flags
+  `PayloadBytes::into_vec` as a known allocating-and-copying escape hatch.
+- `docs/adr-010-transport-frame-boundary-for-zero-copy.md` (Accepted). Lines
+  189-192 name the residual serializer-to-codec bridge and link issue
+  [leynos/wireframe#538](https://github.com/leynos/wireframe/issues/538); lines
+  196-206 pin the sole production `wrap_payload` call site.
+- `docs/frame-vec-u8-inventory.md`, in particular lines 98-105 and 118 (the
+  middleware `Vec<u8>` island), 124-127 (inbound decode), 132-140 (the
+  middleware-to-codec return path), 200-204 (client hooks), and 226-228 (the
+  serializer contract).
+- `docs/zero-copy-frame-and-payload-migration-roadmap.md`, items 1.2.1 and
+  1.2.2, the precursor wording that `docs/roadmap.md` 10.2.1 condenses.
+
+Trace links:
+
+```plaintext
+ADR-008-REQ-default-path-no-fresh-vec -> EP-M3 -> EP-M4
+  -> tests::baseline_report::outbound_encode_allocates_serializer_vec
+ADR-010-RISK-serializer-bridge -> EP-M5
+  -> docs/frame-vec-u8-baseline.md#outbound-encode
+ROADMAP-10.2.1-alloc -> EP-M1, EP-M3, EP-M4
+  -> tests::baseline_report::snapshot_matches_committed_baseline
+ROADMAP-10.2.1-copied-bytes -> EP-M5
+  -> docs/frame-vec-u8-baseline.md#copied-bytes
+ROADMAP-10.2.1-throughput-latency -> EP-M5
+  -> benches/pipeline_baseline.rs
+INVENTORY-middleware-island -> EP-M3
+  -> tests::baseline_report::middleware_pass_through_is_move_only
+EP-M2 (measurement soundness) -> verus/wireframe_proofs.rs
+  and src/../alloc_probe.rs kani harnesses
+```
+
+Item `10.2.1` requires `10.1.1`, which is complete (`docs/roadmap.md:460-462`),
+so this item is unblocked.
+
+## Constraints
+
+- The four stages, the metric set, and "the default codec path" are fixed by
+  `docs/roadmap.md:472-474`. Do not narrow them.
+- Production behaviour must not change. Every probe drives production code; no
+  probe may re-implement a production step. Where a production function is
+  crate-private, expose it through a `test-support`-gated shim rather than
+  copying its body into the probe. A probe that re-implements the thing it
+  measures proves only that the probe is self-consistent.
+- The `test-support` Cargo feature is the only permitted mechanism for widening
+  visibility. Nothing new may become unconditionally public on the `wireframe`
+  crate.
+- Deterministic counters must be exactly reproducible. No test may assert on
+  wall-clock time, throughput, or latency.
+- Allocation instrumentation must be thread-local, not process-global, so that
+  a parallel test harness running on other threads cannot pollute a
+  measurement. This is a hard requirement, not a preference: the existing
+  process-global counter is documented as noisy, and a noisy baseline cannot
+  support item `10.2.2`'s thresholds.
+- Copied-byte measurement must not require modifying production code. It is an
+  external observation.
+- Use `rstest` for unit tests, `rstest-bdd` v0.5.0 for behavioural tests,
+  `googletest` matchers and `pretty_assertions` for assertion clarity,
+  `proptest` for generated input domains, and `insta` for the rendered
+  baseline snapshot.
+- All documentation must follow `docs/documentation-style-guide.md`: en-GB
+  Oxford spelling, sentence-case headings, prose wrapped at 80 columns, code
+  at 120, language identifiers on every fence, captions on every table, no
+  first-person or second-person pronouns.
+- Register every new document in `docs/contents.md`.
+- Record the measurement methodology in a new ADR
+  (`docs/adr-011-byte-migration-baseline-methodology.md`) and reference it from
+  `docs/frame-vec-u8-baseline.md` and `docs/developers-guide.md`.
+- Append an entry under `## Unreleased` in `CHANGELOG.md`.
+- Mark `docs/roadmap.md` item `10.2.1` done only after every gate passes. Edit
+  the roadmap with `mapsplice` per `docs/developers-guide.md:512-540`, and use
+  inline links rather than footnotes in that file.
+- Run gates with `set -o pipefail` and `tee` to a log under `/tmp`. Delegate
+  full gate runs to the `scrutineer` sub-agent; do not run them inline.
+- Commit after each milestone. Every commit must pass `make check-fmt`,
+  `make lint`, and `make test`.
+
+## Tolerances (exception triggers)
+
+- **Scope**: if implementation touches more than 32 files or exceeds 2,500 net
+  changed lines, stop and re-scope.
+- **Dependencies**: `insta` is the only new dependency this plan authorizes,
+  and only as a `dev-dependency`. If anything else is required — including
+  `dhat`, `stats_alloc`, `iai-callgrind`, or `critcmp` — stop and escalate.
+- **Public interface**: if any change must be visible without the
+  `test-support` feature, stop and escalate.
+- **Verus**: this would be the repository's first Verus proof. If the proof in
+  EP-M2 is not discharged within four attempts, stop, record the failure, and
+  escalate with the option of descoping to the Kani harness plus the proptest
+  model. Do not weaken the property to make it provable.
+- **Kani**: if a harness exceeds ten minutes at its stated unwind bound, reduce
+  the bound and record the reduction rather than raising the timeout.
+- **Valgrind**: if `valgrind --tool=dhat --mode=copy` cannot attribute copies
+  to the probe under test, stop and escalate before inventing a substitute
+  metric.
+- **Measurement instability**: if a deterministic counter varies between two
+  consecutive runs on the same machine, stop. That is an instrument defect, not
+  noise to be averaged away.
+- **Benchmark runtime**: if a single Criterion target exceeds six minutes
+  locally, reduce sample size and record the change.
+- **Ambiguity**: if the correct attribution of a measurement to a stage is
+  genuinely unclear, stop and present the options rather than choosing
+  silently.
+
+## Risks
+
+- Risk: thread-local state accessed from inside a `GlobalAlloc` implementation
+  can recurse or fail during thread-local storage initialization and teardown,
+  because initializing thread-local storage may itself allocate.
+  Severity: high. Likelihood: medium.
+  Mitigation: declare the counters with `thread_local!` using a
+  `const { Cell::new(0) }` initializer so that no lazy allocation occurs on
+  first access, and reach them through `try_with`, treating a failure as "not
+  measuring" rather than panicking. Add a test that allocates during thread
+  teardown and asserts the process does not abort.
+
+- Risk: LLVM inlines small `memcpy` calls into load and store sequences, which
+  Valgrind's DHAT copy mode cannot see, so copied bytes are undercounted for
+  small payloads.
+  Severity: medium. Likelihood: high.
+  Mitigation: treat copied bytes as normative only for the `Large` payload
+  class, record the `Small` class with an explicit undercount caveat, and
+  cross-check both against allocated bytes, which bound copied bytes from above
+  for allocate-then-fill buffers. Record this limitation in ADR-011 rather than
+  hiding it.
+
+- Risk: the bytes copied inside `bincode` and inside `tokio_util` are not
+  attributable to `wireframe` source lines, so a naive reading of a DHAT
+  profile blames the wrong frame.
+  Severity: medium. Likelihood: high.
+  Mitigation: run one probe process per stage with a `--stage` argument, and
+  subtract a `--stage noop` calibration run, so each figure is a difference
+  between two whole-process totals rather than an attribution to a stack.
+
+- Risk: this is the repository's first Verus proof, and
+  `docs/developers-guide.md:376-379` states `make run-verus` is expected to fail
+  until `verus/wireframe_proofs.rs` exists. Establishing the proof harness may
+  cost more than the proof.
+  Severity: medium. Likelihood: medium.
+  Mitigation: EP-M2 is a separable milestone with its own tolerance. The
+  measurement work in EP-M1 and EP-M3 does not depend on it.
+
+- Risk: `insta` is new to the repository, so there is no existing convention
+  for snapshot location or review.
+  Severity: low. Likelihood: high.
+  Mitigation: place snapshots under `tests/snapshots/`, document the
+  re-blessing procedure in `docs/developers-guide.md`, and keep the snapshot
+  restricted to deterministic counters so it never fails for environmental
+  reasons.
+
+- Risk: the baseline document and the snapshot drift apart, leaving a document
+  that describes code that no longer exists.
+  Severity: medium. Likelihood: medium.
+  Mitigation: a test asserts that the fenced table in
+  `docs/frame-vec-u8-baseline.md` is byte-identical to the rendered report.
+
+- Risk: the `test-support` shims widen the surface that later refactors must
+  keep working, creating drag on items 11.x and 12.x.
+  Severity: low. Likelihood: medium.
+  Mitigation: the shims are thin re-exports of existing crate-private
+  functions, feature-gated, and documented as unstable. When 11.1.2 changes
+  `Serializer::serialize`, the shim changes with it and the baseline is
+  re-blessed; that is the intended workflow, not breakage.
+
+- Risk: benchmarks do not currently run in CI at all, so nothing prevents the
+  baseline from rotting.
+  Severity: medium. Likelihood: medium.
+  Mitigation: the deterministic half of the baseline runs under `make test`,
+  which CI does run. Only the timing half and the Valgrind half are
+  operator-invoked. Record this split explicitly so item `10.2.2` does not
+  assume a CI gate that does not exist.
+
+## Verification plan
+
+The implementation introduces one genuinely non-trivial piece of logic: the
+allocation-accounting state machine. Everything downstream — every threshold in
+`10.2.2`, every regression assertion in `11.2.3`, every claim in `13.2.1` —
+rests on that accounting being exact. It is therefore verified rather than
+merely tested.
+
+The probes themselves introduce no invariant; they are straight-line calls into
+production code. They are covered by parameterized tests and a negative
+control.
+
+### Axioms
+
+These are assumed, not verified:
+
+- The system allocator satisfies the `GlobalAlloc` contract.
+- `bincode` and `tokio_util` behave as documented; their internals are not
+  verified. Their observable allocation behaviour is measured, not proven.
+- Valgrind's DHAT copy mode counts bytes passed to `memcpy`, `memmove`,
+  `strcpy`, and `bcopy`, as documented in the Valgrind manual, section 10.5.
+- `thread_local!` with a `const` initializer performs no heap allocation on
+  first access on the supported targets.
+- Criterion's timing methodology is sound; this plan does not verify it and
+  does not assert on its output.
+
+### Obligation V-1: accounting exactness over unbounded event sequences
+
+- **Obligation**: for any finite sequence of allocator events
+  `e_0 .. e_{n-1}`, the accounting function satisfies
+  `total_events = |{e : e is Alloc or Realloc}|`,
+  `total_bytes = Σ size(e) over allocating events`,
+  `curr_bytes = Σ size of live blocks`, and `curr_bytes ≤ total_bytes`. The
+  `Realloc` case is the non-trivial one: it must count as one allocating event
+  of the new size, release the old size from `curr_bytes`, and contribute
+  `min(old, new)` to `realloc_moved_bytes`.
+- **Method**: Verus deductive proof by induction over `Seq<Event>`.
+- **Rationale**: the sequence length is unbounded — a large-payload probe
+  performs thousands of events — so bounded exploration cannot discharge the
+  property. The realloc case makes the induction step non-trivial, so the proof
+  is not a restatement of the assumption.
+- **Domain**: all finite sequences over
+  `Event = Alloc(size) | Realloc(old, new) | Dealloc(size)`, with sizes in
+  `nat`.
+- **Artefact**: `verus/wireframe_proofs.rs` and
+  `verus/wireframe_proofs_alloc.rs`.
+- **Evidence**: `make run-verus` currently fails with a missing-proof-file
+  diagnostic; after EP-M2 it must report zero verification errors. Record the
+  transcript.
+- **Non-vacuity**: the proof must include a witness lemma exhibiting a
+  three-event sequence `[Alloc(8), Realloc(8, 16), Dealloc(16)]` with the
+  concrete expected totals, proving the antecedents are inhabited. Before
+  declaring the proof complete, seed a fault by changing the `Realloc` arm to
+  add `old` instead of `new` to `total_bytes` and confirm Verus rejects it.
+  Inspect the proof for stray `assume` statements; any surviving `assume` fails
+  this obligation.
+
+### Obligation V-2: the real allocator refines the specification
+
+- **Obligation**: the `GlobalAlloc` implementation in
+  `wireframe_testing::codec_benchmarks::alloc_probe` records, for any bounded
+  sequence of allocation operations, exactly the totals that the V-1
+  specification function computes for the corresponding event sequence.
+- **Method**: Kani bounded model checking.
+- **Rationale**: V-1 proves the specification correct; V-2 connects the
+  specification to the code that actually runs. Kani explores every path
+  through the real `alloc`, `realloc`, and `dealloc` arms including the
+  enable/disable gating and the `try_with` fallback, which Verus cannot reach
+  because those paths use `unsafe` and thread-local storage.
+- **Domain**: sequences of up to four operations with symbolic sizes bounded to
+  a small range, plus a symbolic enable/disable schedule. Stated bound:
+  `#[kani::unwind(5)]`.
+- **Artefact**: `#[cfg(kani)]` harnesses in
+  `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`, run by
+  `make kani-baseline`.
+- **Evidence**: `cargo kani --harness verify_alloc_probe_refines_spec` reports
+  no failed properties. Record the transcript including the explored bound.
+- **Non-vacuity**: assert that at least one reachable execution has
+  `total_events > 0` and one has counting disabled, so neither branch is
+  vacuously excluded. Seed a fault by dropping the `layout.size()` addition in
+  the `realloc` arm and confirm Kani produces a counter-example. Do not
+  `kani::assume` a fixed size; the sizes must remain symbolic.
+
+### Obligation V-3: measurement scoping is exact and non-reentrant
+
+- **Obligation**: for a measured scope `S`, the reported counters equal the
+  counters of exactly the allocator events that occurred on the measuring
+  thread between entering and leaving `S`; nested scopes do not double-count;
+  events on other threads are excluded.
+- **Method**: `proptest` over generated scope schedules, plus an `rstest`
+  parameterized test that spawns concurrent allocating threads during a
+  measurement.
+- **Rationale**: this is a property over orderings and interleavings rather
+  than over arithmetic, and the thread-exclusion half cannot be expressed in
+  the single-threaded Verus or Kani models.
+- **Domain**: generated sequences of `Enter`, `Allocate(size)`, `Leave`, and
+  `SpawnAllocatingThread` operations, depth-bounded to 3.
+- **Artefact**: `wireframe_testing/tests/alloc_probe_scoping.rs`.
+- **Evidence**: the property fails before the thread-local change (the current
+  process-global counter cannot exclude other threads) and passes after.
+  Record both transcripts. Use `proptest`'s classification output to show that
+  generated cases actually reach nesting depth 3 and actually spawn threads;
+  if a class is unreached, the generator is wrong and the run does not count.
+- **Non-vacuity**: negative control — a test variant that deliberately shares
+  the counter across threads must fail the property.
+
+### Obligation V-4: the probes exercise the stages they claim to
+
+- **Obligation**: each of the four probes performs a non-zero, stage-specific
+  amount of work, and the reported counters change when the corresponding
+  production code changes.
+- **Method**: `rstest` parameterized tests with `googletest` matchers, plus a
+  seeded-fault probe variant.
+- **Rationale**: a baseline of zero is indistinguishable from a probe that
+  never ran. This obligation exists to make that failure mode impossible.
+- **Domain**: the four stages crossed with the two payload classes.
+- **Artefact**: `tests/baseline_probes.rs`.
+- **Evidence**: every probe reports `total_events > 0` for at least one payload
+  class; the middleware probe reports zero *payload-sized* allocations,
+  matching the "moves only" claim; the outbound-encode probe reports at least
+  one allocation of at least `payload_len` bytes, matching the
+  `Serializer::serialize` claim.
+- **Non-vacuity**: the seeded-fault control. A `#[cfg(test)]` probe variant
+  inserts one additional `payload.to_vec()` into the middleware stage. The
+  test asserts that this variant reports strictly more allocated bytes than the
+  faithful variant, by at least `payload_len`. This proves the instrument can
+  see exactly the class of copy that item `11.1.2` will remove. If the fault
+  variant reports the same numbers, the whole baseline is worthless and the
+  milestone fails.
+
+### Obligation V-5: the recorded baseline matches the code
+
+- **Obligation**: the table in `docs/frame-vec-u8-baseline.md` equals the
+  report rendered from a live run.
+- **Method**: `insta` snapshot assertion plus a document-synchronization test.
+- **Rationale**: prevents the documented baseline from silently decaying into
+  fiction.
+- **Domain**: the full rendered report.
+- **Artefact**: `tests/baseline_report.rs` and
+  `tests/snapshots/baseline_report__deterministic_baseline.snap`.
+- **Evidence**: `make test` fails if either the snapshot or the document
+  diverges. Re-blessing is `cargo insta accept` followed by pasting the
+  snapshot body into the document, which the test then re-checks.
+- **Non-vacuity**: a negative control test mutates one digit in a copy of the
+  document fixture and asserts the synchronization check rejects it.
+
+### Obligation V-6: copied-byte capture is reproducible
+
+- **Obligation**: two consecutive `make baseline-copy` runs on the same machine
+  and binary report identical copied-byte totals per stage.
+- **Method**: behavioural test with `rstest-bdd` over the recorded profile
+  artefacts, plus an operator-run reproducibility check.
+- **Rationale**: Valgrind is deterministic by construction, so any variation
+  indicates the harness is measuring something other than the probe.
+- **Domain**: the four stages at the `Large` payload class.
+- **Artefact**: `tests/features/baseline_copy_profile.feature` with steps in
+  `tests/steps/baseline_copy_profile_steps.rs`.
+- **Evidence**: the scenario parses two recorded profile summaries and asserts
+  equality. Where Valgrind is unavailable the scenario is skipped with an
+  explicit diagnostic, never silently passed.
+- **Non-vacuity**: the fixture set includes one deliberately mismatched pair
+  that the scenario must reject.
+
+### Why Verus and Kani are both used, and where they are not
+
+Verus discharges V-1 over unbounded sequences but cannot reason about the
+`unsafe` `GlobalAlloc` implementation or thread-local storage. Kani discharges
+V-2 over the real implementation but only to a bound of five operations, far
+below the thousands a real probe performs. Neither alone is sufficient; the
+pair is. The residual gap is that V-2's bound does not cover long sequences,
+which V-1 covers only for the specification. That gap is stated here rather
+than papered over.
+
+No proof is attempted for the probes, the report renderer, or the Criterion
+benches. They introduce no invariant over an unbounded domain, and
+parameterized tests with a seeded-fault control give proportionate rigour.
+
+## Plan of work
+
+### Stage A — understand and confirm (no code changes)
+
+Read `src/app/outbound_encoding.rs`, `src/app/inbound_handler.rs`,
+`src/app/frame_handling/response.rs`, `src/middleware.rs`,
+`src/client/hooks.rs`, `src/client/messaging.rs`, `src/client/send_pipeline.rs`,
+`src/codec.rs`, and `src/serializer.rs`, and confirm the four stage boundaries
+described in `Context and orientation` against the current tree.
+
+Confirm two open questions recorded during planning and write the answers into
+`Surprises and discoveries`:
+
+1. `src/app/codec_driver.rs:1-12` documents that the frame pipeline applies
+   protocol hooks via `before_send`, but no such invocation was located in
+   `FramePipeline::process` (`:56-71`) or in
+   `src/app/frame_handling/response.rs`. Determine whether the documentation is
+   stale or whether the invocation lives in an untraced path such as
+   `src/connection/frame.rs`. Do not fix it in this plan; record it and, if it
+   is a genuine defect, raise a separate issue.
+2. `docs/repository-layout.md` is referenced by `AGENTS.md:41-43`,
+   `docs/documentation-style-guide.md`, and `docs/roadmap.md`, but does not
+   exist. Record the gap; creating it is out of scope.
+
+Validation: no code changes; the two answers are written into the plan.
+
+### Stage B — red tests
+
+Write the failing tests before the implementation, in this order:
+
+1. `wireframe_testing/tests/alloc_probe_scoping.rs` — the V-3 property. It
+   fails to compile until `alloc_probe` exists.
+2. `tests/baseline_probes.rs` — the V-4 tests including the seeded-fault
+   control.
+3. `tests/baseline_report.rs` — the V-5 snapshot and document-synchronization
+   tests. The snapshot file does not exist yet, so `insta` reports a new
+   snapshot; the document test fails because
+   `docs/frame-vec-u8-baseline.md` does not exist.
+4. `tests/features/baseline_copy_profile.feature` and its steps — the V-6
+   scenario, failing because no profile artefacts exist.
+
+Validation: each test fails for its intended reason, recorded as a transcript
+in `Artefacts and notes`. A test that fails to compile counts as red only if
+the compilation error names the missing item this plan will add.
+
+### Stage C — implementation and verification together
+
+Milestones EP-M1 through EP-M5 below. Each ends with its own validation.
+
+### Stage D — documentation, cleanup, and wider validation
+
+Milestone EP-M6.
+
+## Milestones and plateaus
+
+### EP-M1 — byte-aware, thread-local allocation instrument
+
+- **Outcome**: `wireframe_testing::codec_benchmarks::alloc_probe` exists and
+  `benches/codec_performance_alloc.rs` uses it instead of its private
+  `CountingAllocator`. The existing `codec/allocations` Criterion group and its
+  label format are unchanged.
+- **Requirements**: `ROADMAP-10.2.1-alloc`.
+- **Interfaces**: in
+  `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`, define:
+
+  ```rust
+  /// Counters describing allocator traffic observed on one thread.
+  #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+  pub struct AllocationCounters {
+      pub allocation_events: u64,
+      pub allocated_bytes: u64,
+      pub deallocation_events: u64,
+      pub deallocated_bytes: u64,
+      pub reallocation_events: u64,
+      pub realloc_moved_bytes: u64,
+  }
+
+  /// A `GlobalAlloc` that counts traffic on the measuring thread only.
+  pub struct ProbeAllocator;
+
+  // SAFETY invariants are documented on the impl.
+  unsafe impl core::alloc::GlobalAlloc for ProbeAllocator { /* ... */ }
+
+  /// Runs `operation` with counting enabled on the current thread and
+  /// returns the counters attributable to it.
+  pub fn measure<T, F: FnOnce() -> T>(operation: F) -> (T, AllocationCounters);
+  ```
+
+  The counters live in `thread_local!` `Cell`s declared with
+  `const { Cell::new(0) }` and are reached with `try_with`; a `try_with`
+  failure means "not measuring" and must never panic. `measure` is re-entrant
+  safe: a nested `measure` attributes events to the innermost scope and adds
+  them to the outer scope on exit.
+- **Acceptance evidence**: `wireframe_testing/tests/alloc_probe_scoping.rs`
+  passes, including the concurrent-thread exclusion case that the previous
+  process-global counter could not satisfy. `make bench-codec` still emits the
+  same `wrap_allocs_<n>` and `decode_allocs_<n>` label shapes.
+- **Conformance check**: no public `wireframe` API changed; only
+  `wireframe_testing` gained a module. No new dependency.
+- **Recovery**: the change is additive to `wireframe_testing` and a
+  single-file substitution in the bench. Revert the bench file to restore the
+  prior behaviour.
+- **Remaining gaps**: the instrument is unverified until EP-M2.
+- **Compatibility decision**: none required. `wireframe_testing` is a test
+  support crate below 1.0 with no external consumer commitment.
+
+### EP-M2 — verification of the accounting
+
+- **Outcome**: V-1 discharged in Verus, V-2 discharged in Kani.
+- **Requirements**: measurement soundness for `ROADMAP-10.2.1-alloc`.
+- **Interfaces**: `verus/wireframe_proofs.rs` as the entry point that `mod`s
+  `verus/wireframe_proofs_alloc.rs`, mirroring `AllocationCounters` as a spec
+  struct and `Event` as a spec enum. A Makefile target `kani-baseline` runs the
+  Kani harnesses; `make run-verus` gains a working proof file for the first
+  time.
+- **Acceptance evidence**: `make run-verus` reports zero errors;
+  `make kani-baseline` reports no failed properties; both seeded faults
+  described in V-1 and V-2 are shown to be rejected, with transcripts.
+- **Conformance check**: `docs/developers-guide.md:354-393` describes the
+  formal tooling entry points and states that `run-verus` fails until a proof
+  file exists; that statement must be updated in EP-M6.
+- **Recovery**: the proof files are outside the Cargo build. Deleting them
+  restores the prior state exactly.
+- **Remaining gaps**: V-2's bound of five operations, stated explicitly.
+- **Compatibility decision**: none.
+
+### EP-M3 — stage probes
+
+- **Outcome**: four probes drive the four production stages in-process, and a
+  seeded-fault variant exists for the negative control.
+- **Requirements**: `ROADMAP-10.2.1-alloc`, `INVENTORY-middleware-island`,
+  `ADR-008-REQ-default-path-no-fresh-vec`.
+- **Interfaces**: in
+  `wireframe_testing/src/codec_benchmarks/pipeline_baseline.rs`:
+
+  ```rust
+  /// One measurable stage of the default codec path.
+  #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+  pub enum Stage {
+      InboundDecode,
+      MiddlewarePassThrough,
+      RequestHooksReadOnly,
+      RequestHooksMutating,
+      OutboundEncode,
+  }
+
+  /// Prepared, reusable inputs for one stage at one payload class.
+  pub struct StageFixture { /* ... */ }
+
+  pub fn fixture(stage: Stage, class: PayloadClass)
+      -> Result<StageFixture, BaselineError>;
+
+  /// Drives the production stage exactly once.
+  pub fn run_stage(fixture: &StageFixture) -> Result<(), BaselineError>;
+  ```
+
+  In `src/app/baseline_support.rs`, gated by
+  `#![cfg(feature = "test-support")]`, expose thin `pub` wrappers over the
+  crate-private stage entry points: `encode_message_frame`
+  (`src/app/outbound_encoding.rs:22`), the decode path used by
+  `parse_envelope` (`src/app/inbound_handler.rs:74`), and
+  `RequestHooks::invoke_before_send_hooks`
+  (`src/client/messaging.rs:335`). Each wrapper is a single delegating call
+  with a doc comment stating it exists for baseline measurement and carries no
+  stability guarantee.
+- **Acceptance evidence**: `tests/baseline_probes.rs` passes, including the
+  seeded-fault control from V-4. The middleware probe reports zero
+  payload-sized allocations; the outbound-encode probe reports at least one
+  allocation of at least `payload_len` bytes.
+- **Conformance check**: every new `wireframe` item is behind `test-support`.
+  Confirm with `cargo public-api` if available, otherwise by inspection of the
+  feature gates.
+- **Recovery**: probes and shims are additive; deleting
+  `src/app/baseline_support.rs` and its `mod` declaration reverts cleanly.
+- **Remaining gaps**: no numbers are recorded yet.
+- **Compatibility decision**: none. The shims are feature-gated and the crate
+  is pre-1.0.
+
+### EP-M4 — deterministic baseline report
+
+- **Outcome**: a rendered report of deterministic counters, snapshotted and
+  cross-checked against the document, plus a `make baseline` target.
+- **Requirements**: `ROADMAP-10.2.1-alloc`.
+- **Interfaces**:
+
+  ```rust
+  /// One row of the deterministic baseline.
+  pub struct BaselineRow {
+      pub stage: Stage,
+      pub payload_class: PayloadClass,
+      pub counters: AllocationCounters,
+  }
+
+  /// Renders rows in a stable, sorted order as a Markdown table.
+  pub fn render_report(rows: &[BaselineRow]) -> String;
+  ```
+
+  `render_report` must sort by `(stage, payload_class)` so that the output does
+  not depend on collection order.
+- **Acceptance evidence**: `make baseline` prints the table and exits zero;
+  `tests/baseline_report.rs` passes both the snapshot assertion and the
+  document-synchronization assertion; the negative control from V-5 is
+  rejected.
+- **Conformance check**: `insta` appears only under `[dev-dependencies]`.
+- **Recovery**: delete the snapshot and re-run `cargo insta accept`.
+- **Remaining gaps**: copied bytes and timings are not yet recorded.
+- **Compatibility decision**: none.
+
+### EP-M5 — copied bytes, throughput, and latency
+
+- **Outcome**: `benches/pipeline_baseline.rs` measures throughput and latency
+  for the four stages; a probe binary plus `make baseline-copy` captures
+  copied-byte totals under Valgrind; both sets of figures are recorded.
+- **Requirements**: `ROADMAP-10.2.1-copied-bytes`,
+  `ROADMAP-10.2.1-throughput-latency`, `ADR-010-RISK-serializer-bridge`.
+- **Interfaces**: a `test-support`-gated binary target
+  `baseline-copy-probe` accepting `--stage <name>` and `--iterations <n>`,
+  where `--stage noop` performs setup and teardown only. `make baseline-copy`
+  runs each stage and the calibration under
+  `valgrind --tool=dhat --mode=copy` and reports, per stage, the difference
+  between the stage total and the calibration total, divided by the iteration
+  count.
+- **Acceptance evidence**: two consecutive `make baseline-copy` runs produce
+  identical per-stage figures (V-6). The Criterion groups
+  `pipeline/inbound_decode`, `pipeline/middleware_pass_through`,
+  `pipeline/request_hooks`, and `pipeline/outbound_encode` appear in
+  `make bench-codec` output with `Throughput::Bytes` set.
+- **Conformance check**: no production code changed for the copy measurement;
+  Valgrind is invoked externally.
+- **Recovery**: the probe binary and bench are additive and independently
+  removable. If Valgrind is unavailable the copy target fails loudly with a
+  diagnostic naming the missing tool; it must not silently record zeros.
+- **Remaining gaps**: copied bytes for the `Small` payload class carry a stated
+  undercount caveat.
+- **Compatibility decision**: none.
+
+### EP-M6 — documentation, roadmap, and final gates
+
+- **Outcome**: the baseline is published, the methodology is recorded as an
+  ADR, the internal conventions are documented, and the roadmap is ticked.
+- **Requirements**: all of the above.
+- **Deliverables**:
+  - `docs/frame-vec-u8-baseline.md` — the baseline itself: the deterministic
+    table (byte-identical to the snapshot), the copied-byte table for the
+    `Large` class with the `Small`-class caveat, the indicative timing table
+    with a hardware, operating-system, and toolchain stamp, and a short section
+    stating the falsifiable claim about where the default path copies today.
+  - `docs/adr-011-byte-migration-baseline-methodology.md` — Status Accepted,
+    following the ADR template in `docs/documentation-style-guide.md:418-495`.
+    It records: the operational definition of a copied byte; why Valgrind DHAT
+    copy mode was chosen and what it cannot see; why allocation counting is
+    thread-local; why deterministic counters are normative and timings are not;
+    and the correction that `wrap_payload` and `Bytes::from` are free on the
+    default codec while `Serializer::serialize` is not.
+  - `docs/developers-guide.md` — a new subsection after "Example and benchmark
+    support" (line 332-352) covering the baseline module, the two make targets,
+    the `insta` re-blessing procedure, and the rule that the baseline document
+    is re-blessed alongside the snapshot. Update the statement at lines 376-379
+    that `run-verus` is expected to fail.
+  - `docs/users-guide.md` — a short note under the codec testing material
+    stating that `wireframe_testing::codec_benchmarks` now exposes baseline
+    probes and an allocation instrument for consumers who wish to measure their
+    own codecs, and that these require the `test-support` feature.
+  - `docs/contents.md` — register the new baseline document and ADR-011.
+  - `CHANGELOG.md` — one bullet under `## Unreleased`.
+  - `docs/roadmap.md` — mark `10.2.1` done using `mapsplice`.
+- **Acceptance evidence**: `make check-fmt`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie` all pass, delegated to `scrutineer`
+  with logs under `/tmp`.
+- **Conformance check**: every upstream identifier in `Conformance basis` maps
+  to a milestone and an acceptance item; ADR-008's requirement at line 85-86
+  is now measurable; ADR-010's risk at lines 189-192 now has a number attached.
+- **Recovery**: documentation changes are independently revertible.
+- **Remaining gaps**: item `10.2.2` will choose the threshold numbers; this
+  plan deliberately does not.
+- **Compatibility decision**: none.
+
+## Concrete steps
+
+Run everything from the repository root.
+
+Establish the red state:
+
+```bash
+set -o pipefail
+cargo test --all-targets --all-features 2>&1 \
+  | tee /tmp/test-wireframe-10-2-1-red.out
+```
+
+Expected: compilation failures naming
+`wireframe_testing::codec_benchmarks::alloc_probe`, which does not yet exist.
+
+After EP-M1:
+
+```bash
+set -o pipefail
+cargo test -p wireframe_testing --all-features 2>&1 \
+  | tee /tmp/test-alloc-probe-10-2-1.out
+```
+
+Expected: `alloc_probe_scoping` passes, including the concurrent case.
+
+After EP-M2:
+
+```bash
+set -o pipefail
+make run-verus 2>&1 | tee /tmp/verus-wireframe-10-2-1.out
+make kani-baseline 2>&1 | tee /tmp/kani-wireframe-10-2-1.out
+```
+
+Expected from Verus, approximately:
+
+```plaintext
+verification results:: 7 verified, 0 errors
+```
+
+Expected from Kani, approximately:
+
+```plaintext
+VERIFICATION:- SUCCESSFUL
+```
+
+After EP-M4:
+
+```bash
+make baseline 2>&1 | tee /tmp/baseline-wireframe-10-2-1.out
+```
+
+Expected: a Markdown table on standard output whose body matches
+`tests/snapshots/baseline_report__deterministic_baseline.snap`.
+
+After EP-M5:
+
+```bash
+make baseline-copy 2>&1 | tee /tmp/baseline-copy-wireframe-10-2-1.out
+make baseline-copy 2>&1 | tee /tmp/baseline-copy-wireframe-10-2-1-b.out
+diff /tmp/baseline-copy-wireframe-10-2-1.out \
+     /tmp/baseline-copy-wireframe-10-2-1-b.out
+```
+
+Expected: `diff` reports no differences in the per-stage copied-byte figures.
+
+Final gates, delegated to `scrutineer`:
+
+```bash
+set -o pipefail
+make check-fmt 2>&1 | tee /tmp/check-fmt-wireframe-10-2-1.out
+make lint      2>&1 | tee /tmp/lint-wireframe-10-2-1.out
+make test      2>&1 | tee /tmp/test-wireframe-10-2-1.out
+make markdownlint 2>&1 | tee /tmp/mdlint-wireframe-10-2-1.out
+make nixie     2>&1 | tee /tmp/nixie-wireframe-10-2-1.out
+```
+
+## Validation and acceptance
+
+Acceptance is behavioural, not structural.
+
+- Running `make baseline` on any machine prints a table, and running it again
+  prints the identical table. Running it on a different machine prints the
+  identical table. If it does not, the instrument is broken.
+- Running `make baseline-copy` twice on the same machine prints identical
+  per-stage copied-byte figures.
+- `docs/frame-vec-u8-baseline.md` states, for the `Large` payload class, a
+  specific number of bytes copied during outbound encode, and that number is
+  at least 65,536 — because `bincode` must copy the payload into the vector it
+  allocates. If the recorded number is below the payload size, the measurement
+  is wrong and the milestone fails.
+- The middleware pass-through row records zero payload-sized allocations,
+  confirming the inventory's "moves only" characterization
+  (`docs/frame-vec-u8-inventory.md:118`). If it does not, the inventory is
+  wrong and that is a finding worth recording.
+- Deleting one line from `docs/frame-vec-u8-baseline.md`'s table and running
+  `make test` fails with a clear diagnostic.
+- Applying the seeded-fault probe variant and running `make test` fails,
+  because the recorded allocated bytes increase by at least the payload size.
+
+Red-Green-Refactor evidence is recorded per milestone in
+`Artefacts and notes`, with the red transcript, the green transcript, and the
+post-refactor transcript.
+
+Quality criteria:
+
+- Tests: `make test` passes with the new unit, property, behavioural, and
+  snapshot tests included.
+- Verification: V-1 discharged in Verus, V-2 in Kani, V-3 in `proptest`,
+  V-4 through V-6 in `rstest` and `rstest-bdd`, each with its stated
+  non-vacuity control demonstrated.
+- Lint and format: `make check-fmt`, `make lint`, `make markdownlint`, and
+  `make nixie` pass.
+- Performance: no threshold is set by this item. Recording indicative figures
+  is the deliverable; choosing thresholds is item `10.2.2`.
+- Security: none applicable; no new runtime dependency and no network
+  behaviour changes.
+
+## Idempotence and recovery
+
+Every step is re-runnable. `make baseline` and `make baseline-copy` are
+read-only with respect to the working tree except for Valgrind output files,
+which are written under `target/baseline/` and are covered by `.gitignore`.
+Snapshot re-blessing via `cargo insta accept` is idempotent. The Verus proof
+files live outside the Cargo build, so deleting them restores the prior state
+without touching compilation. No step is destructive, and none requires a
+backup.
+
+## Interfaces and dependencies
+
+New dependency: `insta`, `dev-dependencies` only, used solely for the rendered
+baseline snapshot. No new runtime dependency.
+
+External tool: Valgrind 3.17 or later, for DHAT copy mode. It is not a build
+requirement; `make baseline-copy` is operator-invoked and fails with a clear
+diagnostic when Valgrind is absent.
+
+New modules:
+
+- `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`
+- `wireframe_testing/src/codec_benchmarks/pipeline_baseline.rs`
+- `wireframe_testing/src/codec_benchmarks/baseline_report.rs`
+- `src/app/baseline_support.rs`, gated by `feature = "test-support"`
+- `benches/pipeline_baseline.rs`
+- `verus/wireframe_proofs.rs` and `verus/wireframe_proofs_alloc.rs`
+
+Existing modules that this plan reuses rather than duplicates:
+`wireframe_testing::codec_benchmarks::codec_benchmark_support` for
+`PayloadClass`, `payload_for_class`, and `Measurement`; and
+`wireframe_testing::helpers::drive` for in-process transport should an
+end-to-end cross-check be wanted.
+
+## Relevant documentation and skills
+
+Documentation to read before starting:
+
+- `AGENTS.md` — code style, quality gates, and Rust-specific rules.
+- `docs/documentation-style-guide.md` — mandatory for every document written
+  here, including the ADR template at lines 418-495.
+- `docs/developers-guide.md` — quality gates (176-188), example and benchmark
+  support (332-352), formal verification tooling (354-393), test
+  infrastructure (394-511), and roadmap editing with `mapsplice` (512-540).
+- `docs/frame-vec-u8-inventory.md` — the call-site inventory this baseline
+  measures.
+- ADRs 008, 009, and 010 — the approved design this baseline serves.
+- `docs/rust-testing-with-rstest-fixtures.md` and
+  `docs/rstest-bdd-users-guide.md` — fixture and scenario conventions.
+- `docs/reliable-testing-in-rust-via-dependency-injection.md` — for keeping the
+  probes injectable rather than hard-wired.
+- `docs/rust-doctest-dry-guide.md` — doctest conventions for the new public
+  items; note `make doctest-benchmark` enforces a runnable-doctest ratio.
+- `docs/multi-layered-testing-strategy.md` and
+  `docs/formal-verification-methods-in-wireframe.md` — where Kani and Verus sit
+  relative to the existing Stateright-style model in
+  `crates/wireframe-verification`.
+- `docs/hardening-wireframe-a-guide-to-production-resilience.md`,
+  `docs/generic-message-fragmentation-and-re-assembly-design.md`, and
+  `docs/multi-packet-and-streaming-responses-design.md` — background on paths
+  deliberately excluded from the default-path baseline.
+- `docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md`
+  — why the 1.0 story needs these numbers.
+
+Skills to load:
+
+- `leta` first, for symbol navigation; prefer `leta show`, `leta refs`, and
+  `leta calls` over reading whole files.
+- `rust-router`, then `rust-performance-and-layout` for the measurement work
+  and `rust-unit-testing` for the assertion and fixture shape.
+- `kani` for the V-2 harness and `verus` for the V-1 proof; load
+  `rust-verification` first if the choice between them is ever in doubt.
+- `proptest` for V-3.
+- `arch-decision-records` when writing ADR-011.
+- `execplans` for keeping this document current.
+- `en-gb-oxendict` for spelling in every document touched.
+- `mapsplice` for the roadmap edit in EP-M6.
+- `nextest` if test selection becomes awkward while iterating.
+
+## Progress
+
+- [x] (2026-08-23) Reconnaissance of the default codec path, existing
+  benchmark infrastructure, ADRs 008 to 010, the inventory, and repository
+  conventions.
+- [x] (2026-08-23) Research into allocation and copy measurement tooling:
+  Criterion baselines, `critcmp`, `dhat-rs`, `stats_alloc`, `iai-callgrind`,
+  and Valgrind DHAT copy mode.
+- [x] (2026-08-23) Draft plan written.
+- [ ] Plan reviewed and approved.
+- [ ] Stage A — confirm stage boundaries; answer the two open questions.
+- [ ] Stage B — red tests.
+- [ ] EP-M1 — byte-aware, thread-local allocation instrument.
+- [ ] EP-M2 — Verus proof and Kani harness.
+- [ ] EP-M3 — stage probes and `test-support` shims.
+- [ ] EP-M4 — deterministic baseline report and snapshot.
+- [ ] EP-M5 — copied bytes, throughput, and latency.
+- [ ] EP-M6 — documentation, roadmap tick, and final gates.
+
+## Surprises and discoveries
+
+- Observation: the "final default-path `Vec<u8>` copy between serialization and
+  `FrameCodec::wrap_payload`" named by the roadmap and ADR-010 is not located
+  where the phrase suggests.
+  Evidence: `LengthDelimitedFrameCodec::wrap_payload` is the identity function
+  (`src/codec.rs:260-285`), and `Bytes::from(Vec<u8>)`
+  (`src/app/outbound_encoding.rs:36`) takes ownership without copying. The
+  allocation and copy occur inside `bincode` because `Serializer::serialize`
+  returns `Vec<u8>` (`src/serializer.rs:61-113`).
+  Impact: the baseline must attribute outbound cost to `Serializer::serialize`.
+  ADR-011 records the correction so that item `11.1.2` targets the right code.
+
+- Observation: `FrameCodec::frame_payload_bytes` has a copying default body
+  that the default codec does not use.
+  Evidence: `src/codec.rs:90` uses `Bytes::copy_from_slice`; the
+  `LengthDelimitedFrameCodec` implementation overrides it with `frame.clone()`
+  (`src/codec.rs:260-285`).
+  Impact: a protocol-native codec that omits the override pays a
+  payload-sized copy per frame. Out of scope here, but relevant to item
+  `11.2.3`, which covers a protocol-native codec.
+
+- Observation: the existing allocation counter cannot support the baseline as
+  specified.
+  Evidence: `benches/codec_performance_alloc.rs:34-77` never reads
+  `layout.size()`, so it cannot report bytes, and it uses process-global
+  atomics, which its own documentation at lines 79-84 acknowledges makes it
+  noisy.
+  Impact: EP-M1 replaces it rather than extending it.
+
+- Observation: `docs/repository-layout.md` is referenced by `AGENTS.md:41-43`,
+  the documentation style guide, and the roadmap, but does not exist.
+  Evidence: no file matches `docs/repository-layout*`; only inbound references
+  were found.
+  Impact: out of scope for this item; recorded so it is not mistaken for a
+  search failure.
+
+- Observation: `src/app/codec_driver.rs:1-12` documents that the frame pipeline
+  applies protocol hooks, but no `ProtocolHooks::before_send` invocation was
+  located in `FramePipeline::process` (`:56-71`).
+  Evidence: reconnaissance traced the default path from `process_stream`
+  through `forward_response` to `flush_pipeline_output` without encountering
+  the call.
+  Impact: to be confirmed in Stage A. If the documentation is stale, raise a
+  separate issue; do not fix it here.
+
+- Observation: `insta` is not currently a dependency anywhere in the workspace,
+  and no snapshot test exists.
+  Evidence: no matches for `insta` in `Cargo.toml`, `Cargo.lock`, or any
+  source file.
+  Impact: EP-M4 introduces the first snapshot convention, documented in
+  `docs/developers-guide.md`.
+
+- Observation: no Verus proof and no Kani harness exists in the repository yet;
+  `make run-verus` is documented as expected to fail.
+  Evidence: `docs/developers-guide.md:376-379`; no `verus/` directory and no
+  `#[kani::proof]` attribute in the tree.
+  Impact: EP-M2 establishes both, which is why it carries its own tolerance and
+  is separable from the measurement work.
+
+## Decision log
+
+- **D-1.** Decision: extend the existing benchmark support in
+  `wireframe_testing::codec_benchmarks` rather than starting a parallel
+  harness.
+  Rationale: `docs/developers-guide.md:332-352` already directs bench targets,
+  unit tests, and BDD fixtures to that module. A second harness would fragment
+  the convention and duplicate the payload-class definitions.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-2.** Decision: define a copied byte as a byte passed to `memcpy`,
+  `memmove`, `strcpy`, or `bcopy`, and measure it with
+  `valgrind --tool=dhat --mode=copy`.
+  Rationale: no definition existed anywhere in the repository. The copies that
+  matter occur inside `bincode` and `tokio_util`, so no `wireframe`-owned
+  counter can see them; only an external observer can. Valgrind's DHAT copy
+  mode is documented for exactly this purpose (Valgrind manual, section 10.5)
+  and its own documentation shows a Rust `extend_from_slice` stack, confirming
+  that Rust slice copies are intercepted. Alternatives rejected: the `dhat`
+  crate, whose documentation states it does not profile copy functions and
+  which is self-described as experimental with low maintenance priority;
+  `stats_alloc`, which gives allocation bytes but not copy bytes;
+  `iai-callgrind`, which would add a benchmark harness dependency for a
+  measurement that a direct Valgrind invocation already provides.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-3.** Decision: allocation counting is thread-local, not process-global.
+  Rationale: the existing process-global counter is documented as noisy, and a
+  baseline that varies between runs cannot support the thresholds that item
+  `10.2.2` must set. Thread-local counting makes the deterministic counters
+  genuinely deterministic and lets the measurement run inside the normal
+  parallel test harness rather than requiring serialization.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-4.** Decision: "request hooks" means the client-side hooks in
+  `src/client/hooks.rs`. Server-side `WireframeProtocol` hooks and client
+  preamble replay are excluded.
+  Rationale: ADR-008 lists `BeforeSendHook` among the surfaces it governs, and
+  `docs/frame-vec-u8-inventory.md:200-204` groups the client hooks as the hook
+  surface for this migration. Server-side protocol hooks are inert on the
+  default path because `protocol` is `None`. Preamble leftovers are treated by
+  the inventory (lines 212-222) as a separate compatibility surface and are
+  scheduled for item `12.2.2`.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-5.** Decision: baseline the default codec only; do not include a
+  protocol-native codec.
+  Rationale: `docs/roadmap.md:472-474` says "on the default codec path". The
+  precursor document
+  `docs/zero-copy-frame-and-payload-migration-roadmap.md` item 1.2.1 mentions a
+  protocol-native codec, but `docs/roadmap.md` is the governing artefact and
+  item `11.2.3` is where a protocol-native codec is explicitly required. Where
+  the existing workload matrix makes a Hotline figure free to collect, it is
+  recorded as supplementary context and clearly marked non-normative.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-6.** Decision: deterministic counters are normative and asserted in
+  tests; throughput and latency are indicative and never asserted.
+  Rationale: allocation events, allocated bytes, and copied bytes are
+  identical on every machine, so they can be committed and guarded. Wall-clock
+  figures are hardware-dependent, and asserting on them produces flaky tests
+  and false confidence. Item `10.2.2` must therefore express any timing
+  threshold as a relative delta measured within a single session on a single
+  machine, not as an absolute number compared across machines.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-7.** Decision: expose crate-private stage entry points through
+  `test-support`-gated shims rather than re-implementing them in the probes.
+  Rationale: a probe that re-implements the code it measures verifies only
+  itself; a mutation in production code would leave the baseline unchanged. The
+  repository already uses `test-support` for this class of widening, for
+  example `src/connection/test_support.rs`.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-8.** Decision: both Verus and Kani are used, for different obligations.
+  Rationale: the accounting property is over unbounded sequences, which only a
+  prover can discharge, but the code that runs is `unsafe` and uses
+  thread-local storage, which Verus cannot model. Kani closes that gap for
+  bounded sequences against the real implementation. Using only one would leave
+  either the long-sequence case or the real-code case unverified. The residual
+  gap between them is stated in the verification plan rather than concealed.
+  Date/Author: 2026-08-23, planning agent.
+
+- **D-9.** Decision: adopt `insta` as a new development dependency.
+  Rationale: the rendered baseline is multivariant output across stages and
+  payload classes whose format consistency is the point of the artefact, which
+  is exactly the case the project's testing policy reserves for snapshot
+  testing. Re-blessing via `cargo insta accept` gives a clean workflow for the
+  deliberate re-baselining that item `11.1.2` will require.
+  Date/Author: 2026-08-23, planning agent.
+
+## Outcomes and retrospective
+
+To be completed at EP-M6. Before setting this plan to `COMPLETE`, reconcile
+every discovery in `Surprises and discoveries` against the upstream artefacts
+listed in `Conformance basis`. In particular, the correction about where the
+default path actually copies (see the first discovery) affects the wording of
+`docs/roadmap.md` items `10.2.2` and `11.1.2` and of ADR-010's known-risks
+section. Either update those artefacts or record in this log why the existing
+wording remains adequate. Do not mark the plan complete while that
+reconciliation is outstanding.
+
+## Artefacts and notes
+
+To be populated during implementation with the red, green, and refactor
+transcripts for each milestone, the Verus and Kani output, the two
+`make baseline-copy` runs used to demonstrate reproducibility, and the seeded
+fault transcripts that discharge the non-vacuity requirements in V-1, V-2,
+V-4, and V-5.

--- a/docs/execplans/10-2-1-capture-baselines.md
+++ b/docs/execplans/10-2-1-capture-baselines.md
@@ -9,47 +9,45 @@ Status: DRAFT
 
 No `PLANS.md` exists in this repository as of 2026-08-23.
 
+Revision 2 (2026-08-23) follows a six-lens design review. The changes are
+summarized in the revision note at the end of this document; the short version
+is that the plan now asserts invariants and merely records numbers, rather than
+asserting numbers.
+
 ## Purpose / big picture
 
 Roadmap item `10.2.1` is the measurement gate that the rest of the
 `Frame = Vec<u8>` migration depends on. Items `10.2.2`, `11.1.2`, `11.2.3`, and
-`13.2.1` all compare later work against numbers that do not exist yet. Without
-those numbers, "remove the final default-path copy" is an assertion nobody can
+`13.2.1` all compare later work against evidence that does not exist yet.
+Without it, "remove the final default-path copy" is an assertion nobody can
 falsify.
 
-This plan produces a reproducible baseline for four stages of the default
-codec path — inbound decode, middleware pass-through, request hooks, and
-outbound encode — across four metrics: allocation events, allocated bytes,
-copied bytes, and throughput with latency.
+This plan produces two different kinds of artefact, and keeping them apart is
+the single most important design decision in it.
 
-After this work, a maintainer can observe success by running two commands and
-reading one document:
+**Invariants** state what is true about the default codec path today, in a form
+that survives a dependency bump and inverts exactly when the migration lands.
+For example: "outbound encode performs at least one allocation of at least the
+payload size." These are asserted by tests.
+
+**Measurements** are the concrete numbers — allocation counts, allocated bytes,
+copied bytes, nanoseconds. These are recorded with a full environment stamp and
+are explicitly *not* asserted, because they are properties of `bincode`,
+`bytes`, `tokio-util`, `libstd`, the toolchain, and the optimization profile as
+much as of `wireframe`.
+
+After this work a maintainer can observe success three ways:
 
 ```bash
-make baseline           # deterministic counters; prints a table, passes tests
-make baseline-copy      # Valgrind copy profile; prints copied-byte totals
+make test            # invariants hold; format of the report is stable
+make baseline        # regenerates the recorded numbers into the document
+make baseline-copy   # captures copied bytes under Valgrind
 ```
 
-and then reading `docs/frame-vec-u8-baseline.md`, which records:
-
-- For each of the four stages, at both payload classes, the exact number of
-  allocation events and allocated bytes, reproducible bit-for-bit on any
-  machine.
-- For each stage at the large payload class, the number of bytes copied
-  through `memcpy`-family calls.
-- Indicative throughput and latency figures with a recorded hardware and
-  toolchain stamp, plus an explicit statement that these figures are
-  machine-dependent and must be re-measured, not compared across machines.
-- A named, falsifiable claim about where the default path copies payload
-  bytes today, so that item `11.1.2` has something concrete to remove and
-  item `11.2.3` has something concrete to guard.
-
-The baseline is not merely written down. The deterministic counters are
-rendered into an `insta` snapshot and asserted by a test, and a further test
-asserts that the table embedded in `docs/frame-vec-u8-baseline.md` is
-byte-identical to the rendered report. A baseline that silently drifts away
-from the code it describes is worse than no baseline, so the plan makes drift
-a test failure.
+and `docs/frame-vec-u8-baseline.md` contains a generated, environment-stamped
+record covering inbound decode, middleware pass-through, request hooks, and
+outbound encode, together with a named, falsifiable claim about where the
+default path copies payload bytes today.
 
 ## Context and orientation
 
@@ -58,1171 +56,1130 @@ This section assumes no prior knowledge of the repository.
 ### What wireframe is
 
 `wireframe` is a Rust library for building servers and clients that speak
-custom binary protocols. A server application is a
-`WireframeApp<S, C, E, F>` where `S` is a serializer, `E` is a packet
-(envelope) type, and `F` is a frame codec. The default instantiation, declared
-at `src/app/builder/core.rs:29-34`, is:
+custom binary protocols. A server application is a `WireframeApp<S, C, E, F>`
+where `S` is a serializer, `E` is a packet (envelope) type, and `F` is a frame
+codec. The default instantiation (`src/app/builder/core.rs:29-34`) is:
 
 ```rust
 WireframeApp<BincodeSerializer, (), Envelope, LengthDelimitedFrameCodec>
 ```
 
 Its `Default` implementation (`src/app/builder/core.rs:52-80`) leaves
-`middleware` empty and `protocol`, `fragmentation`, and `message_assembler`
-all `None`. On the default path, therefore, middleware, protocol hooks,
-fragmentation, and reassembly are inert. Only decode, dispatch, and encode do
-real work. Throughout this plan, "the default codec path" means exactly this
+`middleware` empty and `protocol`, `fragmentation`, and `message_assembler` all
+`None`. Throughout this plan, "the default codec path" means exactly this
 configuration.
 
-### The four stages, precisely
+### The four stages
 
-**Inbound decode.** `WireframeApp::process_stream`
-(`src/app/inbound_handler.rs:158-226`) wraps the transport in a
-`tokio_util::codec::Framed` built from `CombinedCodec`
-(`src/app/combined_codec.rs:8-18`). Each frame reaches `handle_frame`
-(`src/app/inbound_handler.rs:228-276`), then
-`build_dispatchable_envelope` (`:278-322`), which calls
-`parse_envelope` (`:74-95`). That in turn calls `BincodeSerializer::parse`
-(`src/serializer.rs:150-157`), which calls `Envelope::from_bytes`, resolving
-to the blanket `Message::from_bytes` (`src/message.rs:106-111`) and finally
-into `bincode`. The `Vec<u8>` allocation that becomes `Envelope.payload` is
-made inside `bincode`, not inside `wireframe`. It is observable only through
-allocator instrumentation, never through a `wireframe`-owned copy call.
+**Inbound decode.** `process_stream` (`src/app/inbound_handler.rs:158-226`)
+wraps the transport in a `tokio_util::codec::Framed` built from `CombinedCodec`
+(`src/app/combined_codec.rs:8-18`). Frames reach `handle_frame` (`:228-276`),
+then `build_dispatchable_envelope` (`:278-322`), then `parse_envelope`
+(`:74`), which calls `BincodeSerializer::parse` (`src/serializer.rs:150-157`)
+and thence `bincode`. The `Vec<u8>` that becomes `Envelope.payload` is
+allocated inside `bincode`, not inside `wireframe`; it is observable only
+through allocator instrumentation.
 
-**Middleware pass-through.** `frame_handling::forward_response`
+**Middleware pass-through.** `forward_response`
 (`src/app/frame_handling/response.rs:29-63`) builds
-`ServiceRequest::new(env.payload, env.correlation_id)` at line 41 and calls
-`service.call(request)` at line 42. `ServiceRequest`
-(`src/middleware.rs:39-76`) holds a `FrameContainer<Vec<u8>>`.
-`RouteService::call` (`src/middleware.rs:315-339`) rebuilds the packet with
-`E::from_parts(PacketParts::new(id, correlation_id, req.into_inner()))`. Every
-step here is a move. `WireframeApp::build_chains`
-(`src/app/inbound_handler.rs:146-156`) iterates the middleware vector in
-reverse; on the default path that vector is empty and the loop body never
-executes.
+`ServiceRequest::new(env.payload, env.correlation_id)` at line 41, calls
+`service.call(request)` at line 42, and rebuilds the packet from
+`resp.into_inner()` at line 55. The payload itself is moved, never copied. The
+stage is not free, however: `Service` is declared `#[async_trait]`
+(`src/middleware.rs:168-169`), so every `call` boxes a future.
 
-**Request hooks.** These are the client-side hooks in `src/client/hooks.rs`:
+**Request hooks.** The client-side hooks in `src/client/hooks.rs`:
 `BeforeSendHook = Arc<dyn Fn(&mut Vec<u8>) + Send + Sync>` (line 152) and
-`AfterReceiveHook = Arc<dyn Fn(&mut BytesMut) + Send + Sync>` (line 176),
-collected in `RequestHooks` (lines 184-189) and invoked by
-`invoke_before_send_hooks` and `invoke_after_receive_hooks`
-(`src/client/messaging.rs:335-346`) from `src/client/send_pipeline.rs:41` and
-`src/client/messaging.rs:295`.
+`AfterReceiveHook` (line 176), held in the `pub(crate)` struct `RequestHooks`
+(lines 184-189). They are invoked by
+`WireframeClient::invoke_before_send_hooks` (`src/client/messaging.rs:335`,
+inside the `impl<S, T, C> WireframeClient<S, T, C>` block opened at line 27) —
+a method on the client, not on `RequestHooks`.
 
-The server-side `WireframeProtocol::before_send` hooks in `src/hooks.rs` are a
-different mechanism. On the default path `protocol` is `None`, so
-`ProtocolHooks::before_send` (`src/hooks.rs:172-177`) is a no-op. They are out
-of scope; see `Decision log` entry D-4.
+On the default path `RequestHooks` is two empty vectors, so the stage is a loop
+over nothing. Measuring it therefore requires synthetic hooks, and the row
+records a *hook-shape cost model*, not a default-path figure. The plan says so
+in the document rather than pretending otherwise.
 
 **Outbound encode.** `encode_message_frame`
-(`src/app/outbound_encoding.rs:22-38`) is the whole of it:
+(`src/app/outbound_encoding.rs:22-38`), called from `send_envelope`
+(`src/app/codec_driver.rs:132`) and `flush_pipeline_output` (`:164-180`).
 
-```rust
-let bytes = serializer.serialize(msg).map_err(SendError::Serialize)?;
-// Keep this bridge behaviour-preserving until issue #538 changes the
-// public serializer contract to return a Bytes-native container.
-let frame = codec.wrap_payload(Bytes::from(bytes));
-```
+### Where the default path actually copies
 
-It is called from `send_envelope` (`src/app/codec_driver.rs:120-152`, line
-132) and `flush_pipeline_output` (`:164-180`). ADR-010
-(`docs/adr-010-transport-frame-boundary-for-zero-copy.md:196-206`) confirms
-this is the sole production caller of `FrameCodec::wrap_payload`.
+The roadmap and ADR-010 describe "the final default-path `Vec<u8>` copy between
+serialization and `FrameCodec::wrap_payload`". Investigation shows that phrase
+names two operations that do not copy, and misses two costs that do. Getting
+this right is the highest-value output of this item, because item `11.1.2` is
+currently pointed at code that is already free.
 
-### A correction the baseline must record
+What does **not** copy:
 
-The roadmap and ADRs describe a "final default-path `Vec<u8>` copy between
-serialization and `FrameCodec::wrap_payload`". Read literally, that phrase
-names two operations that are both free on the default codec:
+- `LengthDelimitedFrameCodec::wrap_payload` (`src/codec.rs:283`) is the identity
+  function; `type Frame = Bytes` (`:262`).
+- `Bytes::from(Vec<u8>)` (`src/app/outbound_encoding.rs:36`) takes ownership of
+  the vector's buffer rather than copying it.
 
-- `Bytes::from(Vec<u8>)` at `src/app/outbound_encoding.rs:36` takes ownership
-  of the vector's buffer. It does not copy.
-- `LengthDelimitedFrameCodec::wrap_payload` (`src/codec.rs:260-285`) is the
-  identity function; `type Frame = Bytes` and the payload is returned
-  unchanged.
+What does cost, in order along the outbound path:
 
-The real cost is one step earlier: `Serializer::serialize`
-(`src/serializer.rs:61-113`) returns `Vec<u8>`, so `bincode` must allocate a
-fresh vector and copy the envelope payload into it. That allocation and that
-copy are what item `11.1.2` must remove, by giving the serializer a
-`Bytes`-native output contract. The baseline must therefore attribute the
-outbound cost to `Serializer::serialize`, not to `Bytes::from` or
-`wrap_payload`, or item `11.1.2` will be measured against the wrong number.
+1. **`Serializer::serialize` allocates and copies.** Its signature returns
+   `Vec<u8>` (`src/serializer.rs:67-71`), so `bincode` must allocate a vector
+   and copy the envelope payload into it. This is the cost item `11.1.2` can
+   remove by giving the serializer a `Bytes`-native contract.
+2. **`Bytes::from(Vec<u8>)` allocates, even though it does not copy.** When
+   `len != capacity` it heap-allocates a 24-byte `Shared` control block
+   (`bytes-1.12.1/src/bytes.rs:947-967`). Because `bincode` grows its output
+   vector amortized, `len != capacity` is the normal case, so the default path
+   pays this on every outbound frame. A `Bytes`-native serializer that produces
+   a right-sized buffer removes it; one that still hands over an over-capacity
+   `Vec` does not.
+3. **The framed encoder copies the whole payload again, and item `11.1.2`
+   cannot remove it.** `LengthDelimitedEncoder::encode`
+   (`src/codec.rs:248-257`) delegates to `tokio_util`'s `LengthDelimitedCodec`,
+   which reserves space in the `Framed` write buffer and copies the payload
+   into it. This copy is outside `encode_message_frame` and therefore outside
+   the boundary a naive reading of the roadmap would measure.
 
-The same asymmetry appears inbound: `FrameCodec::frame_payload_bytes` has a
-default body of `Bytes::copy_from_slice` (`src/codec.rs:90`), which copies,
-but `LengthDelimitedFrameCodec` overrides it with `frame.clone()`
-(`src/codec.rs:260-285`), a reference-count bump. The default path does not
-pay that copy; a protocol-native codec that does not override the method
-would.
+The consequence is concrete: a baseline scoped to `encode_message_frame` would
+record roughly one payload-sized copy where the default path performs two, and
+item `10.2.2` would then set thresholds against half the outbound traffic. This
+plan therefore measures the framed encoder as a fifth row and states in the
+baseline document that it is out of scope for `11.1.2`.
 
-### What already exists
+A related asymmetry inbound: `FrameCodec::frame_payload_bytes` has a default
+body of `Bytes::copy_from_slice` (`src/codec.rs:89-91`), which copies, but
+`LengthDelimitedFrameCodec` overrides it with `frame.clone()` (`:281`). The
+default path does not pay that copy; a protocol-native codec that omits the
+override would. That is item `11.2.3`'s concern, not this one's.
 
-Roadmap item `9.6.1` (see `docs/execplans/9-6-1-codec-performance-benchmarks.md`,
-status COMPLETE) built codec-level benchmarks:
+### What already exists, and what it cannot do
 
-- `benches/codec_performance.rs` defines the Criterion groups `codec/encode`,
-  `codec/decode`, and `codec/fragmentation_overhead`.
-- `benches/codec_performance_alloc.rs` defines the group `codec/allocations`
-  and contains a private `CountingAllocator` (lines 34-77) installed as
-  `#[global_allocator]`.
-- `wireframe_testing/src/codec_benchmarks/` holds the shared support code:
-  `SMALL_PAYLOAD_BYTES = 32`, `LARGE_PAYLOAD_BYTES = 64 * 1024`,
-  `VALIDATION_ITERATIONS = 16`, `payload_for_class`, `CodecUnderTest`,
-  `PayloadClass`, `BenchmarkWorkload`, `benchmark_workloads`, `measure_encode`,
-  `measure_decode`, `Measurement`, `MeasurementExt`, `AllocationBaseline`, and
-  `allocation_label`.
-- `make bench-codec` (`Makefile:66-67`) runs both bench binaries with
-  `--features test-support`.
+Roadmap item `9.6.1` (`docs/execplans/9-6-1-codec-performance-benchmarks.md`,
+COMPLETE) built codec-level benchmarks: `benches/codec_performance.rs`
+(Criterion groups `codec/encode`, `codec/decode`,
+`codec/fragmentation_overhead`), `benches/codec_performance_alloc.rs` (group
+`codec/allocations`, with a private `CountingAllocator` at lines 34-77 and a
+`#[global_allocator]` at lines 38-39), and the shared support module
+`wireframe_testing/src/codec_benchmarks/` defining `SMALL_PAYLOAD_BYTES = 32`,
+`LARGE_PAYLOAD_BYTES = 64 * 1024`, `PayloadClass`, `payload_for_class`,
+`Measurement`, and the workload matrix. `make bench-codec`
+(`Makefile:66-67`) runs both bench binaries by name.
 
-Three gaps matter for this item. First, the existing coverage stops at the
-codec boundary: there is nothing for middleware, hooks, or the
-serializer-to-codec bridge. Second, `CountingAllocator` counts allocation
-*events* only — it never reads `layout.size()`, so it cannot report bytes —
-and it uses process-global atomics, which is why its own documentation
-(lines 79-84) calls it a "noisy relative baseline". Third, nothing anywhere in
-the repository measures copied bytes, and no document defines what a "copied
-byte" is.
+Three gaps matter. The existing coverage stops at the codec boundary, with
+nothing for middleware, hooks, or the serializer bridge. `CountingAllocator`
+never reads `layout.size()`, so it cannot report bytes, and it uses
+process-global atomics, which its own documentation (lines 79-84) concedes
+makes it "a noisy relative baseline". And nothing anywhere measures copied
+bytes.
+
+The repository does, however, already have the right idiom for the invariant
+half of this work. `src/codec/tests.rs` asserts zero-copy behaviour by pointer
+identity: `length_delimited_wrap_payload_reuses_bytes` (lines 63-71), the
+parameterized `wrap_payload_reuses_bytes` (lines 195-212) and
+`frame_payload_bytes_reuses_memory` (lines 214-232) across length-delimited,
+Hotline, and MySQL codecs, and the helper `assert_decode_zero_copy` (lines
+236-245). This plan extends that idiom rather than inventing a new one.
 
 ### Terms defined
 
 - **Allocation event**: one call into the global allocator's `alloc`,
   `alloc_zeroed`, or `realloc` entry point.
-- **Allocated bytes**: the sum of `Layout::size()` over allocation events. For
+- **Allocated bytes**: the sum of `Layout::size()` over allocation events; for
   `realloc`, the new size.
-- **Copied byte**: a byte written to a second location by a `memcpy`,
-  `memmove`, `strcpy`, or `bcopy` call while an equivalent live copy exists.
-  This is the operational definition adopted by this plan; see `Decision log`
-  entry D-2 and ADR-011.
+- **Payload-sized allocation**: an allocation event whose size is at least the
+  payload length for the class under test. Counting these separately from raw
+  totals is what makes the invariants immune to incidental allocation churn
+  inside dependencies.
+- **Copied byte**: a byte passed to `memcpy`, `memmove`, `strcpy`, or `bcopy`,
+  as counted by `valgrind --tool=dhat --mode=copy` (Valgrind manual, section
+  10.5). See `Decision log` entry D-2 and ADR-011.
 - **Payload class**: `Small` (32 bytes) or `Large` (65,536 bytes), as already
   defined in `wireframe_testing::codec_benchmarks`.
-- **Probe**: a deterministic, in-process function that drives one production
-  stage exactly once for one payload class, with no transport and no runtime
-  scheduling.
-- **Deterministic counter**: a measurement that yields an identical value on
-  every machine and every run. Allocation events, allocated bytes, and copied
-  bytes are deterministic counters. Throughput and latency are not.
+- **Probe**: a synchronous, in-process function that drives one production
+  stage once for one payload class, with no transport. The middleware stage is
+  the exception: `Service::call` is async, so its probe uses a
+  `current_thread` runtime and blocks on the future. The plan says so rather
+  than pretending the stage is synchronous.
+- **Reproducible measurement**: a measurement that yields an identical value
+  for a fixed toolchain, a fixed `Cargo.lock`, a fixed optimization profile,
+  and a 64-bit target. No measurement in this plan is claimed to be
+  machine-independent; see `Decision log` entry D-6.
 
 ## Conformance basis
 
 There is no Terms of Reference document in this repository. The upstream
 artefacts are:
 
-- `docs/roadmap.md` section 10.2, item `10.2.1` (lines 470-481), revision as at
-  commit `d77dd76`.
-- `docs/adr-008-zero-copy-public-byte-container.md` (Accepted). The binding
-  technical requirement is line 85-86: "The default codec path must be able to
-  move from serialization to `wrap_payload` without materializing a fresh
-  `Vec<u8>`." Its non-goal at line 181 explicitly declines to guarantee zero
-  allocation for mutation paths, so the baseline must separate read-only from
-  mutating hook shapes.
-- `docs/adr-009-vec-u8-migration-rollout.md` (Accepted). Line 270-272 flags
-  `PayloadBytes::into_vec` as a known allocating-and-copying escape hatch.
-- `docs/adr-010-transport-frame-boundary-for-zero-copy.md` (Accepted). Lines
-  189-192 name the residual serializer-to-codec bridge and link issue
-  [leynos/wireframe#538](https://github.com/leynos/wireframe/issues/538); lines
-  196-206 pin the sole production `wrap_payload` call site.
-- `docs/frame-vec-u8-inventory.md`, in particular lines 98-105 and 118 (the
-  middleware `Vec<u8>` island), 124-127 (inbound decode), 132-140 (the
-  middleware-to-codec return path), 200-204 (client hooks), and 226-228 (the
-  serializer contract).
-- `docs/zero-copy-frame-and-payload-migration-roadmap.md`, items 1.2.1 and
-  1.2.2, the precursor wording that `docs/roadmap.md` 10.2.1 condenses.
+- `docs/roadmap.md` section 10.2, item `10.2.1` (lines 470-481), as at commit
+  `d77dd76`. Item `10.1.1` is complete (lines 460-462), so this item is
+  unblocked.
+- `docs/adr-008-zero-copy-public-byte-container.md` (Accepted), technical
+  requirement at lines 85-86 and the non-goal at line 181 declining to
+  guarantee zero allocation on mutation paths.
+- `docs/adr-009-vec-u8-migration-rollout.md` (Accepted), lines 270-272 on
+  `PayloadBytes::into_vec` as a known allocating escape hatch.
+- `docs/adr-010-transport-frame-boundary-for-zero-copy.md` (Accepted), lines
+  189-192 naming the serializer bridge and linking issue
+  [leynos/wireframe#538](https://github.com/leynos/wireframe/issues/538), and
+  lines 196-206 pinning the sole production `wrap_payload` call site.
+- `docs/frame-vec-u8-inventory.md`, in particular the middleware data-flow
+  discussion at lines 116-119 and the explicit payload-flow statement at lines
+  240-244, plus lines 200-204 on client hooks and 226-228 on the serializer.
+- `docs/roadmap.md` section 15 (Formal verification, lines 583-718), which owns
+  the prover work this plan deliberately does not do. See `Decision log` D-8.
 
 Trace links:
 
 ```plaintext
-ADR-008-REQ-default-path-no-fresh-vec -> EP-M3 -> EP-M4
-  -> tests::baseline_report::outbound_encode_allocates_serializer_vec
-ADR-010-RISK-serializer-bridge -> EP-M5
-  -> docs/frame-vec-u8-baseline.md#outbound-encode
-ROADMAP-10.2.1-alloc -> EP-M1, EP-M3, EP-M4
-  -> tests::baseline_report::snapshot_matches_committed_baseline
+ADR-008-REQ-default-path-no-fresh-vec -> EP-M3
+  -> tests::baseline_invariants::outbound_encode_allocates_payload_sized_buffer
+ADR-010-RISK-serializer-bridge -> EP-M1 (correction) and EP-M5 (measurement)
+  -> docs/adr-011-byte-migration-baseline-methodology.md
+ROADMAP-10.2.1-alloc -> EP-M1, EP-M2, EP-M4
+  -> docs/frame-vec-u8-baseline.md#allocation-baselines
 ROADMAP-10.2.1-copied-bytes -> EP-M5
   -> docs/frame-vec-u8-baseline.md#copied-bytes
-ROADMAP-10.2.1-throughput-latency -> EP-M5
-  -> benches/pipeline_baseline.rs
-INVENTORY-middleware-island -> EP-M3
-  -> tests::baseline_report::middleware_pass_through_is_move_only
-EP-M2 (measurement soundness) -> verus/wireframe_proofs.rs
-  and src/../alloc_probe.rs kani harnesses
+ROADMAP-10.2.1-throughput-latency -> EP-M5 -> benches/pipeline_baseline.rs
+INVENTORY-middleware-moves-payload -> EP-M3
+  -> tests::baseline_invariants::middleware_moves_payload_without_copying
 ```
-
-Item `10.2.1` requires `10.1.1`, which is complete (`docs/roadmap.md:460-462`),
-so this item is unblocked.
 
 ## Constraints
 
 - The four stages, the metric set, and "the default codec path" are fixed by
-  `docs/roadmap.md:472-474`. Do not narrow them.
-- Production behaviour must not change. Every probe drives production code; no
-  probe may re-implement a production step. Where a production function is
-  crate-private, expose it through a `test-support`-gated shim rather than
-  copying its body into the probe. A probe that re-implements the thing it
-  measures proves only that the probe is self-consistent.
-- The `test-support` Cargo feature is the only permitted mechanism for widening
-  visibility. Nothing new may become unconditionally public on the `wireframe`
-  crate.
-- Deterministic counters must be exactly reproducible. No test may assert on
-  wall-clock time, throughput, or latency.
-- Allocation instrumentation must be thread-local, not process-global, so that
-  a parallel test harness running on other threads cannot pollute a
-  measurement. This is a hard requirement, not a preference: the existing
-  process-global counter is documented as noisy, and a noisy baseline cannot
-  support item `10.2.2`'s thresholds.
-- Copied-byte measurement must not require modifying production code. It is an
-  external observation.
+  `docs/roadmap.md:472-474`. Do not narrow them. The framed-encoder row is an
+  addition, justified above, not a substitution.
+- A probe must drive production code, never re-implement it. Where a production
+  step is not reachable, extract it into a named production function that both
+  the production caller and the probe use. Four such extractions are specified
+  in EP-M2; each is a refactor of existing code, not new logic.
+- No test may assert an absolute allocation count, byte total, copied-byte
+  total, throughput, or latency. Tests assert invariants; the numbers are
+  recorded. This is the constraint that keeps a daily Dependabot cadence from
+  turning the baseline into a rubber stamp.
+- Nothing new may become part of the default-feature public surface of either
+  `wireframe` or `wireframe_testing`. New surfaces are feature-gated and
+  off by default.
+- `#[global_allocator]` must never be declared inside a library. The
+  `wireframe_testing` crate provides the allocator *type*; each consuming
+  binary installs it. Every measurement entry point must verify the allocator
+  is installed before reporting, because an uninstalled allocator reports zeros
+  and zero is also what success looks like.
+- Copied-byte measurement must not modify production code.
 - Use `rstest` for unit tests, `rstest-bdd` v0.5.0 for behavioural tests,
   `googletest` matchers and `pretty_assertions` for assertion clarity,
-  `proptest` for generated input domains, and `insta` for the rendered
-  baseline snapshot.
-- All documentation must follow `docs/documentation-style-guide.md`: en-GB
-  Oxford spelling, sentence-case headings, prose wrapped at 80 columns, code
-  at 120, language identifiers on every fence, captions on every table, no
-  first-person or second-person pronouns.
-- Register every new document in `docs/contents.md`.
-- Record the measurement methodology in a new ADR
-  (`docs/adr-011-byte-migration-baseline-methodology.md`) and reference it from
-  `docs/frame-vec-u8-baseline.md` and `docs/developers-guide.md`.
-- Append an entry under `## Unreleased` in `CHANGELOG.md`.
-- Mark `docs/roadmap.md` item `10.2.1` done only after every gate passes. Edit
-  the roadmap with `mapsplice` per `docs/developers-guide.md:512-540`, and use
-  inline links rather than footnotes in that file.
-- Run gates with `set -o pipefail` and `tee` to a log under `/tmp`. Delegate
-  full gate runs to the `scrutineer` sub-agent; do not run them inline.
-- Commit after each milestone. Every commit must pass `make check-fmt`,
+  `proptest` for generated orderings, and `insta` for the report *renderer's*
+  format only, driven by fixed synthetic rows rather than live measurements.
+- Documentation follows `docs/documentation-style-guide.md`: en-GB Oxford
+  spelling, sentence-case headings, prose at 80 columns, code at 120, language
+  identifiers on fences, captions on tables, no first- or second-person
+  pronouns.
+- Register new documents in `docs/contents.md`; append to `CHANGELOG.md` under
+  `## Unreleased`; edit `docs/roadmap.md` with `mapsplice`
+  (`docs/developers-guide.md:512-540`) using inline links, not footnotes.
+- Run gates with `set -o pipefail` and `tee` to `/tmp`. Delegate full gate runs
+  to the `scrutineer` sub-agent.
+- Commit after each milestone; every commit passes `make check-fmt`,
   `make lint`, and `make test`.
 
 ## Tolerances (exception triggers)
 
-- **Scope**: if implementation touches more than 32 files or exceeds 2,500 net
-  changed lines, stop and re-scope.
-- **Dependencies**: `insta` is the only new dependency this plan authorizes,
-  and only as a `dev-dependency`. If anything else is required — including
-  `dhat`, `stats_alloc`, `iai-callgrind`, or `critcmp` — stop and escalate.
-- **Public interface**: if any change must be visible without the
-  `test-support` feature, stop and escalate.
-- **Verus**: this would be the repository's first Verus proof. If the proof in
-  EP-M2 is not discharged within four attempts, stop, record the failure, and
-  escalate with the option of descoping to the Kani harness plus the proptest
-  model. Do not weaken the property to make it provable.
-- **Kani**: if a harness exceeds ten minutes at its stated unwind bound, reduce
-  the bound and record the reduction rather than raising the timeout.
-- **Valgrind**: if `valgrind --tool=dhat --mode=copy` cannot attribute copies
-  to the probe under test, stop and escalate before inventing a substitute
-  metric.
-- **Measurement instability**: if a deterministic counter varies between two
-  consecutive runs on the same machine, stop. That is an instrument defect, not
-  noise to be averaged away.
-- **Benchmark runtime**: if a single Criterion target exceeds six minutes
-  locally, reduce sample size and record the change.
+- **Scope**: more than 20 files or 1,400 net changed lines — stop and re-scope.
+  This matches the completed `9.6.1` plan's scale.
+- **Dependencies**: `insta` (dev-dependency) and the `cargo-insta` binary tool
+  are the only additions authorized. Anything else — `dhat`, `stats_alloc`,
+  `iai-callgrind`, `critcmp` — stop and escalate.
+- **Production edits**: the four seam extractions in EP-M2 are authorized
+  because they are behaviour-preserving refactors. Any further production
+  change, or any change to a function's observable behaviour, stops and
+  escalates.
+- **Prover tooling**: this plan introduces no Verus proof and no Kani harness.
+  If implementation appears to need one, stop and escalate rather than
+  starting; roadmap section 15 owns that work.
+- **Instrument instability**: if a recorded counter differs between two runs on
+  the same machine with the same lockfile, profile, and toolchain, stop. First
+  confirm it is not first-touch initialization (see EP-M1's warm-up
+  requirement) before declaring an instrument defect.
+- **Valgrind runtime**: if `make baseline-copy` exceeds ten minutes, reduce the
+  iteration count and record the reduction.
+- **Criterion runtime**: if a single target exceeds six minutes locally, reduce
+  the sample size and record it.
 - **Ambiguity**: if the correct attribution of a measurement to a stage is
-  genuinely unclear, stop and present the options rather than choosing
-  silently.
+  genuinely unclear, stop and present options rather than choosing silently.
 
 ## Risks
 
-- Risk: thread-local state accessed from inside a `GlobalAlloc` implementation
-  can recurse or fail during thread-local storage initialization and teardown,
-  because initializing thread-local storage may itself allocate.
+- Risk: the thread-local instrument silently under-reports when work escapes to
+  another thread, and an under-report is indistinguishable from the zero that
+  means success.
   Severity: high. Likelihood: medium.
-  Mitigation: declare the counters with `thread_local!` using a
-  `const { Cell::new(0) }` initializer so that no lazy allocation occurs on
-  first access, and reach them through `try_with`, treating a failure as "not
-  measuring" rather than panicking. Add a test that allocates during thread
-  teardown and asserts the process does not abort.
+  Mitigation: the instrument carries an escape detector. A process-global
+  counter records allocations seen on any thread while a measurement scope is
+  open on another; a measurement whose `escaped` flag is set is an error, not a
+  number. This is a hard requirement of EP-M1, not a nicety.
 
-- Risk: LLVM inlines small `memcpy` calls into load and store sequences, which
-  Valgrind's DHAT copy mode cannot see, so copied bytes are undercounted for
-  small payloads.
+- Risk: thread-local access inside `GlobalAlloc` recurses or fails during
+  thread-local storage setup and teardown, because initializing thread-local
+  storage may itself allocate.
+  Severity: high. Likelihood: medium.
+  Mitigation: declare the counters with `thread_local!` using
+  `const { Cell::new(0) }` so first access performs no lazy allocation, reach
+  them with `try_with`, and treat failure as "not measuring". Add a test that
+  allocates during thread teardown and asserts the process does not abort.
+
+- Risk: recorded numbers drift because `bincode`, `bytes`, or `tokio-util`
+  changes. Cargo Dependabot runs daily (`.github/dependabot.yml`) with
+  auto-merge configured.
+  Severity: high without mitigation, low with. Likelihood: high.
+  Mitigation: no test asserts a number. The generated document carries an
+  environment stamp naming the toolchain and the locked versions of the three
+  crates, so a changed number is self-explaining rather than alarming.
+
+- Risk: an uninstalled `#[global_allocator]` in one of the six consuming
+  binaries yields all-zero counters that read as success.
+  Severity: high. Likelihood: medium.
+  Mitigation: `assert_installed()` allocates a canary and errors if the
+  counters do not move. Called at the entry of every measurement binary. The
+  report renderer refuses to emit an all-zero row without an explicit marker.
+
+- Risk: first-touch lazy initialization inside `bincode`, `tokio-util`, or
+  `tracing` is attributed to whichever probe runs first on a thread, making
+  counters order-dependent.
   Severity: medium. Likelihood: high.
-  Mitigation: treat copied bytes as normative only for the `Large` payload
-  class, record the `Small` class with an explicit undercount caveat, and
-  cross-check both against allocated bytes, which bound copied bytes from above
-  for allocate-then-fill buffers. Record this limitation in ADR-011 rather than
-  hiding it.
+  Mitigation: every probe performs one unmeasured warm-up iteration before the
+  measured run, and the tolerance above distinguishes first-touch variance from
+  an instrument defect.
 
-- Risk: the bytes copied inside `bincode` and inside `tokio_util` are not
-  attributable to `wireframe` source lines, so a naive reading of a DHAT
-  profile blames the wrong frame.
-  Severity: medium. Likelihood: high.
-  Mitigation: run one probe process per stage with a `--stage` argument, and
-  subtract a `--stage noop` calibration run, so each figure is a difference
-  between two whole-process totals rather than an attribution to a stack.
-
-- Risk: this is the repository's first Verus proof, and
-  `docs/developers-guide.md:376-379` states `make run-verus` is expected to fail
-  until `verus/wireframe_proofs.rs` exists. Establishing the proof harness may
-  cost more than the proof.
+- Risk: Valgrind does not run on Apple Silicon, stranding contributors on the
+  copied-byte metric.
   Severity: medium. Likelihood: medium.
-  Mitigation: EP-M2 is a separable milestone with its own tolerance. The
-  measurement work in EP-M1 and EP-M3 does not depend on it.
+  Mitigation: `make baseline-copy` runs inside a pinned rootless-Podman image,
+  which also makes figures comparable across Linux distributions by fixing
+  libc and the Valgrind version. `BASELINE_COPY_NATIVE=1` selects the faster
+  native path. The image digest goes into the provenance stamp.
 
-- Risk: `insta` is new to the repository, so there is no existing convention
-  for snapshot location or review.
-  Severity: low. Likelihood: high.
-  Mitigation: place snapshots under `tests/snapshots/`, document the
-  re-blessing procedure in `docs/developers-guide.md`, and keep the snapshot
-  restricted to deterministic counters so it never fails for environmental
-  reasons.
-
-- Risk: the baseline document and the snapshot drift apart, leaving a document
-  that describes code that no longer exists.
+- Risk: the copied-byte table is the one artefact no test guards, so it goes
+  stale silently.
   Severity: medium. Likelihood: medium.
-  Mitigation: a test asserts that the fenced table in
-  `docs/frame-vec-u8-baseline.md` is byte-identical to the rendered report.
+  Mitigation: the provenance stamp records the git commit at capture time, and
+  a test fails when that commit predates the most recent change to
+  `src/serializer.rs`, `src/codec.rs`, or `src/app/outbound_encoding.rs`.
+  Staleness becomes visible without needing Valgrind to detect it.
 
-- Risk: the `test-support` shims widen the surface that later refactors must
-  keep working, creating drag on items 11.x and 12.x.
+- Risk: `make test` does not build `wireframe_testing`'s tests, because
+  `Cargo.toml:15` sets `default-members = ["."]`, and CI does not run
+  `make test` at all — `.github/workflows/ci.yml` runs `check-fmt`, `lint`,
+  `markdownlint`, `nixie`, `test-workflow-contracts`, and a coverage action.
+  Severity: high. Likelihood: certain if unaddressed.
+  Mitigation: all invariant tests live in the root crate's `tests/`, which the
+  gates do build. EP-M1 additionally verifies that the counters agree between
+  the dev profile and the coverage build before anything depends on them.
+
+- Risk: the seam extractions in EP-M2 drag on items 11.x and 12.x.
   Severity: low. Likelihood: medium.
-  Mitigation: the shims are thin re-exports of existing crate-private
-  functions, feature-gated, and documented as unstable. When 11.1.2 changes
-  `Serializer::serialize`, the shim changes with it and the baseline is
-  re-blessed; that is the intended workflow, not breakage.
-
-- Risk: benchmarks do not currently run in CI at all, so nothing prevents the
-  baseline from rotting.
-  Severity: medium. Likelihood: medium.
-  Mitigation: the deterministic half of the baseline runs under `make test`,
-  which CI does run. Only the timing half and the Valgrind half are
-  operator-invoked. Record this split explicitly so item `10.2.2` does not
-  assume a CI gate that does not exist.
+  Mitigation: each extraction moves an existing statement sequence into a named
+  function called from its original site. Later items change the function's
+  body along with everything else; the probe follows.
 
 ## Verification plan
 
-The implementation introduces one genuinely non-trivial piece of logic: the
-allocation-accounting state machine. Everything downstream — every threshold in
-`10.2.2`, every regression assertion in `11.2.3`, every claim in `13.2.1` —
-rests on that accounting being exact. It is therefore verified rather than
-merely tested.
-
-The probes themselves introduce no invariant; they are straight-line calls into
-production code. They are covered by parameterized tests and a negative
-control.
+The implementation introduces one non-trivial piece of logic — the allocation
+instrument's scoping and escape detection — and one set of claims about the
+production code. Everything else is straight-line calls into production code
+and a string renderer.
 
 ### Axioms
 
-These are assumed, not verified:
+Assumed, not verified: the system allocator satisfies the `GlobalAlloc`
+contract; `bincode`, `bytes`, and `tokio-util` behave as documented and their
+internals are measured rather than proven; Valgrind's DHAT copy mode counts
+bytes passed to the `memcpy` family as documented; `thread_local!` with a
+`const` initializer performs no heap allocation on first access on the
+supported targets; Criterion's timing methodology is sound.
 
-- The system allocator satisfies the `GlobalAlloc` contract.
-- `bincode` and `tokio_util` behave as documented; their internals are not
-  verified. Their observable allocation behaviour is measured, not proven.
-- Valgrind's DHAT copy mode counts bytes passed to `memcpy`, `memmove`,
-  `strcpy`, and `bcopy`, as documented in the Valgrind manual, section 10.5.
-- `thread_local!` with a `const` initializer performs no heap allocation on
-  first access on the supported targets.
-- Criterion's timing methodology is sound; this plan does not verify it and
-  does not assert on its output.
+### Obligation V-1: measurement scoping is exact, and escape is loud
 
-### Obligation V-1: accounting exactness over unbounded event sequences
-
-- **Obligation**: for any finite sequence of allocator events
-  `e_0 .. e_{n-1}`, the accounting function satisfies
-  `total_events = |{e : e is Alloc or Realloc}|`,
-  `total_bytes = Σ size(e) over allocating events`,
-  `curr_bytes = Σ size of live blocks`, and `curr_bytes ≤ total_bytes`. The
-  `Realloc` case is the non-trivial one: it must count as one allocating event
-  of the new size, release the old size from `curr_bytes`, and contribute
-  `min(old, new)` to `realloc_moved_bytes`.
-- **Method**: Verus deductive proof by induction over `Seq<Event>`.
-- **Rationale**: the sequence length is unbounded — a large-payload probe
-  performs thousands of events — so bounded exploration cannot discharge the
-  property. The realloc case makes the induction step non-trivial, so the proof
-  is not a restatement of the assumption.
-- **Domain**: all finite sequences over
-  `Event = Alloc(size) | Realloc(old, new) | Dealloc(size)`, with sizes in
-  `nat`.
-- **Artefact**: `verus/wireframe_proofs.rs` and
-  `verus/wireframe_proofs_alloc.rs`.
-- **Evidence**: `make run-verus` currently fails with a missing-proof-file
-  diagnostic; after EP-M2 it must report zero verification errors. Record the
-  transcript.
-- **Non-vacuity**: the proof must include a witness lemma exhibiting a
-  three-event sequence `[Alloc(8), Realloc(8, 16), Dealloc(16)]` with the
-  concrete expected totals, proving the antecedents are inhabited. Before
-  declaring the proof complete, seed a fault by changing the `Realloc` arm to
-  add `old` instead of `new` to `total_bytes` and confirm Verus rejects it.
-  Inspect the proof for stray `assume` statements; any surviving `assume` fails
-  this obligation.
-
-### Obligation V-2: the real allocator refines the specification
-
-- **Obligation**: the `GlobalAlloc` implementation in
-  `wireframe_testing::codec_benchmarks::alloc_probe` records, for any bounded
-  sequence of allocation operations, exactly the totals that the V-1
-  specification function computes for the corresponding event sequence.
-- **Method**: Kani bounded model checking.
-- **Rationale**: V-1 proves the specification correct; V-2 connects the
-  specification to the code that actually runs. Kani explores every path
-  through the real `alloc`, `realloc`, and `dealloc` arms including the
-  enable/disable gating and the `try_with` fallback, which Verus cannot reach
-  because those paths use `unsafe` and thread-local storage.
-- **Domain**: sequences of up to four operations with symbolic sizes bounded to
-  a small range, plus a symbolic enable/disable schedule. Stated bound:
-  `#[kani::unwind(5)]`.
-- **Artefact**: `#[cfg(kani)]` harnesses in
-  `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`, run by
-  `make kani-baseline`.
-- **Evidence**: `cargo kani --harness verify_alloc_probe_refines_spec` reports
-  no failed properties. Record the transcript including the explored bound.
-- **Non-vacuity**: assert that at least one reachable execution has
-  `total_events > 0` and one has counting disabled, so neither branch is
-  vacuously excluded. Seed a fault by dropping the `layout.size()` addition in
-  the `realloc` arm and confirm Kani produces a counter-example. Do not
-  `kani::assume` a fixed size; the sizes must remain symbolic.
-
-### Obligation V-3: measurement scoping is exact and non-reentrant
-
-- **Obligation**: for a measured scope `S`, the reported counters equal the
-  counters of exactly the allocator events that occurred on the measuring
-  thread between entering and leaving `S`; nested scopes do not double-count;
-  events on other threads are excluded.
-- **Method**: `proptest` over generated scope schedules, plus an `rstest`
-  parameterized test that spawns concurrent allocating threads during a
-  measurement.
-- **Rationale**: this is a property over orderings and interleavings rather
-  than over arithmetic, and the thread-exclusion half cannot be expressed in
-  the single-threaded Verus or Kani models.
+- **Obligation**: for a measured scope `S` on thread `t`, the reported counters
+  count each allocator event on `t` between entering and leaving `S` exactly
+  once per enclosing scope and zero times for any non-enclosing scope; and if
+  any allocation occurs on a thread other than `t` while `S` is open, the
+  reported result is an error rather than a number.
+- **Method**: `proptest` over generated scope schedules, plus `rstest` cases
+  for concurrent threads, panic unwinding, and thread teardown.
+- **Rationale**: this is a property over orderings and interleavings. It is
+  also the only place where a wrong answer is silently plausible, which is why
+  it gets the strongest instrument in the plan.
 - **Domain**: generated sequences of `Enter`, `Allocate(size)`, `Leave`, and
-  `SpawnAllocatingThread` operations, depth-bounded to 3.
-- **Artefact**: `wireframe_testing/tests/alloc_probe_scoping.rs`.
-- **Evidence**: the property fails before the thread-local change (the current
-  process-global counter cannot exclude other threads) and passes after.
-  Record both transcripts. Use `proptest`'s classification output to show that
-  generated cases actually reach nesting depth 3 and actually spawn threads;
-  if a class is unreached, the generator is wrong and the run does not count.
-- **Non-vacuity**: negative control — a test variant that deliberately shares
-  the counter across threads must fail the property.
+  `SpawnAllocatingThread`, nesting-depth-bounded to 3.
+- **Artefact**: `tests/baseline_alloc_scoping.rs` in the root crate, so the
+  gates actually run it.
+- **Evidence**: `make test` passes. Record `proptest` classification output
+  showing that generated cases reach depth 3 and do spawn threads; an
+  unreached class means the generator is wrong and the run does not count.
+- **Non-vacuity**: three negative controls, each of which must fail the
+  property — a variant sharing the counter across threads, a variant whose
+  scope guard does not restore state on unwind, and a variant with the escape
+  detector disabled.
 
-### Obligation V-4: the probes exercise the stages they claim to
+### Obligation V-2: the probes drive the stages they name
 
-- **Obligation**: each of the four probes performs a non-zero, stage-specific
-  amount of work, and the reported counters change when the corresponding
-  production code changes.
+- **Obligation**: each probe performs a non-zero, stage-specific amount of
+  work, and its counters change when the production code it drives changes.
 - **Method**: `rstest` parameterized tests with `googletest` matchers, plus a
   seeded-fault probe variant.
 - **Rationale**: a baseline of zero is indistinguishable from a probe that
-  never ran. This obligation exists to make that failure mode impossible.
-- **Domain**: the four stages crossed with the two payload classes.
-- **Artefact**: `tests/baseline_probes.rs`.
-- **Evidence**: every probe reports `total_events > 0` for at least one payload
-  class; the middleware probe reports zero *payload-sized* allocations,
-  matching the "moves only" claim; the outbound-encode probe reports at least
-  one allocation of at least `payload_len` bytes, matching the
-  `Serializer::serialize` claim.
+  never ran. This obligation makes that failure mode impossible.
+- **Domain**: the four stages plus the framed-encoder row, crossed with the two
+  payload classes.
+- **Artefact**: `tests/baseline_invariants.rs`.
 - **Non-vacuity**: the seeded-fault control. A `#[cfg(test)]` probe variant
-  inserts one additional `payload.to_vec()` into the middleware stage. The
-  test asserts that this variant reports strictly more allocated bytes than the
-  faithful variant, by at least `payload_len`. This proves the instrument can
-  see exactly the class of copy that item `11.1.2` will remove. If the fault
-  variant reports the same numbers, the whole baseline is worthless and the
-  milestone fails.
+  inserts one additional `payload.to_vec()` into the middleware stage; the test
+  asserts the variant reports strictly more payload-sized allocated bytes than
+  the faithful variant, by at least `payload_len`. This proves the instrument
+  sees exactly the class of copy item `11.1.2` will remove. If the fault
+  variant reports the same numbers, the milestone fails.
 
-### Obligation V-5: the recorded baseline matches the code
+### Obligation V-3: the default-path claims hold
 
-- **Obligation**: the table in `docs/frame-vec-u8-baseline.md` equals the
-  report rendered from a live run.
-- **Method**: `insta` snapshot assertion plus a document-synchronization test.
-- **Rationale**: prevents the documented baseline from silently decaying into
-  fiction.
-- **Domain**: the full rendered report.
-- **Artefact**: `tests/baseline_report.rs` and
-  `tests/snapshots/baseline_report__deterministic_baseline.snap`.
-- **Evidence**: `make test` fails if either the snapshot or the document
-  diverges. Re-blessing is `cargo insta accept` followed by pasting the
-  snapshot body into the document, which the test then re-checks.
-- **Non-vacuity**: a negative control test mutates one digit in a copy of the
-  document fixture and asserts the synchronization check rejects it.
+These are the invariants the baseline exists to state. Each is written to
+invert when the migration lands, and each is listed in the inversion register
+(EP-M3) so that a future failure is read as success rather than as a defect.
+
+- **V-3a**: `wrap_payload` on the default codec returns a `Bytes` whose pointer
+  equals the input's. Method: pointer-identity assertion, extending the
+  existing idiom at `src/codec/tests.rs:195-212`. Expected to keep holding.
+- **V-3b**: outbound encode performs at least one payload-sized allocation.
+  Expected to **invert at 11.1.2**.
+- **V-3c**: outbound encode performs at least one non-payload-sized allocation
+  when the serializer's output vector has `len != capacity`, corresponding to
+  the `Bytes::from` control block. Expected to invert at 11.1.2 only if the
+  replacement produces a right-sized buffer, which is the point of stating it.
+- **V-3d**: middleware pass-through performs zero payload-sized allocations —
+  the payload is moved — while performing at least one non-payload-sized
+  allocation for the boxed future. Expected to keep holding.
+- **V-3e**: the framed encoder performs at least one payload-sized copy.
+  Expected to keep holding through 11.1.2; stated so that nobody mistakes its
+  survival for a failed migration.
+- **Method**: `rstest` parameterized tests over both payload classes, in
+  `tests/baseline_invariants.rs`.
+- **Non-vacuity**: each assertion is paired with a control demonstrating it can
+  fail — for V-3b, a variant driving a handwritten right-sized serializer that
+  must be reported as *not* satisfying the invariant.
+
+### Obligation V-4: the report renderer's format is stable
+
+- **Obligation**: `render_report` produces a stable, sorted,
+  column-aligned Markdown table for a given set of rows.
+- **Method**: `insta` snapshot over **fixed synthetic rows**, never over live
+  measurements.
+- **Rationale**: this is genuinely multivariant output whose format consistency
+  matters, which is what snapshot testing is for. Driving it from synthetic
+  rows keeps it immune to dependency churn, so the snapshot only ever changes
+  when a human changes the format.
+- **Artefact**: `tests/baseline_report_format.rs` and
+  `tests/snapshots/baseline_report_format__table.snap`.
+- **Non-vacuity**: a case with rows supplied in reverse order must produce
+  identical output, proving the sort is real.
+
+### Obligation V-5: the recorded document is generated, not transcribed
+
+- **Obligation**: the table region of `docs/frame-vec-u8-baseline.md`, delimited
+  by `<!-- baseline:begin -->` and `<!-- baseline:end -->`, equals what the
+  renderer produces for the current tree.
+- **Method**: `rstest-bdd` scenario driving `make baseline --check`, plus a
+  compile-time `include_str!` comparison in the unit suite. `include_str!`
+  avoids Whitaker's `no_std_fs_operations` deny-level lint and makes deletion
+  of the document a compile error rather than a runtime failure.
+- **Rationale**: a generated document cannot lie. This replaces the
+  hand-transcription step that a review identified as the plan's most likely
+  source of long-term rot.
+- **Artefact**: `tests/features/baseline_document.feature`,
+  `tests/steps/baseline_document_steps.rs`, and
+  `tests/baseline_document_sync.rs`.
+- **Non-vacuity**: a fixture with one digit altered must be rejected, and the
+  rejection message must name the marker region.
 
 ### Obligation V-6: copied-byte capture is reproducible
 
-- **Obligation**: two consecutive `make baseline-copy` runs on the same machine
-  and binary report identical copied-byte totals per stage.
-- **Method**: behavioural test with `rstest-bdd` over the recorded profile
-  artefacts, plus an operator-run reproducibility check.
-- **Rationale**: Valgrind is deterministic by construction, so any variation
-  indicates the harness is measuring something other than the probe.
-- **Domain**: the four stages at the `Large` payload class.
-- **Artefact**: `tests/features/baseline_copy_profile.feature` with steps in
-  `tests/steps/baseline_copy_profile_steps.rs`.
-- **Evidence**: the scenario parses two recorded profile summaries and asserts
-  equality. Where Valgrind is unavailable the scenario is skipped with an
-  explicit diagnostic, never silently passed.
-- **Non-vacuity**: the fixture set includes one deliberately mismatched pair
-  that the scenario must reject.
+- **Obligation**: two consecutive `make baseline-copy` runs in the same
+  environment report identical per-stage figures.
+- **Method**: the target runs itself twice and diffs; a mismatch is a non-zero
+  exit. No separate behavioural fixture, because a test over handwritten
+  profile files cannot fail when the Valgrind harness is wrong.
+- **Evidence**: the transcript in `Artefacts and notes`.
+- **Non-vacuity**: Valgrind is deterministic by construction, so this check
+  detects harness non-determinism specifically — a fixture that varies per run,
+  a stray timestamp, an unpinned iteration count.
 
-### Why Verus and Kani are both used, and where they are not
+### Why no Verus proof and no Kani harness
 
-Verus discharges V-1 over unbounded sequences but cannot reason about the
-`unsafe` `GlobalAlloc` implementation or thread-local storage. Kani discharges
-V-2 over the real implementation but only to a bound of five operations, far
-below the thousands a real probe performs. Neither alone is sufficient; the
-pair is. The residual gap is that V-2's bound does not cover long sequences,
-which V-1 covers only for the specification. That gap is stated here rather
-than papered over.
+`docs/roadmap.md` section 15 (lines 583-718) is a dedicated formal-verification
+phase that owns this work: item `15.1.4` (line 611) adds the `make kani`,
+`make kani-full`, and `make verus` targets; item `15.3.1` (line 651) adds the
+first Kani smoke harnesses; item `15.5.2` (line 704) adds proof-only modules
+under `verus/` for accounting invariants. None is done, and
+`docs/developers-guide.md:376-379` records that `make run-verus` is expected to
+fail until they are.
 
-No proof is attempted for the probes, the report renderer, or the Criterion
-benches. They introduce no invariant over an unbounded domain, and
-parameterized tests with a seeded-fault control give proportionate rigour.
+An earlier revision of this plan proposed discharging the instrument's counter
+arithmetic in Verus and its `GlobalAlloc` implementation in Kani. That was the
+wrong call twice over. It would have written the repository's first proof into
+the entry point item `15.5.2` reserves, about a test instrument's addition
+rather than about a protocol invariant. And it aimed formal machinery at the
+part of the design least likely to be wrong: the way this instrument produces a
+false baseline is misattribution — wrong scope, wrong thread, wrong profile,
+uninstalled allocator — none of which a proof about arithmetic touches. V-1's
+property tests and V-2's seeded fault attack misattribution directly.
+
+The counter arithmetic is instead covered by an `rstest` table of eight known
+event sequences, including the `realloc` case and the counting-disabled case,
+against hand-computed expected values. If the estate later wants a proof of it,
+it belongs as a sub-item under roadmap section 15.3, once `15.1.4` exists.
 
 ## Plan of work
 
-### Stage A — understand and confirm (no code changes)
+### Stage A — confirm, correct, and measure one thing (minimal code)
 
-Read `src/app/outbound_encoding.rs`, `src/app/inbound_handler.rs`,
-`src/app/frame_handling/response.rs`, `src/middleware.rs`,
-`src/client/hooks.rs`, `src/client/messaging.rs`, `src/client/send_pipeline.rs`,
-`src/codec.rs`, and `src/serializer.rs`, and confirm the four stage boundaries
-described in `Context and orientation` against the current tree.
+Confirm the four stage boundaries and the copy analysis above against the
+current tree. Then do three things.
 
-Confirm two open questions recorded during planning and write the answers into
-`Surprises and discoveries`:
+First, ship the roadmap and ADR-010 wording correction as its own docs-only
+commit. `docs/roadmap.md:475-477` (item 10.2.2) and `:491-492` (item 11.1.2)
+currently point implementers at `wrap_payload`, which is free. This correction
+is independently valuable and must not wait for the measurement work.
 
-1. `src/app/codec_driver.rs:1-12` documents that the frame pipeline applies
-   protocol hooks via `before_send`, but no such invocation was located in
-   `FramePipeline::process` (`:56-71`) or in
-   `src/app/frame_handling/response.rs`. Determine whether the documentation is
-   stale or whether the invocation lives in an untraced path such as
-   `src/connection/frame.rs`. Do not fix it in this plan; record it and, if it
-   is a genuine defect, raise a separate issue.
-2. `docs/repository-layout.md` is referenced by `AGENTS.md:41-43`,
-   `docs/documentation-style-guide.md`, and `docs/roadmap.md`, but does not
-   exist. Record the gap; creating it is out of scope.
+Second, record answers to two open questions in `Surprises and discoveries`:
+whether `src/app/codec_driver.rs:1-12`'s claim that the frame pipeline applies
+protocol `before_send` hooks is accurate — no such invocation was located in
+`FramePipeline::process` (`:56-71`) — and the absence of
+`docs/repository-layout.md`, which `AGENTS.md:41-43` and the style guide both
+reference. Neither is fixed here; if the first is a genuine defect, raise an
+issue.
 
-Validation: no code changes; the two answers are written into the plan.
+Third, run one fifteen-minute experiment that decides the shape of EP-M5: a
+single `valgrind --tool=dhat --mode=copy` over a throwaway 32-byte outbound
+encode. An earlier revision assumed LLVM inlines small copies so DHAT would
+undercount the `Small` class. That assumption is untested and probably wrong,
+because the copies at issue take runtime lengths across crate boundaries and
+so emit real `memcpy` calls. If `Small` copied bytes scale with payload size,
+the `Small` class is measurable and stays in scope.
+
+Validation: the correction is committed and gates pass; the two answers and the
+experiment result are written into this plan.
 
 ### Stage B — red tests
 
-Write the failing tests before the implementation, in this order:
+Write the failing tests before the implementation, all in the root crate's
+`tests/`: `baseline_alloc_scoping.rs` (V-1), `baseline_invariants.rs` (V-2 and
+V-3), `baseline_report_format.rs` (V-4), then the document tests (V-5) once
+EP-M4 creates the document stub.
 
-1. `wireframe_testing/tests/alloc_probe_scoping.rs` — the V-3 property. It
-   fails to compile until `alloc_probe` exists.
-2. `tests/baseline_probes.rs` — the V-4 tests including the seeded-fault
-   control.
-3. `tests/baseline_report.rs` — the V-5 snapshot and document-synchronization
-   tests. The snapshot file does not exist yet, so `insta` reports a new
-   snapshot; the document test fails because
-   `docs/frame-vec-u8-baseline.md` does not exist.
-4. `tests/features/baseline_copy_profile.feature` and its steps — the V-6
-   scenario, failing because no profile artefacts exist.
+Each test fails for its intended reason, recorded as a transcript. To keep the
+commit-gate constraint intact, tests are committed in the same milestone as the
+code that makes them pass, with the red transcript captured beforehand and
+recorded in `Artefacts and notes`.
 
-Validation: each test fails for its intended reason, recorded as a transcript
-in `Artefacts and notes`. A test that fails to compile counts as red only if
-the compilation error names the missing item this plan will add.
+### Stage C — implementation
 
-### Stage C — implementation and verification together
+Milestones EP-M1 through EP-M4.
 
-Milestones EP-M1 through EP-M5 below. Each ends with its own validation.
+### Stage D — measurement, publication, and wider validation
 
-### Stage D — documentation, cleanup, and wider validation
-
-Milestone EP-M6.
+Milestone EP-M5.
 
 ## Milestones and plateaus
 
-### EP-M1 — byte-aware, thread-local allocation instrument
+### EP-M1 — the allocation instrument
 
-- **Outcome**: `wireframe_testing::codec_benchmarks::alloc_probe` exists and
-  `benches/codec_performance_alloc.rs` uses it instead of its private
-  `CountingAllocator`. The existing `codec/allocations` Criterion group and its
-  label format are unchanged.
-- **Requirements**: `ROADMAP-10.2.1-alloc`.
-- **Interfaces**: in
-  `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`, define:
+- **Outcome**: `wireframe_testing::codec_benchmarks::alloc_probe` exists, is
+  verified against V-1, and `benches/codec_performance_alloc.rs` uses it
+  instead of its private `CountingAllocator`.
+- **Interfaces**, in
+  `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`:
 
   ```rust
-  /// Counters describing allocator traffic observed on one thread.
+  /// Allocator traffic observed on one thread within a measured scope.
   #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-  pub struct AllocationCounters {
-      pub allocation_events: u64,
-      pub allocated_bytes: u64,
-      pub deallocation_events: u64,
-      pub deallocated_bytes: u64,
-      pub reallocation_events: u64,
-      pub realloc_moved_bytes: u64,
+  #[non_exhaustive]
+  pub struct AllocatorTraffic {
+      allocation_events: u64,
+      allocated_bytes: u64,
+      payload_sized_events: u64,
+      payload_sized_bytes: u64,
+      deallocation_events: u64,
+      deallocated_bytes: u64,
   }
 
-  /// A `GlobalAlloc` that counts traffic on the measuring thread only.
+  /// A `GlobalAlloc` that counts traffic on the measuring thread.
+  ///
+  /// Binaries install this; libraries must not. See `install_probe_allocator!`.
   pub struct ProbeAllocator;
 
-  // SAFETY invariants are documented on the impl.
-  unsafe impl core::alloc::GlobalAlloc for ProbeAllocator { /* ... */ }
+  /// Errors that prevent a measurement from being trustworthy.
+  #[derive(Debug, thiserror::Error)]
+  #[non_exhaustive]
+  pub enum MeasureError {
+      /// The binary did not install `ProbeAllocator`.
+      #[error("ProbeAllocator is not the installed global allocator")]
+      AllocatorNotInstalled,
+      /// Allocation occurred on another thread while the scope was open.
+      #[error("allocation escaped the measuring thread; result is not usable")]
+      Escaped,
+  }
 
-  /// Runs `operation` with counting enabled on the current thread and
-  /// returns the counters attributable to it.
-  pub fn measure<T, F: FnOnce() -> T>(operation: F) -> (T, AllocationCounters);
+  /// Confirms the probe allocator is installed, by allocating a canary.
+  pub fn assert_installed() -> Result<(), MeasureError>;
+
+  /// Runs `operation` with counting enabled on the current thread.
+  ///
+  /// Nested scopes attribute each event once to every enclosing scope. A
+  /// panic inside `operation` restores the prior state via the scope guard.
+  pub fn measure_in_place<F: FnOnce()>(
+      threshold_bytes: usize,
+      operation: F,
+  ) -> Result<AllocatorTraffic, MeasureError>;
   ```
 
-  The counters live in `thread_local!` `Cell`s declared with
-  `const { Cell::new(0) }` and are reached with `try_with`; a `try_with`
-  failure means "not measuring" and must never panic. `measure` is re-entrant
-  safe: a nested `measure` attributes events to the innermost scope and adds
-  them to the outer scope on exit.
-- **Acceptance evidence**: `wireframe_testing/tests/alloc_probe_scoping.rs`
-  passes, including the concurrent-thread exclusion case that the previous
-  process-global counter could not satisfy. `make bench-codec` still emits the
-  same `wrap_allocs_<n>` and `decode_allocs_<n>` label shapes.
-- **Conformance check**: no public `wireframe` API changed; only
-  `wireframe_testing` gained a module. No new dependency.
-- **Recovery**: the change is additive to `wireframe_testing` and a
-  single-file substitution in the bench. Revert the bench file to restore the
-  prior behaviour.
-- **Remaining gaps**: the instrument is unverified until EP-M2.
-- **Compatibility decision**: none required. `wireframe_testing` is a test
-  support crate below 1.0 with no external consumer commitment.
+  `AllocatorTraffic`'s fields are private with accessor methods, so a seventh
+  counter is not a breaking change. Counters are `thread_local!` `Cell`s with
+  `const { Cell::new(0) }` initializers, reached via `try_with`. The escape
+  detector is a process-global `AtomicU64` of open scopes plus a per-thread
+  owner check. `alloc_zeroed` is overridden explicitly, matching the existing
+  bench allocator (`benches/codec_performance_alloc.rs:66-70`); omitting it
+  would route through `alloc` and shift the counts. An
+  `install_probe_allocator!()` macro makes each binary's registration one
+  greppable line.
+- **Acceptance evidence**: `tests/baseline_alloc_scoping.rs` passes with all
+  three V-1 negative controls rejected. Counters are shown to agree between the
+  dev profile and a coverage-instrumented build; if they do not, that fact is
+  recorded and the document's environment stamp gains a profile field before
+  anything else proceeds. `make bench-codec` still emits the same
+  `wrap_allocs_<n>` label shape, with old and new values recorded side by side
+  in the commit message, because the thread-local change will move them and
+  every saved Criterion baseline under `target/criterion` is orphaned by it.
+- **Conformance check**: no `wireframe` API changed. `wireframe_testing` gains
+  a module and a `[lints]` section inheriting the workspace lint policy, so the
+  most correctness-critical component in this item is held to the same standard
+  as the rest of the tree rather than the least-linted crate in it.
+- **Recovery**: additive plus a one-file bench substitution, committed
+  separately so it reverts alone.
+- **Remaining gaps**: no probes yet.
 
-### EP-M2 — verification of the accounting
+### EP-M2 — production seams and probes
 
-- **Outcome**: V-1 discharged in Verus, V-2 discharged in Kani.
-- **Requirements**: measurement soundness for `ROADMAP-10.2.1-alloc`.
-- **Interfaces**: `verus/wireframe_proofs.rs` as the entry point that `mod`s
-  `verus/wireframe_proofs_alloc.rs`, mirroring `AllocationCounters` as a spec
-  struct and `Event` as a spec enum. A Makefile target `kani-baseline` runs the
-  Kani harnesses; `make run-verus` gains a working proof file for the first
-  time.
-- **Acceptance evidence**: `make run-verus` reports zero errors;
-  `make kani-baseline` reports no failed properties; both seeded faults
-  described in V-1 and V-2 are shown to be rejected, with transcripts.
-- **Conformance check**: `docs/developers-guide.md:354-393` describes the
-  formal tooling entry points and states that `run-verus` fails until a proof
-  file exists; that statement must be updated in EP-M6.
-- **Recovery**: the proof files are outside the Cargo build. Deleting them
-  restores the prior state exactly.
-- **Remaining gaps**: V-2's bound of five operations, stated explicitly.
-- **Compatibility decision**: none.
-
-### EP-M3 — stage probes
-
-- **Outcome**: four probes drive the four production stages in-process, and a
-  seeded-fault variant exists for the negative control.
-- **Requirements**: `ROADMAP-10.2.1-alloc`, `INVENTORY-middleware-island`,
-  `ADR-008-REQ-default-path-no-fresh-vec`.
-- **Interfaces**: in
-  `wireframe_testing/src/codec_benchmarks/pipeline_baseline.rs`:
+- **Outcome**: four production seam extractions, feature-gated shims, and five
+  probes that drive production code.
+- **Production seams** (each a behaviour-preserving extraction, called from its
+  original site):
+  1. `src/app/inbound_handler.rs` — widen `parse_envelope` (line 74, currently
+     a bare private `fn`) to `pub(crate)`, and add the shim inside this module
+     rather than a sibling, because a sibling module cannot see a private item.
+  2. `src/app/frame_handling/response.rs` — extract
+     `pub(crate) async fn middleware_round_trip(...)` covering lines 41-55, and
+     call it from `forward_response`. Without this the middleware probe would
+     re-implement the very lines it measures.
+  3. `src/client/hooks.rs` — extract a free function
+     `invoke_before_send(hooks: &[BeforeSendHook], bytes: &mut Vec<u8>)`
+     and have `WireframeClient::invoke_before_send_hooks`
+     (`src/client/messaging.rs:335`) delegate to it. The method is on the
+     client and reaching it otherwise requires a live `Framed` transport,
+     contradicting the definition of a probe.
+  4. `src/app/outbound_encoding.rs` — the shim returns
+     `Result<F::Frame, SendError>`, not `EncodedFrame<F::Frame>`, because
+     `EncodedFrame` is `pub(crate)` (line 18) and returning it from a `pub`
+     function trips `private_interfaces`, which `-D warnings` makes an error.
+- **Feature plumbing**, which is a hard compile break if omitted:
+  `wireframe_testing/Cargo.toml` currently declares
+  `wireframe = { path = "..", features = ["testkit"] }` and has no `[features]`
+  section, so it cannot see anything gated on `test-support`. Add
+  `[features] baseline = ["wireframe/test-support"]`, default off, gate the new
+  modules behind it, and add `features = ["baseline"]` to the root crate's
+  dev-dependency on `wireframe_testing`. Enabling `test-support`
+  unconditionally would ship the shims to every downstream consumer of a
+  published crate.
+- **Interfaces**, in
+  `wireframe_testing/src/codec_benchmarks/default_path_baseline.rs`:
 
   ```rust
-  /// One measurable stage of the default codec path.
-  #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+  /// A measurable stage of the default codec path.
+  #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+  #[non_exhaustive]
   pub enum Stage {
+      /// Declaration order fixes the recorded row order; do not reorder.
       InboundDecode,
       MiddlewarePassThrough,
-      RequestHooksReadOnly,
-      RequestHooksMutating,
+      RequestHooks,
       OutboundEncode,
+      FramedEncoderWrite,
   }
 
-  /// Prepared, reusable inputs for one stage at one payload class.
-  pub struct StageFixture { /* ... */ }
+  /// Whether a request hook reads or mutates the payload.
+  #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+  pub enum HookShape { ReadOnly, Mutating }
 
-  pub fn fixture(stage: Stage, class: PayloadClass)
+  pub fn fixture(stage: Stage, class: PayloadClass, hook: Option<HookShape>)
       -> Result<StageFixture, BaselineError>;
 
-  /// Drives the production stage exactly once.
-  pub fn run_stage(fixture: &StageFixture) -> Result<(), BaselineError>;
+  /// Drives the production stage once. Infallible by construction, so no
+  /// error path lies inside the measured window.
+  #[must_use]
+  pub fn run_stage(fixture: &StageFixture) -> StageOutput;
   ```
 
-  In `src/app/baseline_support.rs`, gated by
-  `#![cfg(feature = "test-support")]`, expose thin `pub` wrappers over the
-  crate-private stage entry points: `encode_message_frame`
-  (`src/app/outbound_encoding.rs:22`), the decode path used by
-  `parse_envelope` (`src/app/inbound_handler.rs:74`), and
-  `RequestHooks::invoke_before_send_hooks`
-  (`src/client/messaging.rs:335`). Each wrapper is a single delegating call
-  with a doc comment stating it exists for baseline measurement and carries no
-  stability guarantee.
-- **Acceptance evidence**: `tests/baseline_probes.rs` passes, including the
-  seeded-fault control from V-4. The middleware probe reports zero
-  payload-sized allocations; the outbound-encode probe reports at least one
-  allocation of at least `payload_len` bytes.
-- **Conformance check**: every new `wireframe` item is behind `test-support`.
-  Confirm with `cargo public-api` if available, otherwise by inspection of the
-  feature gates.
-- **Recovery**: probes and shims are additive; deleting
-  `src/app/baseline_support.rs` and its `mod` declaration reverts cleanly.
-- **Remaining gaps**: no numbers are recorded yet.
-- **Compatibility decision**: none. The shims are feature-gated and the crate
-  is pre-1.0.
+  `run_stage` returns `StageOutput` so the caller can `black_box` it; a
+  `-> ()` signature would let the optimizer elide the work being measured.
+  `PayloadClass` gains `PartialOrd, Ord` upstream so the report can sort.
+- **Acceptance evidence**: `tests/baseline_invariants.rs` passes V-2 including
+  the seeded-fault control, and V-3a through V-3e hold with their controls
+  rejected. `cargo build -p wireframe_testing` succeeds standalone, not merely
+  inside the workspace.
+- **Conformance check**: every new `wireframe` item is behind `test-support`;
+  every new `wireframe_testing` item is behind `baseline`. Verify by diffing
+  `cargo public-api` output with and without the features, since a default-run
+  would never see a gated item.
+- **Recovery**: the seams are extractions; inlining them restores the prior
+  shape. Shims and probes are additive.
 
-### EP-M4 — deterministic baseline report
+### EP-M3 — invariants and the inversion register
 
-- **Outcome**: a rendered report of deterministic counters, snapshotted and
-  cross-checked against the document, plus a `make baseline` target.
-- **Requirements**: `ROADMAP-10.2.1-alloc`.
-- **Interfaces**:
+- **Outcome**: the five default-path claims are asserted, and a register
+  records what is expected to change and when.
+- **Deliverable**: a section of `docs/frame-vec-u8-baseline.md` listing, for
+  each assertion, the test name, the claim, and the roadmap item at which it is
+  expected to invert (V-3b and V-3c at `11.1.2`) or its signature to change
+  (`BeforeSendHook` at `12.2.1`, which flips the hook surface alongside
+  `Serializer::serialize`). Cross-reference this register from the roadmap
+  items themselves.
+- **Rationale**: when item `11.1.2` succeeds, three assertions fail. Without
+  the register the implementer reads "outbound encode performs at least one
+  payload-sized allocation — FAILED" and goes hunting for an instrument bug.
+- **Acceptance evidence**: `make test` passes; the register names every
+  assertion that appears in `tests/baseline_invariants.rs`, checked by a test
+  that compares the register's list against the test names.
 
-  ```rust
-  /// One row of the deterministic baseline.
-  pub struct BaselineRow {
-      pub stage: Stage,
-      pub payload_class: PayloadClass,
-      pub counters: AllocationCounters,
-  }
+### EP-M4 — the generated record
 
-  /// Renders rows in a stable, sorted order as a Markdown table.
-  pub fn render_report(rows: &[BaselineRow]) -> String;
-  ```
+- **Outcome**: `make baseline` regenerates the recorded numbers into
+  `docs/frame-vec-u8-baseline.md`; `make baseline --check` verifies it.
+- **Interfaces**: `collect_baseline()`, returning
+  `Result<Vec<BaselineRow>, BaselineError>` so item `10.2.2` can set thresholds
+  without re-parsing Markdown, and `render_report(&[BaselineRow]) -> String`
+  producing a captioned
+  Markdown table sorted by `(stage, payload_class, hook_shape)`. Both live in
+  `wireframe_testing`, which declares no `print_stdout` deny, so the printing
+  binary does not need an `#[expect]` attribute.
+- **The environment stamp** is part of the rendered output: `rustc` version,
+  the locked versions of `bincode`, `bytes`, and `tokio-util`,
+  `target_pointer_width`, the cargo profile, and the git commit. A changed
+  number then explains itself.
+- **Regeneration**: `make baseline` rewrites only the region between
+  `<!-- baseline:begin -->` and `<!-- baseline:end -->`. There is no
+  hand-transcription step, so V-5 verifies a generated artefact.
+- **Acceptance evidence**: `make baseline` then `make baseline --check` exits
+  zero; altering one digit and re-running `--check` exits non-zero naming the
+  region; `tests/baseline_report_format.rs` passes V-4 with the
+  reverse-order control.
+- **Conformance check**: `insta` appears only in `[dev-dependencies]`, and the
+  snapshot is driven by synthetic rows, so no dependency bump can touch it.
 
-  `render_report` must sort by `(stage, payload_class)` so that the output does
-  not depend on collection order.
-- **Acceptance evidence**: `make baseline` prints the table and exits zero;
-  `tests/baseline_report.rs` passes both the snapshot assertion and the
-  document-synchronization assertion; the negative control from V-5 is
-  rejected.
-- **Conformance check**: `insta` appears only under `[dev-dependencies]`.
-- **Recovery**: delete the snapshot and re-run `cargo insta accept`.
-- **Remaining gaps**: copied bytes and timings are not yet recorded.
-- **Compatibility decision**: none.
+### EP-M5 — copied bytes, timings, and publication
 
-### EP-M5 — copied bytes, throughput, and latency
-
-- **Outcome**: `benches/pipeline_baseline.rs` measures throughput and latency
-  for the four stages; a probe binary plus `make baseline-copy` captures
-  copied-byte totals under Valgrind; both sets of figures are recorded.
-- **Requirements**: `ROADMAP-10.2.1-copied-bytes`,
-  `ROADMAP-10.2.1-throughput-latency`, `ADR-010-RISK-serializer-bridge`.
-- **Interfaces**: a `test-support`-gated binary target
-  `baseline-copy-probe` accepting `--stage <name>` and `--iterations <n>`,
-  where `--stage noop` performs setup and teardown only. `make baseline-copy`
-  runs each stage and the calibration under
-  `valgrind --tool=dhat --mode=copy` and reports, per stage, the difference
-  between the stage total and the calibration total, divided by the iteration
-  count.
-- **Acceptance evidence**: two consecutive `make baseline-copy` runs produce
-  identical per-stage figures (V-6). The Criterion groups
-  `pipeline/inbound_decode`, `pipeline/middleware_pass_through`,
-  `pipeline/request_hooks`, and `pipeline/outbound_encode` appear in
-  `make bench-codec` output with `Throughput::Bytes` set.
-- **Conformance check**: no production code changed for the copy measurement;
-  Valgrind is invoked externally.
-- **Recovery**: the probe binary and bench are additive and independently
-  removable. If Valgrind is unavailable the copy target fails loudly with a
-  diagnostic naming the missing tool; it must not silently record zeros.
-- **Remaining gaps**: copied bytes for the `Small` payload class carry a stated
-  undercount caveat.
-- **Compatibility decision**: none.
-
-### EP-M6 — documentation, roadmap, and final gates
-
-- **Outcome**: the baseline is published, the methodology is recorded as an
-  ADR, the internal conventions are documented, and the roadmap is ticked.
-- **Requirements**: all of the above.
-- **Deliverables**:
-  - `docs/frame-vec-u8-baseline.md` — the baseline itself: the deterministic
-    table (byte-identical to the snapshot), the copied-byte table for the
-    `Large` class with the `Small`-class caveat, the indicative timing table
-    with a hardware, operating-system, and toolchain stamp, and a short section
-    stating the falsifiable claim about where the default path copies today.
-  - `docs/adr-011-byte-migration-baseline-methodology.md` — Status Accepted,
-    following the ADR template in `docs/documentation-style-guide.md:418-495`.
-    It records: the operational definition of a copied byte; why Valgrind DHAT
-    copy mode was chosen and what it cannot see; why allocation counting is
-    thread-local; why deterministic counters are normative and timings are not;
-    and the correction that `wrap_payload` and `Bytes::from` are free on the
-    default codec while `Serializer::serialize` is not.
-  - `docs/developers-guide.md` — a new subsection after "Example and benchmark
-    support" (line 332-352) covering the baseline module, the two make targets,
-    the `insta` re-blessing procedure, and the rule that the baseline document
-    is re-blessed alongside the snapshot. Update the statement at lines 376-379
-    that `run-verus` is expected to fail.
-  - `docs/users-guide.md` — a short note under the codec testing material
-    stating that `wireframe_testing::codec_benchmarks` now exposes baseline
-    probes and an allocation instrument for consumers who wish to measure their
-    own codecs, and that these require the `test-support` feature.
-  - `docs/contents.md` — register the new baseline document and ADR-011.
-  - `CHANGELOG.md` — one bullet under `## Unreleased`.
-  - `docs/roadmap.md` — mark `10.2.1` done using `mapsplice`.
-- **Acceptance evidence**: `make check-fmt`, `make lint`, `make test`,
-  `make markdownlint`, and `make nixie` all pass, delegated to `scrutineer`
-  with logs under `/tmp`.
-- **Conformance check**: every upstream identifier in `Conformance basis` maps
-  to a milestone and an acceptance item; ADR-008's requirement at line 85-86
-  is now measurable; ADR-010's risk at lines 189-192 now has a number attached.
-- **Recovery**: documentation changes are independently revertible.
-- **Remaining gaps**: item `10.2.2` will choose the threshold numbers; this
-  plan deliberately does not.
-- **Compatibility decision**: none.
+- **Outcome**: copied-byte and timing figures are captured and published, the
+  methodology is recorded as an ADR, and the roadmap is ticked.
+- **Copied bytes**: a `[[bin]]` target `baseline-copy-probe` in
+  `wireframe_testing`, gated on the `baseline` feature, accepting
+  `--stage <name>` and `--iterations <n>`. `make baseline-copy` runs each stage
+  at `N` and at `2N` under `valgrind --tool=dhat --mode=copy` and reports the
+  slope `(total_2N - total_N) / N`. The slope cancels process startup, dynamic
+  linking, fixture construction, and Valgrind's own overhead exactly, needs no
+  separate calibration stage, and gives a free linearity check: figures that do
+  not scale mean the harness is measuring setup. Division uses `checked_div`,
+  because `integer_division` and `integer_division_remainder_used` are both
+  `deny` (`Cargo.toml:129-130`), and the two raw totals and `N` are published
+  alongside the quotient so truncation is recoverable. Recorded defaults:
+  `N = 10_000` for `Large`, `N = 100_000` for `Small`. A named script under
+  `scripts/` parses DHAT's `dhat.out.<pid>` output; its input format is stated
+  in the script's header comment.
+- **Timings**: `benches/pipeline_baseline.rs`, registered in `Cargo.toml` as
+  `[[bench]] name = "pipeline_baseline", harness = false`, and added by name to
+  `make bench-codec`, which lists its benches explicitly (`Makefile:66-67`).
+  Reuse the existing `iter_custom` shape from
+  `wireframe_testing/src/codec_benchmarks/codec_benchmark_support.rs`, which
+  amortizes clock resolution across a batch. Use `Throughput::Bytes` for
+  decode, encode, and the framed write; `Throughput::Elements(1)` for
+  middleware and read-only hooks, where a bytes figure would report a pointer
+  move in TiB/s and be quoted out of context. `black_box` the loop body, not
+  just the aggregate, or the no-work stages are deleted by the optimizer.
+- **Documentation**:
+  - `docs/frame-vec-u8-baseline.md` — the generated tables, the inversion
+    register from EP-M3, the provenance stamp, and the falsifiable claim about
+    where the default path copies today, including the framed-encoder copy that
+    `11.1.2` cannot remove.
+  - `docs/adr-011-byte-migration-baseline-methodology.md` — Status Proposed
+    until the final commit, then Accepted. Records the operational definition
+    of a copied byte and why Valgrind was chosen; why the instrument is
+    thread-local and why escape is an error; why invariants are asserted and
+    numbers are not; the correction about where the default path copies,
+    including the `Bytes::from` control-block allocation; and that prover
+    targets are deliberately operator-invoked and must not be added to CI,
+    because `rust-toolchain.toml` and `tools/verus/VERSION` are pinned
+    independently and a CI-wired prover would turn a pin gap into a red build.
+  - `docs/developers-guide.md` — a subsection after "Example and benchmark
+    support" (line 331 onward) covering the instrument, the probes, the two
+    make targets, the regeneration workflow, and the rule that a dependency
+    bump legitimately changes the recorded numbers.
+  - `docs/contents.md`, `CHANGELOG.md`, and `docs/roadmap.md` (via `mapsplice`,
+    in a commit that does nothing else).
+- **Acceptance evidence**: `make baseline-copy` self-diffs clean; the recorded
+  outbound copied-byte figure for the `Large` class is at least 131,072,
+  reflecting both the serializer copy and the framed-encoder copy — a figure
+  near 65,536 means the stage boundary is wrong. All gates pass via
+  `scrutineer`.
+- **Recovery**: documentation changes revert independently; ADR-011 stays
+  Proposed until the final commit; the roadmap tick is its own commit.
 
 ## Concrete steps
 
-Run everything from the repository root.
-
-Establish the red state:
+Run everything from the repository root, with `set -o pipefail`.
 
 ```bash
-set -o pipefail
 cargo test --all-targets --all-features 2>&1 \
-  | tee /tmp/test-wireframe-10-2-1-red.out
+  | tee /tmp/test-wireframe-10-2-1-red.out          # Stage B: expect red
+cargo test -p wireframe_testing --features baseline 2>&1 \
+  | tee /tmp/test-wt-10-2-1.out                     # after EP-M1/EP-M2
+make baseline        2>&1 | tee /tmp/baseline-10-2-1.out
+make baseline --check 2>&1 | tee /tmp/baseline-check-10-2-1.out
+make baseline-copy   2>&1 | tee /tmp/baseline-copy-10-2-1.out
 ```
 
-Expected: compilation failures naming
-`wireframe_testing::codec_benchmarks::alloc_probe`, which does not yet exist.
-
-After EP-M1:
-
-```bash
-set -o pipefail
-cargo test -p wireframe_testing --all-features 2>&1 \
-  | tee /tmp/test-alloc-probe-10-2-1.out
-```
-
-Expected: `alloc_probe_scoping` passes, including the concurrent case.
-
-After EP-M2:
-
-```bash
-set -o pipefail
-make run-verus 2>&1 | tee /tmp/verus-wireframe-10-2-1.out
-make kani-baseline 2>&1 | tee /tmp/kani-wireframe-10-2-1.out
-```
-
-Expected from Verus, approximately:
+`make baseline --check` on an unmodified tree is expected to print:
 
 ```plaintext
-verification results:: 7 verified, 0 errors
+docs/frame-vec-u8-baseline.md is up to date
 ```
 
-Expected from Kani, approximately:
-
-```plaintext
-VERIFICATION:- SUCCESSFUL
-```
-
-After EP-M4:
-
-```bash
-make baseline 2>&1 | tee /tmp/baseline-wireframe-10-2-1.out
-```
-
-Expected: a Markdown table on standard output whose body matches
-`tests/snapshots/baseline_report__deterministic_baseline.snap`.
-
-After EP-M5:
-
-```bash
-make baseline-copy 2>&1 | tee /tmp/baseline-copy-wireframe-10-2-1.out
-make baseline-copy 2>&1 | tee /tmp/baseline-copy-wireframe-10-2-1-b.out
-diff /tmp/baseline-copy-wireframe-10-2-1.out \
-     /tmp/baseline-copy-wireframe-10-2-1-b.out
-```
-
-Expected: `diff` reports no differences in the per-stage copied-byte figures.
-
-Final gates, delegated to `scrutineer`:
-
-```bash
-set -o pipefail
-make check-fmt 2>&1 | tee /tmp/check-fmt-wireframe-10-2-1.out
-make lint      2>&1 | tee /tmp/lint-wireframe-10-2-1.out
-make test      2>&1 | tee /tmp/test-wireframe-10-2-1.out
-make markdownlint 2>&1 | tee /tmp/mdlint-wireframe-10-2-1.out
-make nixie     2>&1 | tee /tmp/nixie-wireframe-10-2-1.out
-```
+Final gates, delegated to `scrutineer`: `make check-fmt`, `make lint`,
+`make test`, `make markdownlint`, `make nixie`, each teed to
+`/tmp/<action>-wireframe-10-2-1.out`.
 
 ## Validation and acceptance
 
-Acceptance is behavioural, not structural.
+Acceptance is behavioural.
 
-- Running `make baseline` on any machine prints a table, and running it again
-  prints the identical table. Running it on a different machine prints the
-  identical table. If it does not, the instrument is broken.
-- Running `make baseline-copy` twice on the same machine prints identical
-  per-stage copied-byte figures.
-- `docs/frame-vec-u8-baseline.md` states, for the `Large` payload class, a
-  specific number of bytes copied during outbound encode, and that number is
-  at least 65,536 — because `bincode` must copy the payload into the vector it
-  allocates. If the recorded number is below the payload size, the measurement
-  is wrong and the milestone fails.
-- The middleware pass-through row records zero payload-sized allocations,
-  confirming the inventory's "moves only" characterization
-  (`docs/frame-vec-u8-inventory.md:118`). If it does not, the inventory is
-  wrong and that is a finding worth recording.
-- Deleting one line from `docs/frame-vec-u8-baseline.md`'s table and running
-  `make test` fails with a clear diagnostic.
-- Applying the seeded-fault probe variant and running `make test` fails,
-  because the recorded allocated bytes increase by at least the payload size.
+- `make test` passes, and every V-1 through V-5 negative control is rejected
+  for its intended reason.
+- Inserting one `payload.to_vec()` into the middleware stage makes
+  `tests/baseline_invariants.rs` fail with a payload-sized-bytes increase of at
+  least `payload_len`.
+- Deleting `docs/frame-vec-u8-baseline.md` makes the test suite fail to
+  compile, because the document is read with `include_str!`.
+- Editing one digit inside the generated region and running
+  `make baseline --check` exits non-zero and names the region.
+- `make baseline-copy` self-diffs clean, and the recorded `Large` outbound
+  copied-byte figure is at least 131,072.
+- `cargo build -p wireframe_testing` succeeds outside the workspace.
 
-Red-Green-Refactor evidence is recorded per milestone in
-`Artefacts and notes`, with the red transcript, the green transcript, and the
-post-refactor transcript.
-
-Quality criteria:
-
-- Tests: `make test` passes with the new unit, property, behavioural, and
-  snapshot tests included.
-- Verification: V-1 discharged in Verus, V-2 in Kani, V-3 in `proptest`,
-  V-4 through V-6 in `rstest` and `rstest-bdd`, each with its stated
-  non-vacuity control demonstrated.
-- Lint and format: `make check-fmt`, `make lint`, `make markdownlint`, and
-  `make nixie` pass.
-- Performance: no threshold is set by this item. Recording indicative figures
-  is the deliverable; choosing thresholds is item `10.2.2`.
-- Security: none applicable; no new runtime dependency and no network
-  behaviour changes.
+Quality criteria: `make check-fmt`, `make lint`, `make test`,
+`make markdownlint`, and `make nixie` all pass. No performance threshold is set
+by this item; choosing thresholds is item `10.2.2`. No security surface
+changes.
 
 ## Idempotence and recovery
 
-Every step is re-runnable. `make baseline` and `make baseline-copy` are
-read-only with respect to the working tree except for Valgrind output files,
-which are written under `target/baseline/` and are covered by `.gitignore`.
-Snapshot re-blessing via `cargo insta accept` is idempotent. The Verus proof
-files live outside the Cargo build, so deleting them restores the prior state
-without touching compilation. No step is destructive, and none requires a
-backup.
+Every step is re-runnable. `make baseline` is idempotent by construction —
+running it twice produces no diff. `make baseline-copy` writes Valgrind output
+under `target/baseline/`, which is git-ignored. No step is destructive. The
+commit order is chosen so that the bench-allocator substitution, the ADR status
+flip, and the roadmap tick are each their own revertible commit.
 
 ## Interfaces and dependencies
 
-New dependency: `insta`, `dev-dependencies` only, used solely for the rendered
-baseline snapshot. No new runtime dependency.
+New dependency: `insta` (`[dev-dependencies]`) plus the `cargo-insta` binary
+tool, used only for the renderer's format snapshot over synthetic rows.
 
-External tool: Valgrind 3.17 or later, for DHAT copy mode. It is not a build
-requirement; `make baseline-copy` is operator-invoked and fails with a clear
-diagnostic when Valgrind is absent.
+External tools: Valgrind 3.17 or later for DHAT copy mode, invoked through a
+pinned rootless-Podman image so the figures are portable and comparable;
+`BASELINE_COPY_NATIVE=1` selects the native path. Neither is a build
+requirement, and `make baseline-copy` fails with a clear diagnostic when the
+tool is absent rather than recording zeros.
 
-New modules:
+New modules: `wireframe_testing/src/codec_benchmarks/{alloc_probe,
+default_path_baseline, baseline_report}.rs`; a `baseline-copy-probe` binary and
+`benches/pipeline_baseline.rs`; `scripts/parse-dhat-copy.<ext>`; root-crate
+tests `baseline_alloc_scoping.rs`, `baseline_invariants.rs`,
+`baseline_report_format.rs`, `baseline_document_sync.rs`, plus the BDD feature
+and steps.
 
-- `wireframe_testing/src/codec_benchmarks/alloc_probe.rs`
-- `wireframe_testing/src/codec_benchmarks/pipeline_baseline.rs`
-- `wireframe_testing/src/codec_benchmarks/baseline_report.rs`
-- `src/app/baseline_support.rs`, gated by `feature = "test-support"`
-- `benches/pipeline_baseline.rs`
-- `verus/wireframe_proofs.rs` and `verus/wireframe_proofs_alloc.rs`
-
-Existing modules that this plan reuses rather than duplicates:
-`wireframe_testing::codec_benchmarks::codec_benchmark_support` for
-`PayloadClass`, `payload_for_class`, and `Measurement`; and
-`wireframe_testing::helpers::drive` for in-process transport should an
-end-to-end cross-check be wanted.
+Reused rather than duplicated: `PayloadClass`, `payload_for_class`,
+`Measurement`, and the `iter_custom` shape from
+`wireframe_testing::codec_benchmarks::codec_benchmark_support`; the
+pointer-identity idiom from `src/codec/tests.rs`.
 
 ## Relevant documentation and skills
 
-Documentation to read before starting:
+Read before starting: `AGENTS.md`; `docs/documentation-style-guide.md`
+(including the ADR template at lines 418-495);
+`docs/developers-guide.md` (quality gates 176-188, benchmark support 331-352,
+formal tooling 354-393, test infrastructure 394-511, `mapsplice` 512-540);
+`docs/frame-vec-u8-inventory.md`; ADRs 008, 009, and 010;
+`docs/rust-testing-with-rstest-fixtures.md`;
+`docs/rstest-bdd-users-guide.md`;
+`docs/reliable-testing-in-rust-via-dependency-injection.md`;
+`docs/rust-doctest-dry-guide.md` (note `make doctest-benchmark` enforces a
+runnable-doctest ratio, and `missing_docs` is denied, so every new public item
+needs a doc comment);
+`docs/multi-layered-testing-strategy.md`;
+`docs/formal-verification-methods-in-wireframe.md` (for why the prover work
+belongs to roadmap section 15);
+`docs/generic-message-fragmentation-and-re-assembly-design.md`,
+`docs/multi-packet-and-streaming-responses-design.md`, and
+`docs/hardening-wireframe-a-guide-to-production-resilience.md` for the paths
+deliberately excluded; and, in `docs/`,
+`the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md`.
 
-- `AGENTS.md` — code style, quality gates, and Rust-specific rules.
-- `docs/documentation-style-guide.md` — mandatory for every document written
-  here, including the ADR template at lines 418-495.
-- `docs/developers-guide.md` — quality gates (176-188), example and benchmark
-  support (332-352), formal verification tooling (354-393), test
-  infrastructure (394-511), and roadmap editing with `mapsplice` (512-540).
-- `docs/frame-vec-u8-inventory.md` — the call-site inventory this baseline
-  measures.
-- ADRs 008, 009, and 010 — the approved design this baseline serves.
-- `docs/rust-testing-with-rstest-fixtures.md` and
-  `docs/rstest-bdd-users-guide.md` — fixture and scenario conventions.
-- `docs/reliable-testing-in-rust-via-dependency-injection.md` — for keeping the
-  probes injectable rather than hard-wired.
-- `docs/rust-doctest-dry-guide.md` — doctest conventions for the new public
-  items; note `make doctest-benchmark` enforces a runnable-doctest ratio.
-- `docs/multi-layered-testing-strategy.md` and
-  `docs/formal-verification-methods-in-wireframe.md` — where Kani and Verus sit
-  relative to the existing Stateright-style model in
-  `crates/wireframe-verification`.
-- `docs/hardening-wireframe-a-guide-to-production-resilience.md`,
-  `docs/generic-message-fragmentation-and-re-assembly-design.md`, and
-  `docs/multi-packet-and-streaming-responses-design.md` — background on paths
-  deliberately excluded from the default-path baseline.
-- `docs/the-road-to-wireframe-1-0-feature-set-philosophy-and-capability-maturity.md`
-  — why the 1.0 story needs these numbers.
-
-Skills to load:
-
-- `leta` first, for symbol navigation; prefer `leta show`, `leta refs`, and
-  `leta calls` over reading whole files.
-- `rust-router`, then `rust-performance-and-layout` for the measurement work
-  and `rust-unit-testing` for the assertion and fixture shape.
-- `kani` for the V-2 harness and `verus` for the V-1 proof; load
-  `rust-verification` first if the choice between them is ever in doubt.
-- `proptest` for V-3.
-- `arch-decision-records` when writing ADR-011.
-- `execplans` for keeping this document current.
-- `en-gb-oxendict` for spelling in every document touched.
-- `mapsplice` for the roadmap edit in EP-M6.
-- `nextest` if test selection becomes awkward while iterating.
+Skills: `leta` first, for symbol navigation. Then `rust-router`, routing to
+`rust-performance-and-layout` for the instrument, `rust-unit-testing` for
+fixtures and assertions, `rust-unsafe-and-ffi` for the `GlobalAlloc` safety
+comments, and `arch-crate-design` for the feature gating. `proptest` for V-1.
+`arch-decision-records` for ADR-011. `en-gb-oxendict` for every document.
+`mapsplice` for the roadmap edit. `execplans` for keeping this current.
+`nextest` if test selection becomes awkward. Do **not** load `kani` or `verus`
+for this item; see the verification plan.
 
 ## Progress
 
-- [x] (2026-08-23) Reconnaissance of the default codec path, existing
-  benchmark infrastructure, ADRs 008 to 010, the inventory, and repository
-  conventions.
-- [x] (2026-08-23) Research into allocation and copy measurement tooling:
-  Criterion baselines, `critcmp`, `dhat-rs`, `stats_alloc`, `iai-callgrind`,
-  and Valgrind DHAT copy mode.
-- [x] (2026-08-23) Draft plan written.
+- [x] (2026-08-23) Reconnaissance: default codec path, benchmark
+  infrastructure, ADRs 008-010, inventory, repository conventions.
+- [x] (2026-08-23) Research: Criterion baselines, `critcmp`, `dhat-rs`,
+  `stats_alloc`, `iai-callgrind`, Valgrind DHAT copy mode.
+- [x] (2026-08-23) Draft plan (revision 1).
+- [x] (2026-08-23) Six-lens design review; plan revised (revision 2).
 - [ ] Plan reviewed and approved.
-- [ ] Stage A — confirm stage boundaries; answer the two open questions.
-- [ ] Stage B — red tests.
-- [ ] EP-M1 — byte-aware, thread-local allocation instrument.
-- [ ] EP-M2 — Verus proof and Kani harness.
-- [ ] EP-M3 — stage probes and `test-support` shims.
-- [ ] EP-M4 — deterministic baseline report and snapshot.
-- [ ] EP-M5 — copied bytes, throughput, and latency.
-- [ ] EP-M6 — documentation, roadmap tick, and final gates.
+- [ ] Stage A — confirm boundaries; ship the roadmap/ADR-010 correction; answer
+  the two open questions; run the Small-class Valgrind experiment.
+- [ ] EP-M1 — the allocation instrument.
+- [ ] EP-M2 — production seams and probes.
+- [ ] EP-M3 — invariants and the inversion register.
+- [ ] EP-M4 — the generated record.
+- [ ] EP-M5 — copied bytes, timings, and publication.
 
 ## Surprises and discoveries
 
 - Observation: the "final default-path `Vec<u8>` copy between serialization and
-  `FrameCodec::wrap_payload`" named by the roadmap and ADR-010 is not located
-  where the phrase suggests.
-  Evidence: `LengthDelimitedFrameCodec::wrap_payload` is the identity function
-  (`src/codec.rs:260-285`), and `Bytes::from(Vec<u8>)`
-  (`src/app/outbound_encoding.rs:36`) takes ownership without copying. The
-  allocation and copy occur inside `bincode` because `Serializer::serialize`
-  returns `Vec<u8>` (`src/serializer.rs:61-113`).
-  Impact: the baseline must attribute outbound cost to `Serializer::serialize`.
-  ADR-011 records the correction so that item `11.1.2` targets the right code.
+  `FrameCodec::wrap_payload`" is not where the phrase suggests, and there is a
+  second payload-sized copy the roadmap does not mention.
+  Evidence: `src/codec.rs:283` (`wrap_payload` is the identity),
+  `src/app/outbound_encoding.rs:36` (`Bytes::from` takes ownership),
+  `src/serializer.rs:67-71` (the serializer must materialize a `Vec<u8>`), and
+  `src/codec.rs:248-257` (`LengthDelimitedEncoder::encode` delegates to
+  `tokio_util`, which copies the payload into the `Framed` write buffer).
+  Impact: `docs/roadmap.md:475-477` and `:491-492` and ADR-010's known-risks
+  section point item `11.1.2` at free operations. Stage A ships the correction.
 
-- Observation: `FrameCodec::frame_payload_bytes` has a copying default body
-  that the default codec does not use.
-  Evidence: `src/codec.rs:90` uses `Bytes::copy_from_slice`; the
-  `LengthDelimitedFrameCodec` implementation overrides it with `frame.clone()`
-  (`src/codec.rs:260-285`).
-  Impact: a protocol-native codec that omits the override pays a
-  payload-sized copy per frame. Out of scope here, but relevant to item
-  `11.2.3`, which covers a protocol-native codec.
+- Observation: `Bytes::from(Vec<u8>)` does not copy, but it is not free.
+  Evidence: `bytes-1.12.1/src/bytes.rs:947-967` heap-allocates a 24-byte
+  `Shared` control block whenever `len != capacity`, which is the normal case
+  for `bincode`'s amortized output vector.
+  Impact: the outbound row's expected allocation count is at least two, and
+  invariant V-3c states the control-block allocation explicitly so that
+  `11.1.2` is judged on whether it produces a right-sized buffer.
 
-- Observation: the existing allocation counter cannot support the baseline as
-  specified.
-  Evidence: `benches/codec_performance_alloc.rs:34-77` never reads
-  `layout.size()`, so it cannot report bytes, and it uses process-global
-  atomics, which its own documentation at lines 79-84 acknowledges makes it
-  noisy.
-  Impact: EP-M1 replaces it rather than extending it.
+- Observation: middleware pass-through is not allocation-free.
+  Evidence: `Service` is `#[async_trait]` (`src/middleware.rs:168-169`), so
+  every `call` boxes a future.
+  Impact: the claim is "zero *payload-sized* allocations", not "zero
+  allocations". Stated in V-3d and in ADR-011.
+
+- Observation: CI does not run `make test`.
+  Evidence: `.github/workflows/ci.yml` runs `make check-fmt`, `make lint`,
+  `make markdownlint`, `make nixie`, and `make test-workflow-contracts`; Rust
+  tests reach CI only through a pinned coverage action.
+  Impact: revision 1's anti-rot argument was false. Compounding it,
+  `Cargo.toml:15` sets `default-members = ["."]`, so `make test` does not build
+  `wireframe_testing`'s tests either. All invariant tests therefore live in the
+  root crate's `tests/`.
+
+- Observation: `wireframe_testing` cannot see anything gated on `test-support`.
+  Evidence: `wireframe_testing/Cargo.toml:16` declares
+  `features = ["testkit"]` and the crate has no `[features]` section. It
+  compiles inside the workspace only because feature unification papers over
+  the gap; `cargo build -p wireframe_testing` would break, as would docs.rs.
+  Impact: EP-M2 adds an opt-in `baseline` feature rather than enabling
+  `test-support` unconditionally, which would ship the shims to every consumer
+  of a published crate.
+
+- Observation: roadmap section 15 already owns the prover work.
+  Evidence: `docs/roadmap.md:583-718`; item `15.1.4` (line 611) adds the make
+  targets, `15.3.1` (line 651) the first Kani harnesses, `15.5.2` (line 704)
+  the `verus/` proof modules — the exact entry point revision 1 proposed to
+  occupy.
+  Impact: EP-M2 of revision 1 was cut. See `Decision log` D-8.
+
+- Observation: Cargo Dependabot runs daily with auto-merge.
+  Evidence: `.github/dependabot.yml` (`package-ecosystem: "cargo"`,
+  `interval: "daily"`) and `.github/workflows/dependabot-automerge.yml`.
+  Impact: any test asserting an absolute allocation figure would go red on bot
+  PRs until re-blessing became reflex. This is the direct cause of the
+  invariants-versus-measurements split.
+
+- Observation: the repository already has the right idiom for the invariant
+  half.
+  Evidence: `src/codec/tests.rs:63-71`, `:195-212`, `:214-232`, `:236-245`
+  assert zero-copy by pointer identity, parameterized across three codecs.
+  Impact: V-3a extends an existing convention instead of inventing one.
 
 - Observation: `docs/repository-layout.md` is referenced by `AGENTS.md:41-43`,
-  the documentation style guide, and the roadmap, but does not exist.
-  Evidence: no file matches `docs/repository-layout*`; only inbound references
-  were found.
-  Impact: out of scope for this item; recorded so it is not mistaken for a
-  search failure.
+  the style guide, and the roadmap, but does not exist.
+  Impact: out of scope; recorded so it is not mistaken for a search failure.
 
 - Observation: `src/app/codec_driver.rs:1-12` documents that the frame pipeline
-  applies protocol hooks, but no `ProtocolHooks::before_send` invocation was
-  located in `FramePipeline::process` (`:56-71`).
-  Evidence: reconnaissance traced the default path from `process_stream`
-  through `forward_response` to `flush_pipeline_output` without encountering
-  the call.
-  Impact: to be confirmed in Stage A. If the documentation is stale, raise a
-  separate issue; do not fix it here.
-
-- Observation: `insta` is not currently a dependency anywhere in the workspace,
-  and no snapshot test exists.
-  Evidence: no matches for `insta` in `Cargo.toml`, `Cargo.lock`, or any
-  source file.
-  Impact: EP-M4 introduces the first snapshot convention, documented in
-  `docs/developers-guide.md`.
-
-- Observation: no Verus proof and no Kani harness exists in the repository yet;
-  `make run-verus` is documented as expected to fail.
-  Evidence: `docs/developers-guide.md:376-379`; no `verus/` directory and no
-  `#[kani::proof]` attribute in the tree.
-  Impact: EP-M2 establishes both, which is why it carries its own tolerance and
-  is separable from the measurement work.
+  applies protocol `before_send` hooks, but no such invocation was located in
+  `FramePipeline::process` (`:56-71`).
+  Impact: to be confirmed in Stage A; if the documentation is stale, raise a
+  separate issue rather than fixing it here.
 
 ## Decision log
 
-- **D-1.** Decision: extend the existing benchmark support in
-  `wireframe_testing::codec_benchmarks` rather than starting a parallel
-  harness.
-  Rationale: `docs/developers-guide.md:332-352` already directs bench targets,
-  unit tests, and BDD fixtures to that module. A second harness would fragment
-  the convention and duplicate the payload-class definitions.
-  Date/Author: 2026-08-23, planning agent.
+- **D-1.** Extend `wireframe_testing::codec_benchmarks` rather than starting a
+  parallel harness. `docs/developers-guide.md:331-352` already directs bench
+  targets, unit tests, and BDD fixtures there. 2026-08-23.
 
-- **D-2.** Decision: define a copied byte as a byte passed to `memcpy`,
-  `memmove`, `strcpy`, or `bcopy`, and measure it with
-  `valgrind --tool=dhat --mode=copy`.
-  Rationale: no definition existed anywhere in the repository. The copies that
-  matter occur inside `bincode` and `tokio_util`, so no `wireframe`-owned
-  counter can see them; only an external observer can. Valgrind's DHAT copy
-  mode is documented for exactly this purpose (Valgrind manual, section 10.5)
-  and its own documentation shows a Rust `extend_from_slice` stack, confirming
-  that Rust slice copies are intercepted. Alternatives rejected: the `dhat`
-  crate, whose documentation states it does not profile copy functions and
-  which is self-described as experimental with low maintenance priority;
-  `stats_alloc`, which gives allocation bytes but not copy bytes;
-  `iai-callgrind`, which would add a benchmark harness dependency for a
-  measurement that a direct Valgrind invocation already provides.
-  Date/Author: 2026-08-23, planning agent.
+- **D-2.** Define a copied byte as a byte passed to `memcpy`, `memmove`,
+  `strcpy`, or `bcopy`, measured with `valgrind --tool=dhat --mode=copy`. No
+  definition existed in the repository. The copies that matter occur inside
+  `bincode` and `tokio_util`, so no `wireframe`-owned counter can see them.
+  Rejected: the `dhat` crate, whose documentation states it does not profile
+  copy functions and which is self-described as experimental; `stats_alloc`,
+  which gives allocation bytes but not copies; `iai-callgrind`, which adds a
+  harness dependency for something a direct Valgrind invocation provides.
+  2026-08-23.
 
-- **D-3.** Decision: allocation counting is thread-local, not process-global.
-  Rationale: the existing process-global counter is documented as noisy, and a
-  baseline that varies between runs cannot support the thresholds that item
-  `10.2.2` must set. Thread-local counting makes the deterministic counters
-  genuinely deterministic and lets the measurement run inside the normal
-  parallel test harness rather than requiring serialization.
-  Date/Author: 2026-08-23, planning agent.
+- **D-3.** Allocation counting is thread-local, and escape is an error rather
+  than a silent under-count. A thread-local counter alone would report zero
+  when work escapes, and zero is also what a successful migration looks like;
+  an instrument whose failure mode is indistinguishable from its success signal
+  cannot support a threshold. 2026-08-23, revised after design review.
 
-- **D-4.** Decision: "request hooks" means the client-side hooks in
-  `src/client/hooks.rs`. Server-side `WireframeProtocol` hooks and client
-  preamble replay are excluded.
-  Rationale: ADR-008 lists `BeforeSendHook` among the surfaces it governs, and
-  `docs/frame-vec-u8-inventory.md:200-204` groups the client hooks as the hook
-  surface for this migration. Server-side protocol hooks are inert on the
-  default path because `protocol` is `None`. Preamble leftovers are treated by
-  the inventory (lines 212-222) as a separate compatibility surface and are
-  scheduled for item `12.2.2`.
-  Date/Author: 2026-08-23, planning agent.
+- **D-4.** "Request hooks" means the client-side hooks in `src/client/hooks.rs`.
+  Server-side `WireframeProtocol` hooks are inert on the default path
+  (`protocol` is `None`) and client preamble replay is scheduled for item
+  `12.2.2` (`docs/frame-vec-u8-inventory.md:212-222`). Because the default
+  path registers no hooks, the row is documented as a hook-shape cost model
+  with a stated synthetic hook body, not as a default-path figure. 2026-08-23.
 
-- **D-5.** Decision: baseline the default codec only; do not include a
-  protocol-native codec.
-  Rationale: `docs/roadmap.md:472-474` says "on the default codec path". The
-  precursor document
-  `docs/zero-copy-frame-and-payload-migration-roadmap.md` item 1.2.1 mentions a
-  protocol-native codec, but `docs/roadmap.md` is the governing artefact and
-  item `11.2.3` is where a protocol-native codec is explicitly required. Where
-  the existing workload matrix makes a Hotline figure free to collect, it is
-  recorded as supplementary context and clearly marked non-normative.
-  Date/Author: 2026-08-23, planning agent.
+- **D-5.** Baseline the default codec only. `docs/roadmap.md:472-474` says "on
+  the default codec path"; item `11.2.3` is where a protocol-native codec is
+  required. Hotline figures are recorded as supplementary and marked
+  non-normative where the existing matrix makes them free. 2026-08-23.
 
-- **D-6.** Decision: deterministic counters are normative and asserted in
-  tests; throughput and latency are indicative and never asserted.
-  Rationale: allocation events, allocated bytes, and copied bytes are
-  identical on every machine, so they can be committed and guarded. Wall-clock
-  figures are hardware-dependent, and asserting on them produces flaky tests
-  and false confidence. Item `10.2.2` must therefore express any timing
-  threshold as a relative delta measured within a single session on a single
-  machine, not as an absolute number compared across machines.
-  Date/Author: 2026-08-23, planning agent.
+- **D-6.** Assert invariants; record measurements. No test asserts an absolute
+  number. Allocation counts are properties of `bincode`, `bytes`,
+  `tokio-util`, `libstd`, the toolchain, and the optimization profile as much
+  as of `wireframe`; `Vec`'s growth strategy is an unspecified implementation
+  detail, and Cargo Dependabot runs daily. A committed number would therefore
+  produce red bot PRs whose only remedy is re-blessing, and a re-blessing
+  reflex destroys exactly the before-and-after comparability items `10.2.2`,
+  `11.2.3`, and `13.2.1` need. Invariants such as "at least one payload-sized
+  allocation" survive dependency churn and invert precisely when the migration
+  lands. 2026-08-23, revised after design review.
 
-- **D-7.** Decision: expose crate-private stage entry points through
-  `test-support`-gated shims rather than re-implementing them in the probes.
-  Rationale: a probe that re-implements the code it measures verifies only
-  itself; a mutation in production code would leave the baseline unchanged. The
-  repository already uses `test-support` for this class of widening, for
-  example `src/connection/test_support.rs`.
-  Date/Author: 2026-08-23, planning agent.
+- **D-7.** Extract production seams rather than re-implementing steps in
+  probes. A probe that re-implements what it measures verifies only itself; a
+  mutation in production code would leave the baseline unchanged. Four
+  extractions are authorized, each moving an existing statement sequence into a
+  named function called from its original site. 2026-08-23.
 
-- **D-8.** Decision: both Verus and Kani are used, for different obligations.
-  Rationale: the accounting property is over unbounded sequences, which only a
-  prover can discharge, but the code that runs is `unsafe` and uses
-  thread-local storage, which Verus cannot model. Kani closes that gap for
-  bounded sequences against the real implementation. Using only one would leave
-  either the long-sequence case or the real-code case unverified. The residual
-  gap between them is stated in the verification plan rather than concealed.
-  Date/Author: 2026-08-23, planning agent.
+- **D-8.** No Verus proof and no Kani harness in this item. Roadmap section 15
+  owns prover bring-up: `15.1.4` adds the targets, `15.3.1` the first harnesses,
+  `15.5.2` the `verus/` modules that revision 1 proposed to pre-empt. Beyond
+  the scheduling conflict, the formal machinery was aimed at counter
+  arithmetic, whereas this instrument's realistic failure mode is
+  misattribution — wrong scope, wrong thread, wrong profile, uninstalled
+  allocator — which V-1's property tests and V-2's seeded fault attack
+  directly. The arithmetic is covered by an eight-case `rstest` table.
+  2026-08-23, decided at design review.
 
-- **D-9.** Decision: adopt `insta` as a new development dependency.
-  Rationale: the rendered baseline is multivariant output across stages and
-  payload classes whose format consistency is the point of the artefact, which
-  is exactly the case the project's testing policy reserves for snapshot
-  testing. Re-blessing via `cargo insta accept` gives a clean workflow for the
-  deliberate re-baselining that item `11.1.2` will require.
-  Date/Author: 2026-08-23, planning agent.
+- **D-9.** `insta` snapshots the renderer's format over fixed synthetic rows,
+  never over live measurements. The rendered report is genuinely multivariant
+  output whose format consistency matters, which is what snapshot testing is
+  for; driving it from synthetic rows means the snapshot changes only when a
+  human changes the format. 2026-08-23, revised after design review.
+
+- **D-10.** The recorded document is generated between marker comments, not
+  transcribed. A generated document cannot drift from the renderer, which
+  removes both the byte-identity hand-paste step and one of the two mechanisms
+  revision 1 used to guard the same property. 2026-08-23, decided at design
+  review.
+
+- **D-11.** Measure the framed-encoder copy as a fifth row. A baseline scoped
+  to `encode_message_frame` would record roughly half the outbound payload
+  traffic, because `LengthDelimitedEncoder::encode` (`src/codec.rs:248-257`)
+  copies the payload into the `Framed` write buffer outside that boundary.
+  Item `10.2.2` would then set thresholds against half the traffic, and item
+  `11.1.2` would appear to remove "the final copy" while a payload-sized copy
+  per frame remained. 2026-08-23, decided at design review.
 
 ## Outcomes and retrospective
 
-To be completed at EP-M6. Before setting this plan to `COMPLETE`, reconcile
-every discovery in `Surprises and discoveries` against the upstream artefacts
-listed in `Conformance basis`. In particular, the correction about where the
-default path actually copies (see the first discovery) affects the wording of
-`docs/roadmap.md` items `10.2.2` and `11.1.2` and of ADR-010's known-risks
-section. Either update those artefacts or record in this log why the existing
-wording remains adequate. Do not mark the plan complete while that
-reconciliation is outstanding.
+To be completed at EP-M5. Before setting this plan to `COMPLETE`, reconcile
+every entry in `Surprises and discoveries` against the upstream artefacts in
+`Conformance basis`. The copy analysis affects the wording of
+`docs/roadmap.md` items `10.2.2` and `11.1.2` and ADR-010's known-risks
+section; Stage A ships that correction, and the retrospective must confirm it
+landed. Do not mark the plan complete while an upstream change remains
+unrecorded.
 
 ## Artefacts and notes
 
 To be populated during implementation with the red, green, and refactor
-transcripts for each milestone, the Verus and Kani output, the two
-`make baseline-copy` runs used to demonstrate reproducibility, and the seeded
-fault transcripts that discharge the non-vacuity requirements in V-1, V-2,
-V-4, and V-5.
+transcripts per milestone; the Stage A Valgrind experiment result that decides
+the `Small` class's scope; the dev-versus-coverage profile comparison from
+EP-M1; the old and new `wrap_allocs_<n>` values recorded when the bench
+allocator is substituted; the `proptest` classification output discharging
+V-1's non-vacuity requirement; and the two `make baseline-copy` runs
+demonstrating reproducibility.
+
+## Revision note
+
+**Revision 2 (2026-08-23)** follows a six-lens design review that examined
+structural integrity, alternatives, measurement validity, interface contracts,
+operational failure modes, and long-term viability.
+
+What changed, and why:
+
+- **Invariants replace committed numbers as the asserted artefact.** Cargo
+  Dependabot runs daily with auto-merge, and allocation counts are properties
+  of three third-party crates and the toolchain. Committed numbers would have
+  become a rubber stamp within a fortnight. The numbers are still captured;
+  they are recorded with an environment stamp rather than asserted.
+- **The Verus proof and Kani harness were cut.** Roadmap section 15 already
+  owns prover bring-up, including the exact `verus/` entry point revision 1
+  proposed to occupy, and the machinery was aimed at the part of the design
+  least likely to be wrong.
+- **Six hard defects were fixed**: the decode shim could not compile across a
+  module boundary; `invoke_before_send_hooks` was attributed to the wrong type
+  and could not be reached without a transport; the outbound shim would have
+  leaked a `pub(crate)` type through a public signature; the middleware stage
+  had no seam and would have been re-implemented; `wireframe_testing` could not
+  see `test-support` at all; and `Stage` and `PayloadClass` lacked the `Ord`
+  the sort required.
+- **Three factual corrections**: `Bytes::from(Vec<u8>)` allocates a control
+  block even though it does not copy; `LengthDelimitedEncoder::encode` performs
+  a second payload-sized copy that item `11.1.2` cannot remove; and middleware
+  pass-through boxes a future per call, so it is not allocation-free.
+- **The instrument gained an escape detector and an installation check**,
+  because both of its silent failure modes report zero, and zero is what
+  success looks like.
+- **The `noop` calibration was replaced by an N-versus-2N slope**, which
+  cancels fixed costs exactly and gives a linearity check for free.
+- **The `Small`-class undercount caveat became a Stage A experiment**, since
+  the inlining hypothesis behind it was never tested and is probably wrong.
+- **Scope tightened** from six milestones to five, and the tolerance from
+  32 files and 2,500 lines to 20 and 1,400, matching the completed `9.6.1`
+  plan.
+
+Effect on remaining work: Stage A now ships an independently valuable
+docs-only correction before any instrument exists, and the measurement work
+that follows is smaller, introduces one new tool rather than three, and
+produces an artefact that answers "did the copy go away?" with a test that
+inverts rather than a number that needs interpreting.

--- a/docs/execplans/10-2-1-capture-baselines.md
+++ b/docs/execplans/10-2-1-capture-baselines.md
@@ -808,8 +808,11 @@ Milestone EP-M5.
   amortizes clock resolution across a batch. Use `Throughput::Bytes` for
   decode, encode, and the framed write; `Throughput::Elements(1)` for
   middleware and read-only hooks, where a bytes figure would report a pointer
-  move in TiB/s and be quoted out of context. `black_box` the loop body, not
-  just the aggregate, or the no-work stages are deleted by the optimizer.
+  move in TiB/s and be quoted out of context. Apply `std::hint::black_box` to
+  the loop body, not just the aggregate, or the no-work stages are deleted by
+  the optimizer. Import it from `std::hint`, not from `criterion`: the
+  re-export is deprecated as of Criterion 0.8 and the existing benches were
+  migrated off it in commit `a31c01a`.
 - **Documentation**:
   - `docs/frame-vec-u8-baseline.md` — the generated tables, the inversion
     register from EP-M3, the provenance stamp, and the falsifiable claim about
@@ -1028,6 +1031,19 @@ for this item; see the verification plan.
   assert zero-copy by pointer identity, parameterized across three codecs.
   Impact: V-3a extends an existing convention instead of inventing one.
 
+- Observation: `main` upgraded Criterion from 0.5.1 to 0.8.2 while this plan
+  was being drafted, and three dependency bumps landed alongside it.
+  Evidence: commits `a31c01a` (Criterion upgrade and `black_box` deprecation
+  fix, touching `benches/codec_performance.rs` and
+  `benches/codec_performance_alloc.rs`), `0210f51`, `5ff9ba2`, and `2e16058`.
+  Impact: two-fold. New bench code must import `std::hint::black_box` rather
+  than `criterion::black_box`. And the churn is direct evidence for decision
+  D-6: four dependency-affecting commits reached `main` inside a single day,
+  which is exactly the cadence that would have kept a committed allocation
+  figure permanently red. The API this plan relies on — `iter_custom`,
+  `Throughput::Bytes`, `Throughput::Elements`, and `BenchmarkId` — is
+  unchanged in 0.8.2.
+
 - Observation: `docs/repository-layout.md` is referenced by `AGENTS.md:41-43`,
   the style guide, and the roadmap, but does not exist.
   Impact: out of scope; recorded so it is not mistaken for a search failure.
@@ -1119,6 +1135,13 @@ for this item; see the verification plan.
   `11.1.2` would appear to remove "the final copy" while a payload-sized copy
   per frame remained. 2026-08-23, decided at design review.
 
+- **D-12.** Target Criterion 0.8.2, the version now on `main`, and import
+  `black_box` from `std::hint`. Commit `a31c01a` upgraded the crate and
+  migrated the existing benches off the deprecated `criterion::black_box`
+  re-export; new bench code follows that pattern rather than reintroducing it.
+  The API surface this plan depends on is unchanged across the upgrade.
+  2026-08-23, recorded when rebasing onto `main`.
+
 ## Outcomes and retrospective
 
 To be completed at EP-M5. Before setting this plan to `COMPLETE`, reconcile
@@ -1177,6 +1200,11 @@ What changed, and why:
 - **Scope tightened** from six milestones to five, and the tolerance from
   32 files and 2,500 lines to 20 and 1,400, matching the completed `9.6.1`
   plan.
+
+**Rebase onto `main` (2026-08-23)** brought Criterion 0.8.2 and three
+dependency bumps. The plan gained decision D-12 and a discovery entry: new
+bench code imports `std::hint::black_box`, and the churn itself is evidence for
+the invariants-not-numbers split.
 
 Effect on remaining work: Stage A now ships an independently valuable
 docs-only correction before any instrument exists, and the measurement work


### PR DESCRIPTION
## Summary

Draft ExecPlan for roadmap item **10.2.1** — capture allocation, copied-byte,
throughput, and latency baselines for inbound decode, middleware pass-through,
request hooks, and outbound encode on the default codec path.

Plan document:
[`docs/execplans/10-2-1-capture-baselines.md`](https://github.com/leynos/wireframe/blob/10-2-1-capture-baselines/docs/execplans/10-2-1-capture-baselines.md)

This PR is **documentation only**. No Rust source, tests, build configuration,
or dependency manifests are touched. The plan requires approval before
implementation begins.

## The central design decision

The plan separates two kinds of artefact:

- **Invariants** — statements such as "outbound encode performs at least one
  payload-sized allocation" — are asserted by tests. They survive a dependency
  bump and invert exactly when item 11.1.2 lands.
- **Measurements** — the concrete counts, bytes, and nanoseconds — are recorded
  with a full environment stamp and are explicitly *not* asserted.

The reason is `.github/dependabot.yml`: Cargo updates run **daily** with
auto-merge configured. Allocation counts are properties of `bincode`, `bytes`,
`tokio-util`, `libstd`, and the toolchain as much as of `wireframe`, so a
committed figure would have gone red on bot PRs until re-blessing became
reflex — destroying the before-and-after comparability that items 10.2.2,
11.2.3, and 13.2.1 need.

## Substantive finding: the roadmap names the wrong copy

Reviewers should look at this first, because it changes what item 11.1.2 must
do. The roadmap and ADR-010 describe "the final default-path `Vec<u8>` copy
between serialization and `FrameCodec::wrap_payload`". That phrase names two
operations that do not copy, and misses two costs that do.

Free on the default codec:

- `LengthDelimitedFrameCodec::wrap_payload` (`src/codec.rs:283`) is the
  identity function; `type Frame = Bytes` (`:262`).
- `Bytes::from(Vec<u8>)` (`src/app/outbound_encoding.rs:36`) takes ownership of
  the vector's buffer.

Not free:

1. `Serializer::serialize` returns `Vec<u8>` (`src/serializer.rs:67-71`), so
   `bincode` allocates a vector and copies the payload into it. **This** is
   what item 11.1.2 can remove.
2. `Bytes::from(Vec<u8>)` heap-allocates a 24-byte `Shared` control block when
   `len != capacity` (`bytes-1.12.1/src/bytes.rs:947-967`) — the normal case,
   because `bincode` grows its output amortized.
3. `LengthDelimitedEncoder::encode` (`src/codec.rs:248-257`) delegates to
   `tokio_util`, which copies the payload **again** into the `Framed` write
   buffer. This is outside `encode_message_frame`, and item 11.1.2 cannot
   remove it.

A baseline scoped to `encode_message_frame` would therefore record roughly half
the outbound payload traffic, and item 10.2.2 would set thresholds against it.
The plan measures the framed encoder as a fifth row and ships a correction to
`docs/roadmap.md:475-477` and `:491-492` plus ADR-010 as its first, standalone
commit.

## Review process

A six-lens design review (structural integrity, alternatives, measurement
validity, interface contracts, operational failure modes, long-term viability)
returned **revise** on the first draft. Every finding below was verified
against the code before being acted on.

Dropped from the draft:

- **The Verus proof and Kani harness.** `docs/roadmap.md:583-718` is a
  dedicated formal-verification phase; item 15.1.4 adds `make kani`/`make
  verus`, 15.3.1 adds the first Kani harnesses, and 15.5.2 adds the `verus/`
  proof modules the draft proposed to occupy. The machinery was also aimed at
  counter arithmetic, whereas this instrument's realistic failure mode is
  misattribution. Property tests and a seeded-fault control attack that
  directly.
- The `insta` gate over live measurements, in favour of a snapshot over fixed
  synthetic rows that tests the renderer's format only.
- The hand-transcribed baseline table, in favour of a generated document region.

Defects fixed (each would have failed to compile or measured the wrong thing):

| Defect | Evidence |
| --- | --- |
| Decode shim unreachable across a module boundary | `parse_envelope` is a bare private `fn` at `src/app/inbound_handler.rs:74` |
| Hooks attributed to the wrong type, and unreachable without a transport | `invoke_before_send_hooks` is on `WireframeClient` at `src/client/messaging.rs:335` |
| Outbound shim leaks a private type through a public signature | `EncodedFrame` is `pub(crate)` at `src/app/outbound_encoding.rs:18` |
| Middleware stage had no seam and would be re-implemented | `src/app/frame_handling/response.rs:41-55` |
| `wireframe_testing` cannot see `test-support` | `wireframe_testing/Cargo.toml:16` enables only `testkit` |
| Report sort has no `Ord` to sort by | `Stage` and `PayloadClass` derive neither |

*Caption: defects found by the design review and verified against the code.*

Two false premises in the draft were also corrected: CI does not run
`make test` (`.github/workflows/ci.yml` runs `check-fmt`, `lint`,
`markdownlint`, `nixie`, and `test-workflow-contracts`, with Rust tests
reaching CI only via a coverage action), and `Cargo.toml:15` sets
`default-members = ["."]`, so `make test` would not build `wireframe_testing`'s
tests either. All invariant tests therefore live in the root crate's `tests/`.

The plan also reuses the repository's existing pointer-identity idiom for
zero-copy assertions (`src/codec/tests.rs:63-71`, `:195-232`, `:236-245`)
rather than inventing a new one.

Scope tightened from six milestones to five, and the tolerance from 32 files
and 2,500 lines to 20 and 1,400 — matching the completed 9.6.1 plan.

## Validation

`make markdownlint` (including the typos en-GB-oxendict chain) and `make nixie`
both pass. No Rust gates were run because no Rust changed.

## Follow-ups recorded, not actioned

- `src/app/codec_driver.rs:1-12` documents that the frame pipeline applies
  protocol `before_send` hooks, but no such invocation was located in
  `FramePipeline::process` (`:56-71`). To be confirmed in Stage A; an issue if
  it is a genuine defect.
- `docs/repository-layout.md` is referenced by `AGENTS.md:41-43`, the
  documentation style guide, and the roadmap, but does not exist.

## References

- Lody session: https://lody.ai/leynos/sessions/a923b07c-ac76-44ff-9359-8656a9ceb431
- Roadmap item 10.2.1: `docs/roadmap.md:472-474`
- ADR-008, ADR-009, ADR-010, and `docs/frame-vec-u8-inventory.md`
- Issue [#538](https://github.com/leynos/wireframe/issues/538) — the serializer-to-codec bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a reviewed execution plan for establishing migration baselines on the default codec path.

Enhancements:
- Add a detailed execution plan for capturing default codec path allocation, copied-byte, throughput, and latency baselines while separating durable invariants from environment-dependent measurements.
- Document the corrected outbound data-flow analysis, including serializer allocation, framed encoder copying, and the scope of the planned measurements.
- Define staged implementation, validation, reporting, provenance, and review requirements for future baseline instrumentation.

Documentation:
- Add the draft roadmap execution plan at `docs/execplans/10-2-1-capture-baselines.md`.