### PR TITLE
Cancel abandoned server accept loops (#656)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ loom = "0.7.2"
 async-stream = "0.3.6"
 serial_test = "3.2.0"
 metrics-util = "0.20.0"
-tracing-test = "0.2.5"
+tracing-test = { version = "0.2.5", features = ["no-env-filter"] }
 mockall = "0.15.0"
 criterion = "0.8.2"
 cap-std = { version = "4.0.2", features = ["fs_utf8"] }

--- a/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
+++ b/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
@@ -355,7 +355,11 @@ ADR as its source of truth.
 Implementation work governed by this ADR should demonstrate:
 
 - no change to externally contracted behaviour in cancellation, fairness,
-  backpressure, or shutdown; the intentional behaviour changes are recorded in
+  backpressure, or graceful shutdown, except for the documented
+  server-supervisor drop/abort contract: abandoning `run_with_shutdown`
+  eventually cancels its accept loops and releases the listener; the graceful
+  shutdown path and in-flight connection-task drain remain unchanged. The
+  other intentional behaviour changes are recorded in
   [ADR 012](adr-012-prepared-application-and-connection-runtime.md) (factory
   evaluation frequency, readiness timing, startup error surfacing) and
   [ADR 013](adr-013-client-pool-scheduler-and-slot-ownership.md) (lease-drop

--- a/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
+++ b/docs/adr-011-runtime-ownership-and-task-lifetime-boundaries.md
@@ -233,6 +233,22 @@ Examples governed by this rule include:
 - borrowing a prepared route table from the application root during one
   connection task.
 
+### Server supervisor cancellation
+
+`WireframeServer::run_with_shutdown` is a supervisor for independently
+scheduled accept-loop tasks. It owns their `CancellationToken` and
+`TaskTracker`, and `src/server/runtime.rs` holds a named `drop_guard_ref()`
+borrow in the supervisor frame. If the supervisor future is dropped, including
+through `JoinHandle::abort()`, the guard cancels the accept loops so they
+eventually release their listener references. The guarantee is eventual: the
+worker tasks must be scheduled to observe cancellation.
+
+When the caller's shutdown future resolves, the supervisor follows the existing
+graceful path and waits for tracked work. The drop guard does not cancel
+connection tasks that have already been accepted; they retain the existing
+graceful-drain semantics. The borrowed guard is a one-time application of R3,
+not a per-iteration handle clone.
+
 ### R4. Move sole-owned values directly
 
 Values with exactly one runtime owner should be stored directly, even when the
@@ -349,6 +365,8 @@ Implementation work governed by this ADR should demonstrate:
 - benchmark coverage for affected hot paths;
 - tests that prove actors and connection tasks terminate after their final
   owning handle is dropped or cancellation is requested;
+- server-supervisor tests that prove graceful shutdown remains successful and
+  that dropping or aborting the supervisor eventually releases its listener;
 - a recorded lint-or-checklist disposition per rule under
   [#649](https://github.com/leynos/wireframe/issues/649): R3 and R4 have
   grep-able signatures and are lint candidates; R1, R2, R5, R6, and R7 are

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -85,6 +85,19 @@ cancels the accept loops and waits for tracked work. The drop guard does not
 cancel connection tasks that were already accepted; those tasks continue under
 the existing graceful-drain semantics.
 
+The private `SupervisorLifecycle` state starts as `Running` and records one
+terminal outcome: `Graceful` when the shutdown future resolves, `Dropped` when
+the supervisor frame is abandoned, or `Finished` when tracked work ends before
+either cancellation path. Cloned lifecycle handles pass the recorded
+cancellation reason to each accept loop, which records its own exit after it
+observes cancellation. The supervisor cancellation counter and accept-loop
+exit counter (`wireframe_server_supervisor_cancellations_total` and
+`wireframe_server_accept_loops_exited_total`) use only the bounded `reason`
+values `"graceful"` and `"dropped"`; direct future drops and
+`JoinHandle::abort()` therefore have the same `"dropped"` reason. The
+corresponding static tracing events are `server_supervisor_cancellation` and
+`server_accept_loop_exited`, each with the same `reason` field.
+
 ## Allowed aliases and prohibited mixing
 
 | Canonical term | Allowed aliases                     | Avoid in the same context                 |

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -70,6 +70,21 @@ boundaries for Epic 635:
 These records are proposed, not yet accepted; the review checklist derived from
 ADR 011's rules lands with their implementation epic.
 
+### Server supervisor lifecycle
+
+`WireframeServer::run_with_shutdown` owns the server's
+`CancellationToken` and `TaskTracker` while it supervises the worker accept
+loops. A named `drop_guard_ref()` guard cancels the token when the supervisor
+future is dropped, including when its `JoinHandle` is aborted. The accept loops
+then stop accepting and release their listener references. This release is
+eventual rather than synchronous because the loops must be scheduled to observe
+the cancellation.
+
+When the supplied shutdown future resolves, the existing graceful path still
+cancels the accept loops and waits for tracked work. The drop guard does not
+cancel connection tasks that were already accepted; those tasks continue under
+the existing graceful-drain semantics.
+
 ## Allowed aliases and prohibited mixing
 
 | Canonical term | Allowed aliases                     | Avoid in the same context                 |

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -1466,15 +1466,20 @@ signal, and normalizes accept-loop backoff settings through
 `bind_existing_listener` to transition into the `Bound` typestate, inspect the
 bound address, or rebind later.[^17]
 
-`run` awaits Ctrl+C, while `run_with_shutdown` cancels all worker tasks when
-the supplied future resolves.[^18] Each worker runs `accept_loop`, which clones
-the factory, rewinds leftover preamble bytes, and hands the stream to the
-application. Transient accept failures trigger exponential backoff capped by
-the configured maximum delay.[^18][^19] Preamble hooks support asynchronous
-success handlers and asynchronous failure callbacks that receive the stream,
-enabling replies or decode-error logging before the application runs. An
-optional `preamble_timeout` caps how long `read_preamble` waits; timeouts use
-the failure callback path.[^20]
+`run` awaits Ctrl+C, while `run_with_shutdown` cancels the worker accept loops
+and waits for tracked work when the supplied future resolves.[^18] Dropping the
+`run_with_shutdown` future, including by aborting its `JoinHandle`, also
+cancels the accept loops and eventually releases the listener. This cleanup is
+eventual rather than synchronous: the loops must be scheduled to observe the
+cancellation. In-flight connection tasks are not cancelled and may continue
+until they finish. Each worker runs `accept_loop`, which clones the factory,
+rewinds leftover preamble bytes, and hands the stream to the application.
+Transient accept failures trigger exponential backoff capped by the configured
+maximum delay.[^18][^19] Preamble hooks support asynchronous success handlers
+and asynchronous failure callbacks that receive the stream, enabling replies
+or decode-error logging before the application runs. An optional
+`preamble_timeout` caps how long `read_preamble` waits; timeouts use the
+failure callback path.[^20]
 
 `spawn_connection_task` wraps each accepted stream in `read_preamble` and
 `RewindStream`, records connection panics, and logs failures without crashing

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -52,6 +52,48 @@ pub const POOL_BOOKKEEPING_POISON_RECOVERIES: &str =
 /// ```
 pub const CODEC_ERRORS: &str = "wireframe_codec_errors_total";
 
+/// Name of the counter tracking server-supervisor cancellation requests.
+///
+/// The `reason` label is always either `"graceful"`, when the supplied
+/// shutdown future resolved, or `"dropped"`, when the supervisor future was
+/// dropped before graceful shutdown completed. The latter includes task abort.
+///
+/// ```plaintext
+/// # HELP wireframe_server_supervisor_cancellations_total Count of server-supervisor cancellation requests.
+/// # TYPE wireframe_server_supervisor_cancellations_total counter
+/// wireframe_server_supervisor_cancellations_total{reason="graceful"} 1
+/// ```
+pub const SERVER_SUPERVISOR_CANCELLATIONS: &str = "wireframe_server_supervisor_cancellations_total";
+
+/// Name of the counter tracking accept loops that observed cancellation.
+///
+/// The `reason` label has the same bounded vocabulary as
+/// [`SERVER_SUPERVISOR_CANCELLATIONS`].
+///
+/// ```plaintext
+/// # HELP wireframe_server_accept_loops_exited_total Count of accept loops that exited after cancellation.
+/// # TYPE wireframe_server_accept_loops_exited_total counter
+/// wireframe_server_accept_loops_exited_total{reason="dropped"} 2
+/// ```
+pub const SERVER_ACCEPT_LOOPS_EXITED: &str = "wireframe_server_accept_loops_exited_total";
+
+/// Bounded reasons for server-supervisor cancellation metrics.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ServerCancellationReason {
+    Graceful,
+    Dropped,
+}
+
+impl ServerCancellationReason {
+    /// Return the stable metric and tracing label value for this reason.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Graceful => "graceful",
+            Self::Dropped => "dropped",
+        }
+    }
+}
+
 /// Direction of frame processing.
 #[derive(Clone, Copy)]
 pub enum Direction {
@@ -168,3 +210,21 @@ pub fn inc_codec_error(error_type: &'static str, recovery_policy: &'static str) 
 
 #[cfg(not(feature = "metrics"))]
 pub fn inc_codec_error(_error_type: &'static str, _recovery_policy: &'static str) {}
+
+/// Record a server-supervisor cancellation request with a bounded reason.
+#[cfg(feature = "metrics")]
+pub(crate) fn inc_server_supervisor_cancellation(reason: ServerCancellationReason) {
+    counter!(SERVER_SUPERVISOR_CANCELLATIONS, "reason" => reason.as_str()).increment(1);
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn inc_server_supervisor_cancellation(_reason: ServerCancellationReason) {}
+
+/// Record an accept loop that exited after supervisor cancellation.
+#[cfg(feature = "metrics")]
+pub(crate) fn inc_server_accept_loop_exit(reason: ServerCancellationReason) {
+    counter!(SERVER_ACCEPT_LOOPS_EXITED, "reason" => reason.as_str()).increment(1);
+}
+
+#[cfg(not(feature = "metrics"))]
+pub(crate) fn inc_server_accept_loop_exit(_reason: ServerCancellationReason) {}

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -5,7 +5,10 @@ mod backoff;
 #[cfg(test)]
 mod tests;
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU8, Ordering},
+};
 
 #[cfg(test)]
 pub(super) use accept::MockAcceptListener;
@@ -14,7 +17,11 @@ pub use backoff::BackoffConfig;
 use futures::Future;
 use log::warn;
 use tokio::{select, signal};
-use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tokio_util::{
+    sync::{CancellationToken, DropGuardRef},
+    task::TaskTracker,
+};
+use tracing::Instrument;
 
 use super::{AppFactory, Bound, ServerError, WireframeServer};
 use crate::{
@@ -22,9 +29,118 @@ use crate::{
     codec::FrameCodec,
     frame::FrameMetadata,
     message::{DecodeWith, EncodeWith},
+    metrics::{ServerCancellationReason, inc_server_supervisor_cancellation},
     preamble::Preamble,
     serializer::Serializer,
 };
+
+const SUPERVISOR_RUNNING: u8 = 0;
+const SUPERVISOR_GRACEFUL: u8 = 1;
+const SUPERVISOR_DROPPED: u8 = 2;
+const SUPERVISOR_FINISHED: u8 = 3;
+
+/// Shares one terminal cancellation reason with the supervisor's accept loops.
+///
+/// The state only outlives the supervisor while an accept loop needs it to
+/// record its own exit. It never owns a listener or task tracker.
+#[derive(Clone, Debug)]
+pub(in crate::server) struct SupervisorLifecycle {
+    state: Arc<AtomicU8>,
+}
+
+impl SupervisorLifecycle {
+    fn new() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(SUPERVISOR_RUNNING)),
+        }
+    }
+
+    fn record_graceful_cancellation(&self) {
+        self.state.store(SUPERVISOR_GRACEFUL, Ordering::Release);
+        record_supervisor_cancellation(ServerCancellationReason::Graceful);
+    }
+
+    fn record_dropped_cancellation(&self) {
+        if self
+            .state
+            .compare_exchange(
+                SUPERVISOR_RUNNING,
+                SUPERVISOR_DROPPED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            record_supervisor_cancellation(ServerCancellationReason::Dropped);
+        }
+    }
+
+    fn record_completion_without_cancellation(&self) {
+        self.state.store(SUPERVISOR_FINISHED, Ordering::Release);
+    }
+
+    pub(in crate::server) fn cancellation_reason(&self) -> ServerCancellationReason {
+        match self.state.load(Ordering::Acquire) {
+            SUPERVISOR_GRACEFUL => ServerCancellationReason::Graceful,
+            SUPERVISOR_DROPPED | SUPERVISOR_RUNNING | SUPERVISOR_FINISHED => {
+                ServerCancellationReason::Dropped
+            }
+            _ => ServerCancellationReason::Dropped,
+        }
+    }
+}
+
+fn record_supervisor_cancellation(reason: ServerCancellationReason) {
+    inc_server_supervisor_cancellation(reason);
+    tracing::info!(
+        event = "server_supervisor_cancellation",
+        reason = reason.as_str(),
+        "server_supervisor_cancellation",
+    );
+}
+
+/// Cancels accept loops when its supervisor frame is abandoned.
+///
+/// The wrapped [`DropGuardRef`] preserves Tokio's borrowed cancellation guard;
+/// this wrapper records the terminal reason before that guard cancels workers.
+struct SupervisorCancellationDropGuard<'a> {
+    _guard: DropGuardRef<'a>,
+    lifecycle: SupervisorLifecycle,
+}
+
+impl<'a> SupervisorCancellationDropGuard<'a> {
+    fn new(guard: DropGuardRef<'a>, lifecycle: SupervisorLifecycle) -> Self {
+        Self {
+            _guard: guard,
+            lifecycle,
+        }
+    }
+}
+
+impl Drop for SupervisorCancellationDropGuard<'_> {
+    fn drop(&mut self) { self.lifecycle.record_dropped_cancellation(); }
+}
+
+#[expect(
+    clippy::integer_division_remainder_used,
+    reason = "tokio::select! expands to modulus internally"
+)]
+async fn await_supervisor_termination<S>(
+    shutdown: S,
+    shutdown_token: &CancellationToken,
+    tracker: &TaskTracker,
+    lifecycle: &SupervisorLifecycle,
+) where
+    S: Future<Output = ()>,
+{
+    select! {
+        () = shutdown => {
+            lifecycle.record_graceful_cancellation();
+            shutdown_token.cancel();
+        }
+        () = tracker.wait() => lifecycle.record_completion_without_cancellation(),
+    }
+}
 
 impl<F, T, Ser, Ctx, E, Codec> WireframeServer<F, T, Bound, Ser, Ctx, E, Codec>
 where
@@ -135,10 +251,6 @@ where
     /// Returns an [`std::io::Error`] if the server was not bound to a listener.
     /// Accept failures are retried with exponential back-off and do not
     /// surface as errors.
-    #[expect(
-        clippy::integer_division_remainder_used,
-        reason = "tokio::select! expands to modulus internally"
-    )]
     pub async fn run_with_shutdown<S>(self, shutdown: S) -> Result<(), ServerError>
     where
         S: Future<Output = ()> + Send,
@@ -155,8 +267,12 @@ where
             ..
         } = self;
         let shutdown_token = CancellationToken::new();
+        let lifecycle = SupervisorLifecycle::new();
         // Cancel workers if this future is dropped, for example via JoinHandle::abort.
-        let _cancel_workers_on_drop = shutdown_token.drop_guard_ref();
+        let _cancel_workers_on_drop = SupervisorCancellationDropGuard::new(
+            shutdown_token.drop_guard_ref(),
+            lifecycle.clone(),
+        );
         let tracker = TaskTracker::new();
         let preamble = PreambleHooks {
             on_success: on_preamble_success,
@@ -170,16 +286,21 @@ where
             let preamble_hooks = preamble.clone();
             let token = shutdown_token.clone();
             let t = tracker.clone();
-            tracker.spawn(accept_loop(
-                listener,
-                factory,
-                AcceptLoopOptions {
-                    preamble: preamble_hooks,
-                    shutdown: token,
-                    tracker: t,
-                    backoff: backoff_config,
-                },
-            ));
+            let span = tracing::Span::current();
+            tracker.spawn(
+                accept_loop(
+                    listener,
+                    factory,
+                    AcceptLoopOptions {
+                        preamble: preamble_hooks,
+                        shutdown: token,
+                        tracker: t,
+                        backoff: backoff_config,
+                        lifecycle: lifecycle.clone(),
+                    },
+                )
+                .instrument(span),
+            );
         }
 
         // Signal readiness after all workers have been spawned.
@@ -189,10 +310,7 @@ where
             warn!("Failed to send readiness signal: receiver dropped");
         }
 
-        select! {
-            () = shutdown => shutdown_token.cancel(),
-            () = tracker.wait() => {},
-        }
+        await_supervisor_termination(shutdown, &shutdown_token, &tracker, &lifecycle).await;
 
         tracker.close();
         tracker.wait().await;

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -155,6 +155,8 @@ where
             ..
         } = self;
         let shutdown_token = CancellationToken::new();
+        // Cancel workers if this future is dropped, for example via JoinHandle::abort.
+        let _cancel_workers_on_drop = shutdown_token.drop_guard_ref();
         let tracker = TaskTracker::new();
         let preamble = PreambleHooks {
             on_success: on_preamble_success,

--- a/src/server/runtime/accept.rs
+++ b/src/server/runtime/accept.rs
@@ -11,12 +11,13 @@ use tokio::{
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
-use super::backoff::BackoffConfig;
+use super::{SupervisorLifecycle, backoff::BackoffConfig};
 use crate::{
     app::{Envelope, Packet},
     codec::FrameCodec,
     frame::FrameMetadata,
     message::{DecodeWith, EncodeWith},
+    metrics::inc_server_accept_loop_exit,
     preamble::Preamble,
     serializer::Serializer,
     server::{
@@ -53,6 +54,7 @@ pub(in crate::server) struct AcceptLoopOptions<T> {
     pub shutdown: CancellationToken,
     pub tracker: TaskTracker,
     pub backoff: BackoffConfig,
+    pub lifecycle: SupervisorLifecycle,
 }
 
 struct AcceptHandles<'a, T> {
@@ -165,16 +167,9 @@ pub(in crate::server) async fn accept_loop<F, T, L, Ser, Ctx, E, Codec>(
         shutdown,
         tracker,
         backoff,
+        lifecycle,
     } = options;
-    let backoff = backoff.normalized();
-    debug_assert!(
-        backoff.initial_delay <= backoff.max_delay,
-        "BackoffConfig invariant violated: initial_delay > max_delay"
-    );
-    debug_assert!(
-        backoff.initial_delay >= Duration::from_millis(1),
-        "BackoffConfig invariant violated: initial_delay < 1ms"
-    );
+    let backoff = normalized_backoff(backoff);
     let mut delay = backoff.initial_delay;
     let handles = AcceptHandles {
         preamble: &preamble,
@@ -184,6 +179,32 @@ pub(in crate::server) async fn accept_loop<F, T, L, Ser, Ctx, E, Codec>(
     };
     while let Some(next_delay) = accept_iteration(&listener, &factory, &handles, delay).await {
         delay = next_delay;
+    }
+    record_accept_loop_exit(&shutdown, &lifecycle);
+}
+
+fn normalized_backoff(backoff: BackoffConfig) -> BackoffConfig {
+    let backoff = backoff.normalized();
+    debug_assert!(
+        backoff.initial_delay <= backoff.max_delay,
+        "BackoffConfig invariant violated: initial_delay > max_delay"
+    );
+    debug_assert!(
+        backoff.initial_delay >= Duration::from_millis(1),
+        "BackoffConfig invariant violated: initial_delay < 1ms"
+    );
+    backoff
+}
+
+fn record_accept_loop_exit(shutdown: &CancellationToken, lifecycle: &SupervisorLifecycle) {
+    if shutdown.is_cancelled() {
+        let reason = lifecycle.cancellation_reason();
+        inc_server_accept_loop_exit(reason);
+        tracing::info!(
+            event = "server_accept_loop_exited",
+            reason = reason.as_str(),
+            "server_accept_loop_exited",
+        );
     }
 }
 

--- a/src/server/runtime/tests.rs
+++ b/src/server/runtime/tests.rs
@@ -11,10 +11,10 @@ use std::{
 
 use rstest::rstest;
 use tokio::{
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
     sync::oneshot,
     task::yield_now,
-    time::{Duration, Instant, advance, timeout},
+    time::{Duration, Instant, advance, sleep, timeout},
 };
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
@@ -67,6 +67,48 @@ async fn test_server_graceful_shutdown_with_ctrl_c_simulation(
     });
     let _ = tx.send(());
     handle.await.expect("server join error");
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_graceful_shutdown_releases_listener(
+    factory: impl Fn() -> WireframeApp + Send + Sync + Clone + 'static,
+    free_listener: std::io::Result<std::net::TcpListener>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let listener = free_listener?;
+    let addr = listener.local_addr()?;
+    let server = bind_server(factory, listener)?;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    timeout(Duration::from_secs(1), ready_rx)
+        .await
+        .expect("server did not reach readiness")
+        .expect("server dropped readiness sender");
+    shutdown_tx
+        .send(())
+        .expect("server shutdown receiver was dropped");
+    assert!(handle.await?.is_ok(), "graceful shutdown failed");
+
+    timeout(Duration::from_secs(1), async {
+        loop {
+            if TcpStream::connect(addr).await.is_err() {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("server listener remained bound after graceful shutdown");
     Ok(())
 }
 

--- a/src/server/runtime/tests.rs
+++ b/src/server/runtime/tests.rs
@@ -99,16 +99,19 @@ async fn test_graceful_shutdown_releases_listener(
         .expect("server shutdown receiver was dropped");
     assert!(handle.await?.is_ok(), "graceful shutdown failed");
 
-    timeout(Duration::from_secs(1), async {
+    let release_result = timeout(Duration::from_secs(1), async {
         loop {
-            if TcpStream::connect(addr).await.is_err() {
-                break;
+            match TcpStream::connect(addr).await {
+                Ok(stream) => drop(stream),
+                Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => return Ok(()),
+                Err(error) => return Err(error),
             }
             sleep(Duration::from_millis(10)).await;
         }
     })
     .await
     .expect("server listener remained bound after graceful shutdown");
+    release_result?;
     Ok(())
 }
 

--- a/src/server/runtime/tests.rs
+++ b/src/server/runtime/tests.rs
@@ -23,6 +23,7 @@ use super::{
     BackoffConfig,
     MockAcceptListener,
     PreambleHooks,
+    SupervisorLifecycle,
     WireframeServer,
     accept_loop,
 };
@@ -162,6 +163,7 @@ async fn test_accept_loop_shutdown_signal(
             shutdown: token.clone(),
             tracker: tracker.clone(),
             backoff: BackoffConfig::default(),
+            lifecycle: SupervisorLifecycle::new(),
         },
     ));
 
@@ -258,6 +260,7 @@ async fn test_accept_loop_exponential_backoff_async(
             shutdown: token.clone(),
             tracker: tracker.clone(),
             backoff,
+            lifecycle: SupervisorLifecycle::new(),
         },
     ));
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,8 +1,30 @@
 //! Tests for [`WireframeServer`] configuration.
 #![cfg(not(loom))]
 
+use std::net::SocketAddr;
+
+use tokio::{
+    net::TcpStream,
+    sync::oneshot,
+    time::{Duration, sleep, timeout},
+};
 use wireframe::server::WireframeServer;
 use wireframe_testing::{TestResult, factory, unused_listener};
+
+async fn wait_for_listener_release(addr: SocketAddr) -> TestResult {
+    timeout(Duration::from_secs(1), async {
+        loop {
+            match TcpStream::connect(addr).await {
+                Ok(stream) => drop(stream),
+                Err(_) => break,
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .map_err(|_| format!("server listener at {addr} remained bound for one second"))?;
+    Ok(())
+}
 
 #[test]
 fn default_worker_count_matches_cpu_count() -> TestResult {
@@ -58,12 +80,6 @@ fn workers_accepts_large_values() -> TestResult {
 /// prevent the server from accepting connections.
 #[tokio::test]
 async fn readiness_receiver_dropped() -> TestResult {
-    use tokio::{
-        net::TcpStream,
-        sync::oneshot,
-        time::{Duration, sleep},
-    };
-
     let listener = unused_listener()?;
     let server = WireframeServer::new(factory())
         .workers(1)
@@ -88,5 +104,111 @@ async fn readiness_receiver_dropped() -> TestResult {
 
     // Server should still accept connections
     let _stream = TcpStream::connect(addr).await.expect("connect failed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn aborting_server_supervisor_releases_listener() -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(1)
+        .bind_existing_listener(listener)
+        .expect("failed to bind existing listener");
+    let addr = server.local_addr().expect("local addr missing");
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(std::future::pending())
+            .await
+    });
+
+    timeout(Duration::from_secs(1), ready_rx)
+        .await
+        .expect("server did not reach readiness")
+        .expect("server dropped readiness sender");
+
+    handle.abort();
+    let error = handle
+        .await
+        .expect_err("aborted server supervisor unexpectedly completed");
+    if !error.is_cancelled() {
+        return Err("server supervisor was not cancelled".into());
+    }
+
+    wait_for_listener_release(addr).await
+}
+
+#[tokio::test]
+async fn dropping_server_supervisor_releases_listener() -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(1)
+        .bind_existing_listener(listener)
+        .expect("failed to bind existing listener");
+    let addr = server.local_addr().expect("local addr missing");
+    let (ready_tx, mut ready_rx) = oneshot::channel();
+    let mut supervisor = Box::pin(
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(std::future::pending()),
+    );
+
+    #[expect(
+        clippy::integer_division_remainder_used,
+        reason = "tokio::select! expands to modulus internally"
+    )]
+    let readiness: TestResult = timeout(Duration::from_secs(1), async {
+        tokio::select! {
+            readiness = &mut ready_rx => {
+                readiness.map_err(|error| {
+                    format!("server dropped readiness sender: {error}").into()
+                })
+            }
+            result = &mut supervisor => {
+                Err(format!("server supervisor completed before readiness: {result:?}").into())
+            }
+        }
+    })
+    .await
+    .map_err(|_| "server did not reach readiness")?;
+    readiness?;
+
+    drop(supervisor);
+    wait_for_listener_release(addr).await
+}
+
+#[tokio::test]
+async fn server_reaches_readiness_and_accepts_before_shutdown() -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(1)
+        .bind_existing_listener(listener)
+        .expect("failed to bind existing listener");
+    let addr = server.local_addr().expect("local addr missing");
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    timeout(Duration::from_secs(1), ready_rx)
+        .await
+        .expect("server did not reach readiness")
+        .expect("server dropped readiness sender");
+
+    let stream = TcpStream::connect(addr)
+        .await
+        .expect("ready server did not accept connections");
+    drop(stream);
+    shutdown_tx
+        .send(())
+        .expect("server shutdown receiver was dropped");
+    handle.await??;
     Ok(())
 }

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,8 +1,9 @@
 //! Tests for [`WireframeServer`] configuration.
 #![cfg(not(loom))]
 
-use std::net::SocketAddr;
+use std::{io::ErrorKind, net::SocketAddr};
 
+use rstest::rstest;
 use tokio::{
     net::TcpStream,
     sync::oneshot,
@@ -12,17 +13,19 @@ use wireframe::server::WireframeServer;
 use wireframe_testing::{TestResult, factory, unused_listener};
 
 async fn wait_for_listener_release(addr: SocketAddr) -> TestResult {
-    timeout(Duration::from_secs(1), async {
+    let release_result: TestResult = timeout(Duration::from_secs(1), async {
         loop {
             match TcpStream::connect(addr).await {
                 Ok(stream) => drop(stream),
-                Err(_) => break,
+                Err(error) if error.kind() == ErrorKind::ConnectionRefused => return Ok(()),
+                Err(error) => return Err(error.into()),
             }
             sleep(Duration::from_millis(10)).await;
         }
     })
     .await
     .map_err(|_| format!("server listener at {addr} remained bound for one second"))?;
+    release_result?;
     Ok(())
 }
 
@@ -50,18 +53,20 @@ fn default_workers_at_least_one() -> TestResult {
     Ok(())
 }
 
-#[test]
-fn workers_normalizes_configured_values() -> TestResult {
-    for (requested, expected) in [(0, 1), (128, 128)] {
-        let server = WireframeServer::new(factory()).workers(requested);
-        let actual = server.worker_count();
-        if actual != expected {
-            return Err(format!(
-                "worker count mismatch: requested={requested}, actual={actual}, \
-                 expected={expected}"
-            )
-            .into());
-        }
+#[rstest]
+#[case::clamps_zero_to_one(0, 1)]
+#[case::retains_large_worker_count(128, 128)]
+fn workers_normalizes_configured_values(
+    #[case] requested: usize,
+    #[case] expected: usize,
+) -> TestResult {
+    let server = WireframeServer::new(factory()).workers(requested);
+    let actual = server.worker_count();
+    if actual != expected {
+        return Err(format!(
+            "worker count mismatch: requested={requested}, actual={actual}, expected={expected}"
+        )
+        .into());
     }
     Ok(())
 }
@@ -165,6 +170,7 @@ async fn dropping_server_supervisor_releases_listener() -> TestResult {
     readiness?;
 
     drop(supervisor);
+    sleep(Duration::from_millis(10)).await;
     wait_for_listener_release(addr).await
 }
 

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -1,8 +1,6 @@
 //! Tests for [`WireframeServer`] configuration.
 #![cfg(not(loom))]
 
-use std::{io::ErrorKind, net::SocketAddr};
-
 use rstest::rstest;
 use tokio::{
     net::TcpStream,
@@ -10,24 +8,13 @@ use tokio::{
     time::{Duration, sleep, timeout},
 };
 use wireframe::server::WireframeServer;
-use wireframe_testing::{TestResult, factory, unused_listener};
-
-async fn wait_for_listener_release(addr: SocketAddr) -> TestResult {
-    let release_result: TestResult = timeout(Duration::from_secs(1), async {
-        loop {
-            match TcpStream::connect(addr).await {
-                Ok(stream) => drop(stream),
-                Err(error) if error.kind() == ErrorKind::ConnectionRefused => return Ok(()),
-                Err(error) => return Err(error.into()),
-            }
-            sleep(Duration::from_millis(10)).await;
-        }
-    })
-    .await
-    .map_err(|_| format!("server listener at {addr} remained bound for one second"))?;
-    release_result?;
-    Ok(())
-}
+use wireframe_testing::{
+    TestResult,
+    factory,
+    unused_listener,
+    wait_for_listener_release,
+    wait_for_server_readiness,
+};
 
 #[test]
 fn default_worker_count_matches_cpu_count() -> TestResult {
@@ -118,10 +105,7 @@ async fn aborting_server_supervisor_releases_listener() -> TestResult {
             .await
     });
 
-    timeout(Duration::from_secs(1), ready_rx)
-        .await
-        .expect("server did not reach readiness")
-        .expect("server dropped readiness sender");
+    wait_for_server_readiness(ready_rx).await?;
 
     handle.abort();
     let error = handle
@@ -170,7 +154,6 @@ async fn dropping_server_supervisor_releases_listener() -> TestResult {
     readiness?;
 
     drop(supervisor);
-    sleep(Duration::from_millis(10)).await;
     wait_for_listener_release(addr).await
 }
 
@@ -193,10 +176,7 @@ async fn server_reaches_readiness_and_accepts_before_shutdown() -> TestResult {
             .await
     });
 
-    timeout(Duration::from_secs(1), ready_rx)
-        .await
-        .expect("server did not reach readiness")
-        .expect("server dropped readiness sender");
+    wait_for_server_readiness(ready_rx).await?;
 
     let stream = TcpStream::connect(addr)
         .await

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -51,27 +51,17 @@ fn default_workers_at_least_one() -> TestResult {
 }
 
 #[test]
-fn workers_method_enforces_minimum() -> TestResult {
-    let server = WireframeServer::new(factory()).workers(0);
-    if server.worker_count() != 1 {
-        return Err(format!(
-            "worker count should clamp to 1, got {}",
-            server.worker_count()
-        )
-        .into());
-    }
-    Ok(())
-}
-
-#[test]
-fn workers_accepts_large_values() -> TestResult {
-    let server = WireframeServer::new(factory()).workers(128);
-    if server.worker_count() != 128 {
-        return Err(format!(
-            "worker count should be 128 after config, got {}",
-            server.worker_count()
-        )
-        .into());
+fn workers_normalizes_configured_values() -> TestResult {
+    for (requested, expected) in [(0, 1), (128, 128)] {
+        let server = WireframeServer::new(factory()).workers(requested);
+        let actual = server.worker_count();
+        if actual != expected {
+            return Err(format!(
+                "worker count mismatch: requested={requested}, actual={actual}, \
+                 expected={expected}"
+            )
+            .into());
+        }
     }
     Ok(())
 }

--- a/tests/server_lifecycle_model.rs
+++ b/tests/server_lifecycle_model.rs
@@ -36,7 +36,7 @@ impl TerminalAction {
 
 /// Exercise the bounded supervisor model for every worker/action combination.
 ///
-/// The worker-count domain contains normalisation (`0`), one worker, and two
+/// The worker-count domain contains normalization (`0`), one worker, and two
 /// multi-worker configurations. Each action starts from a ready server, while
 /// the graceful path also accepts a connection, so immediate guard
 /// cancellation is detected before the terminal transition is applied.

--- a/tests/server_lifecycle_model.rs
+++ b/tests/server_lifecycle_model.rs
@@ -7,8 +7,13 @@
 
 use std::future;
 
+use proptest::{
+    prelude::*,
+    test_runner::{TestCaseError, TestCaseResult},
+};
 use tokio::{
     net::TcpStream,
+    runtime::Builder,
     sync::oneshot,
     time::{Duration, timeout},
 };
@@ -34,6 +39,14 @@ impl TerminalAction {
     const ALL: [Self; 3] = [Self::Graceful, Self::Drop, Self::Abort];
 }
 
+fn terminal_actions() -> impl Strategy<Value = TerminalAction> {
+    prop_oneof![
+        Just(TerminalAction::Graceful),
+        Just(TerminalAction::Drop),
+        Just(TerminalAction::Abort),
+    ]
+}
+
 /// Exercise the bounded supervisor model for every worker/action combination.
 ///
 /// The worker-count domain contains normalization (`0`), one worker, and two
@@ -48,6 +61,35 @@ async fn bounded_server_supervisor_lifecycle_model() -> TestResult {
         }
     }
     Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 12,
+        .. ProptestConfig::default()
+    })]
+
+    /// Generate bounded lifecycle cases in addition to the exhaustive matrix.
+    #[test]
+    fn generated_server_supervisor_lifecycle_cases(
+        requested_workers in prop_oneof![Just(0usize), Just(1), 2usize..=4],
+        action in terminal_actions(),
+    ) {
+        run_generated_lifecycle_case(requested_workers, action)?;
+    }
+}
+
+fn run_generated_lifecycle_case(
+    requested_workers: usize,
+    action: TerminalAction,
+) -> TestCaseResult {
+    let runtime = Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| TestCaseError::fail(error.to_string()))?;
+    runtime
+        .block_on(exercise_lifecycle(requested_workers, action))
+        .map_err(|error| TestCaseError::fail(error.to_string()))
 }
 
 async fn exercise_lifecycle(requested_workers: usize, action: TerminalAction) -> TestResult {

--- a/tests/server_lifecycle_model.rs
+++ b/tests/server_lifecycle_model.rs
@@ -1,0 +1,172 @@
+//! Bounded lifecycle-model tests for server-supervisor cancellation.
+//!
+//! Each model run exercises every configured worker-count and terminal-action
+//! combination against a current-thread Tokio runtime. The model keeps the
+//! runtime alive while dropped and aborted supervisors release their listeners.
+#![cfg(not(loom))]
+
+use std::future;
+
+use tokio::{
+    net::TcpStream,
+    sync::oneshot,
+    time::{Duration, timeout},
+};
+use wireframe::server::WireframeServer;
+use wireframe_testing::{
+    TestResult,
+    factory,
+    unused_listener,
+    wait_for_listener_release,
+    wait_for_server_readiness,
+};
+
+const WORKER_COUNTS: [usize; 4] = [0, 1, 2, 4];
+
+#[derive(Clone, Copy, Debug)]
+enum TerminalAction {
+    Graceful,
+    Drop,
+    Abort,
+}
+
+impl TerminalAction {
+    const ALL: [Self; 3] = [Self::Graceful, Self::Drop, Self::Abort];
+}
+
+/// Exercise the bounded supervisor model for every worker/action combination.
+///
+/// The worker-count domain contains normalisation (`0`), one worker, and two
+/// multi-worker configurations. Each action starts from a ready server, while
+/// the graceful path also accepts a connection, so immediate guard
+/// cancellation is detected before the terminal transition is applied.
+#[tokio::test(flavor = "current_thread")]
+async fn bounded_server_supervisor_lifecycle_model() -> TestResult {
+    for requested_workers in WORKER_COUNTS {
+        for action in TerminalAction::ALL {
+            exercise_lifecycle(requested_workers, action).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn exercise_lifecycle(requested_workers: usize, action: TerminalAction) -> TestResult {
+    assert_normalized_worker_count(requested_workers)?;
+    match action {
+        TerminalAction::Graceful => graceful_shutdown(requested_workers).await,
+        TerminalAction::Drop => drop_supervisor(requested_workers).await,
+        TerminalAction::Abort => abort_supervisor(requested_workers).await,
+    }
+}
+
+fn assert_normalized_worker_count(requested_workers: usize) -> TestResult {
+    let server = WireframeServer::new(factory()).workers(requested_workers);
+    let actual_workers = server.worker_count();
+    let expected_workers = requested_workers.max(1);
+    if actual_workers != expected_workers {
+        return Err(format!(
+            "worker count mismatch: requested={requested_workers}, actual={actual_workers}, \
+             expected={expected_workers}"
+        )
+        .into());
+    }
+    Ok(())
+}
+
+async fn graceful_shutdown(requested_workers: usize) -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(requested_workers)
+        .bind_existing_listener(listener)?;
+    let addr = server
+        .local_addr()
+        .ok_or_else(|| "local address missing".to_string())?;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+    });
+
+    wait_for_server_readiness(ready_rx).await?;
+    let stream = TcpStream::connect(addr)
+        .await
+        .map_err(|error| format!("ready server did not accept a connection: {error}"))?;
+    drop(stream);
+    shutdown_tx
+        .send(())
+        .map_err(|()| "server shutdown receiver was dropped")?;
+    timeout(Duration::from_secs(1), handle)
+        .await
+        .map_err(|_| "graceful server did not complete in time")???;
+    wait_for_listener_release(addr).await
+}
+
+async fn drop_supervisor(requested_workers: usize) -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(requested_workers)
+        .bind_existing_listener(listener)?;
+    let addr = server
+        .local_addr()
+        .ok_or_else(|| "local address missing".to_string())?;
+    let (ready_tx, mut ready_rx) = oneshot::channel();
+    let mut supervisor = Box::pin(
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(future::pending()),
+    );
+    #[expect(
+        clippy::integer_division_remainder_used,
+        reason = "tokio::select! expands to modulus internally"
+    )]
+    let readiness: TestResult = timeout(Duration::from_secs(1), async {
+        tokio::select! {
+            ready = &mut ready_rx => ready.map_err(|error| {
+                format!("server dropped readiness sender: {error}").into()
+            }),
+            result = &mut supervisor => Err(format!(
+                "server supervisor completed before readiness: {result:?}"
+            ).into()),
+        }
+    })
+    .await
+    .map_err(|_| "server did not reach readiness")?;
+    readiness?;
+    drop(supervisor);
+    wait_for_listener_release(addr).await
+}
+
+async fn abort_supervisor(requested_workers: usize) -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(requested_workers)
+        .bind_existing_listener(listener)?;
+    let addr = server
+        .local_addr()
+        .ok_or_else(|| "local address missing".to_string())?;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(future::pending())
+            .await
+    });
+
+    wait_for_server_readiness(ready_rx).await?;
+    handle.abort();
+    let join_result = timeout(Duration::from_secs(1), handle)
+        .await
+        .map_err(|_| "aborted server did not finish in time")?;
+    let Err(error) = join_result else {
+        return Err("aborted server supervisor unexpectedly completed".into());
+    };
+    if !error.is_cancelled() {
+        return Err("server supervisor was not cancelled".into());
+    }
+    wait_for_listener_release(addr).await
+}

--- a/tests/server_lifecycle_observability.rs
+++ b/tests/server_lifecycle_observability.rs
@@ -1,0 +1,222 @@
+//! Lifecycle-observability tests for server-supervisor cancellation.
+//!
+//! Metrics use a current-thread runtime because the local recorder must remain
+//! installed while accept loops observe cancellation and emit their exits.
+#![cfg(not(loom))]
+
+use std::future;
+
+use metrics::with_local_recorder;
+use tokio::{
+    runtime::Builder,
+    sync::oneshot,
+    time::{Duration, timeout},
+};
+use tracing::Instrument;
+use tracing_test::traced_test;
+use wireframe::{
+    metrics::{SERVER_ACCEPT_LOOPS_EXITED, SERVER_SUPERVISOR_CANCELLATIONS},
+    server::WireframeServer,
+};
+use wireframe_testing::{
+    ObservabilityHandle,
+    TestResult,
+    factory,
+    unused_listener,
+    wait_for_listener_release,
+    wait_for_server_readiness,
+};
+
+const WORKERS: usize = 2;
+
+macro_rules! assert_trace_event {
+    ($event:expr, $reason:expr) => {
+        logs_assert(|lines: &[&str]| {
+            let captured = lines.join("\\n");
+            if !lines.iter().any(|line| line.contains($event)) {
+                return Err(format!(
+                    "trace event {:?} was not captured; captured logs: {captured}",
+                    $event
+                ));
+            }
+            if !lines.iter().any(|line| line.contains($reason)) {
+                return Err(format!(
+                    "trace reason {:?} was not captured; captured logs: {captured}",
+                    $reason
+                ));
+            }
+            Ok(())
+        });
+    };
+}
+
+#[traced_test]
+#[test]
+fn graceful_shutdown_emits_lifecycle_metrics_and_trace() -> TestResult {
+    let mut observability = ObservabilityHandle::new();
+    let span = tracing::Span::current();
+    run_with_local_metrics(&observability, graceful_shutdown().instrument(span))?;
+    observability.snapshot();
+
+    observability
+        .assert_counter(SERVER_SUPERVISOR_CANCELLATIONS, [("reason", "graceful")], 1)
+        .map_err(|error| format!("graceful supervisor cancellation metric missing: {error}"))?;
+    observability
+        .assert_counter(
+            SERVER_ACCEPT_LOOPS_EXITED,
+            [("reason", "graceful")],
+            WORKERS as u64,
+        )
+        .map_err(|error| format!("graceful accept-loop exit metrics missing: {error}"))?;
+    assert_trace_event!("server_supervisor_cancellation", "graceful");
+    assert_trace_event!("server_accept_loop_exited", "graceful");
+    Ok(())
+}
+
+#[traced_test]
+#[test]
+fn dropped_supervisor_emits_lifecycle_metrics_and_trace() -> TestResult {
+    let mut observability = ObservabilityHandle::new();
+    let span = tracing::Span::current();
+    run_with_local_metrics(&observability, drop_supervisor().instrument(span))?;
+    observability.snapshot();
+
+    assert_dropped_metrics(&observability)?;
+    assert_trace_event!("server_supervisor_cancellation", "dropped");
+    assert_trace_event!("server_accept_loop_exited", "dropped");
+    Ok(())
+}
+
+#[test]
+fn aborted_supervisor_emits_dropped_lifecycle_metrics() -> TestResult {
+    let mut observability = ObservabilityHandle::new();
+    run_with_local_metrics(&observability, abort_supervisor())?;
+    observability.snapshot();
+
+    assert_dropped_metrics(&observability)
+}
+
+fn run_with_local_metrics<F>(observability: &ObservabilityHandle, future: F) -> TestResult
+where
+    F: Future<Output = TestResult>,
+{
+    let runtime = Builder::new_current_thread().enable_all().build()?;
+    with_local_recorder(observability.recorder(), || runtime.block_on(future))
+}
+
+fn assert_dropped_metrics(observability: &ObservabilityHandle) -> TestResult {
+    observability
+        .assert_counter(SERVER_SUPERVISOR_CANCELLATIONS, [("reason", "dropped")], 1)
+        .map_err(|error| format!("dropped supervisor cancellation metric missing: {error}"))?;
+    observability
+        .assert_counter(
+            SERVER_ACCEPT_LOOPS_EXITED,
+            [("reason", "dropped")],
+            WORKERS as u64,
+        )
+        .map_err(|error| format!("dropped accept-loop exit metrics missing: {error}"))?;
+    Ok(())
+}
+
+async fn graceful_shutdown() -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(WORKERS)
+        .bind_existing_listener(listener)?;
+    let addr = server
+        .local_addr()
+        .ok_or_else(|| "local address missing".to_string())?;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let span = tracing::Span::current();
+    let handle = tokio::spawn(
+        async move {
+            server
+                .ready_signal(ready_tx)
+                .run_with_shutdown(async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+        }
+        .instrument(span),
+    );
+
+    wait_for_server_readiness(ready_rx).await?;
+    shutdown_tx
+        .send(())
+        .map_err(|()| "server shutdown receiver was dropped")?;
+    let server_result = timeout(Duration::from_secs(1), handle)
+        .await
+        .map_err(|_| "graceful server did not complete in time")??;
+    server_result?;
+    wait_for_listener_release(addr).await
+}
+
+async fn drop_supervisor() -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(WORKERS)
+        .bind_existing_listener(listener)?;
+    let addr = server
+        .local_addr()
+        .ok_or_else(|| "local address missing".to_string())?;
+    let (ready_tx, mut ready_rx) = oneshot::channel();
+    let mut supervisor = Box::pin(
+        server
+            .ready_signal(ready_tx)
+            .run_with_shutdown(future::pending()),
+    );
+    #[expect(
+        clippy::integer_division_remainder_used,
+        reason = "tokio::select! expands to modulus internally"
+    )]
+    let readiness: TestResult = timeout(Duration::from_secs(1), async {
+        tokio::select! {
+            ready = &mut ready_rx => ready.map_err(|error| {
+                format!("server dropped readiness sender: {error}").into()
+            }),
+            result = &mut supervisor => Err(format!(
+                "server supervisor completed before readiness: {result:?}"
+            ).into()),
+        }
+    })
+    .await
+    .map_err(|_| "server did not reach readiness")?;
+    readiness?;
+    drop(supervisor);
+    wait_for_listener_release(addr).await
+}
+
+async fn abort_supervisor() -> TestResult {
+    let listener = unused_listener()?;
+    let server = WireframeServer::new(factory())
+        .workers(WORKERS)
+        .bind_existing_listener(listener)?;
+    let addr = server
+        .local_addr()
+        .ok_or_else(|| "local address missing".to_string())?;
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let span = tracing::Span::current();
+    let handle = tokio::spawn(
+        async move {
+            server
+                .ready_signal(ready_tx)
+                .run_with_shutdown(future::pending())
+                .await
+        }
+        .instrument(span),
+    );
+
+    wait_for_server_readiness(ready_rx).await?;
+    handle.abort();
+    let join_result = timeout(Duration::from_secs(1), handle)
+        .await
+        .map_err(|_| "aborted server did not finish in time")?;
+    let Err(error) = join_result else {
+        return Err("aborted server supervisor unexpectedly completed".into());
+    };
+    if !error.is_cancelled() {
+        return Err("server supervisor was not cancelled".into());
+    }
+    wait_for_listener_release(addr).await
+}

--- a/tests/server_lifecycle_observability.rs
+++ b/tests/server_lifecycle_observability.rs
@@ -33,16 +33,13 @@ macro_rules! assert_trace_event {
     ($event:expr, $reason:expr) => {
         logs_assert(|lines: &[&str]| {
             let captured = lines.join("\\n");
-            if !lines.iter().any(|line| line.contains($event)) {
+            if !lines
+                .iter()
+                .any(|line| line.contains($event) && line.contains($reason))
+            {
                 return Err(format!(
-                    "trace event {:?} was not captured; captured logs: {captured}",
-                    $event
-                ));
-            }
-            if !lines.iter().any(|line| line.contains($reason)) {
-                return Err(format!(
-                    "trace reason {:?} was not captured; captured logs: {captured}",
-                    $reason
+                    "trace event {:?} with reason {:?} was not captured; captured logs: {captured}",
+                    $event, $reason
                 ));
             }
             Ok(())

--- a/wireframe_testing/src/integration_helpers.rs
+++ b/wireframe_testing/src/integration_helpers.rs
@@ -6,7 +6,8 @@
 //! unused local port without relying on file-level lint suppressions.
 
 use std::{
-    net::TcpListener as StdTcpListener,
+    io::ErrorKind,
+    net::{SocketAddr, TcpListener as StdTcpListener},
     pin::Pin,
     sync::{
         Arc,
@@ -15,6 +16,11 @@ use std::{
 };
 
 use rstest::fixture;
+use tokio::{
+    net::TcpStream,
+    sync::oneshot,
+    time::{Duration, sleep, timeout},
+};
 pub use wireframe::testkit::{TestError, TestResult};
 use wireframe::{
     app::{Envelope, Packet, PacketParts},
@@ -42,6 +48,45 @@ use wireframe::{
 /// }
 /// ```
 pub fn unused_listener() -> TestResult<StdTcpListener> { Ok(StdTcpListener::bind("localhost:0")?) }
+
+/// Wait until a loopback listener refuses new connections.
+///
+/// This keeps the active Tokio runtime alive while accept loops observe their
+/// cancellation signal and release the listener. Only `ConnectionRefused`
+/// proves release; all other connection failures are propagated.
+///
+/// # Errors
+///
+/// Returns an error when the listener remains bound for one second or when a
+/// probe fails for a reason other than `ConnectionRefused`.
+pub async fn wait_for_listener_release(addr: SocketAddr) -> TestResult {
+    let release_result: TestResult = timeout(Duration::from_secs(1), async {
+        loop {
+            sleep(Duration::from_millis(10)).await;
+            match TcpStream::connect(addr).await {
+                Ok(stream) => drop(stream),
+                Err(error) if error.kind() == ErrorKind::ConnectionRefused => return Ok(()),
+                Err(error) => return Err(error.into()),
+            }
+        }
+    })
+    .await
+    .map_err(|_| format!("server listener at {addr} remained bound for one second"))?;
+    release_result
+}
+
+/// Wait for a server supervisor to report readiness.
+///
+/// # Errors
+///
+/// Returns an error when readiness is not reported within one second or when
+/// the supervisor drops the readiness sender.
+pub async fn wait_for_server_readiness(readiness: oneshot::Receiver<()>) -> TestResult {
+    timeout(Duration::from_secs(1), readiness)
+        .await
+        .map_err(|_| "server did not reach readiness")?
+        .map_err(|error| format!("server dropped readiness sender: {error}").into())
+}
 
 /// Minimal payload type for echo-style round-trip tests.
 ///

--- a/wireframe_testing/src/integration_helpers.rs
+++ b/wireframe_testing/src/integration_helpers.rs
@@ -59,6 +59,20 @@ pub fn unused_listener() -> TestResult<StdTcpListener> { Ok(StdTcpListener::bind
 ///
 /// Returns an error when the listener remains bound for one second or when a
 /// probe fails for a reason other than `ConnectionRefused`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::net::SocketAddr;
+///
+/// use wireframe_testing::{TestResult, wait_for_listener_release};
+///
+/// # async fn example(addr: SocketAddr) -> TestResult {
+/// wait_for_listener_release(addr).await?;
+/// // Successful completion means a connection probe was refused.
+/// Ok(())
+/// # }
+/// ```
 pub async fn wait_for_listener_release(addr: SocketAddr) -> TestResult {
     let release_result: TestResult = timeout(Duration::from_secs(1), async {
         loop {
@@ -81,6 +95,19 @@ pub async fn wait_for_listener_release(addr: SocketAddr) -> TestResult {
 ///
 /// Returns an error when readiness is not reported within one second or when
 /// the supervisor drops the readiness sender.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use tokio::sync::oneshot;
+/// use wireframe_testing::{TestResult, wait_for_server_readiness};
+///
+/// # async fn example(readiness: oneshot::Receiver<()>) -> TestResult {
+/// wait_for_server_readiness(readiness).await?;
+/// // Successful completion means the supervisor reported readiness.
+/// Ok(())
+/// # }
+/// ```
 pub async fn wait_for_server_readiness(readiness: oneshot::Receiver<()>) -> TestResult {
     timeout(Duration::from_secs(1), readiness)
         .await

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -98,6 +98,8 @@ pub use integration_helpers::{
     echo_handler,
     factory,
     unused_listener,
+    wait_for_listener_release,
+    wait_for_server_readiness,
 };
 pub use logging::{LoggerHandle, logger};
 #[doc(inline)]


### PR DESCRIPTION
## Summary

This branch makes an abandoned `WireframeServer::run_with_shutdown` supervisor
cancel its accept loops, releasing the bound listener after the future is
dropped or its `JoinHandle` is aborted.

Closes #656.

## Review walkthrough

- Start with [the supervisor guard](https://github.com/leynos/wireframe/blob/issue-656-cancel-server-accept-loops-when-the-run-with-shutdown-future-is-dropped/src/server/runtime.rs#L157), which owns cancellation for the full `run_with_shutdown` frame without changing normal graceful shutdown.
- Then review [the integration lifecycle tests](https://github.com/leynos/wireframe/blob/issue-656-cancel-server-accept-loops-when-the-run-with-shutdown-future-is-dropped/tests/server.rs#L110), which cover `JoinHandle::abort()`, direct future drop, and the readiness footgun.
- Finish with [the graceful-shutdown regression](https://github.com/leynos/wireframe/blob/issue-656-cancel-server-accept-loops-when-the-run-with-shutdown-future-is-dropped/src/server/runtime/tests.rs#L73), which confirms a normal shutdown returns successfully and releases its listener.

## Validation

- `make check-fmt`, `make lint`, `make typecheck`, `make test`, `make markdownlint`, and `make nixie` passed.
- `coderabbit review --agent` completed with no findings.

## Notes

Cancellation after abort is eventual: the accept loops must be scheduled to
observe the token. In-flight connection tasks remain outside this cancellation
path, preserving graceful-draining behaviour.

## References

- [Issue #656](https://github.com/leynos/wireframe/issues/656)
- [Lody session](https://lody.ai/leynos/sessions/584fb385-2057-42f1-95ed-ca72a14a791a)

## Summary by Sourcery

Ensure abandoned server supervisors cancel their accept loops while preserving graceful shutdown and in-flight connection draining.

New Features:
- Cancel server accept loops when the `run_with_shutdown` supervisor is dropped or aborted, eventually releasing listener resources.
- Expose bounded cancellation and accept-loop exit metrics and tracing events for graceful and abandoned supervisor lifecycles.

Bug Fixes:
- Prevent abandoned server supervisors from leaving accept loops and bound listeners alive indefinitely.

Enhancements:
- Document server supervisor ownership, cancellation, graceful-drain behavior, and lifecycle observability.

Build:
- Configure `tracing-test` to disable environment filtering for lifecycle observability tests.

Documentation:
- Update runtime ownership, developer, and user documentation with the server-supervisor cancellation contract.

Tests:
- Add graceful-shutdown, direct-drop, and `JoinHandle::abort()` listener-release coverage, plus bounded lifecycle and metrics/tracing tests.

Chores:
- Add shared test helpers for waiting on readiness and listener release.