### PR TITLE
Document undocumented public items (#531)

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -49,6 +49,7 @@ pub const MIN_FRAME_LENGTH: usize = 64;
 /// value to prevent unbounded memory allocation.
 pub const MAX_FRAME_LENGTH: usize = 16 * 1024 * 1024;
 
+/// Clamp a requested frame length to the supported range.
 pub(crate) fn clamp_frame_length(value: usize) -> usize {
     value.clamp(MIN_FRAME_LENGTH, MAX_FRAME_LENGTH)
 }
@@ -142,6 +143,7 @@ impl Default for LengthDelimitedFrameCodec {
 /// Length prefix header size (4 bytes for big-endian u32).
 pub const LENGTH_HEADER_SIZE: usize = 4;
 
+/// Decoder half of [`LengthDelimitedFrameCodec`].
 #[doc(hidden)]
 pub struct LengthDelimitedDecoder {
     inner: LengthDelimitedCodec,
@@ -236,6 +238,7 @@ fn build_eof_error(context: EofContext) -> io::Error {
     }
 }
 
+/// Encoder half of [`LengthDelimitedFrameCodec`].
 #[doc(hidden)]
 pub struct LengthDelimitedEncoder {
     inner: LengthDelimitedCodec,

--- a/src/codec/examples.rs
+++ b/src/codec/examples.rs
@@ -28,6 +28,16 @@ pub struct HotlineFrameCodec {
 
 impl HotlineFrameCodec {
     /// Construct a Hotline codec with a maximum frame length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::codec::{FrameCodec, examples::HotlineFrameCodec};
+    ///
+    /// let codec = HotlineFrameCodec::new(1024);
+    ///
+    /// assert_eq!(codec.max_frame_length(), 1024);
+    /// ```
     #[must_use]
     pub fn new(max_frame_length: usize) -> Self { Self { max_frame_length } }
 }
@@ -153,6 +163,16 @@ pub struct MysqlFrameCodec {
 
 impl MysqlFrameCodec {
     /// Construct a `MySQL` codec with a maximum frame length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wireframe::codec::{FrameCodec, examples::MysqlFrameCodec};
+    ///
+    /// let codec = MysqlFrameCodec::new(1024);
+    ///
+    /// assert_eq!(codec.max_frame_length(), 1024);
+    /// ```
     #[must_use]
     pub fn new(max_frame_length: usize) -> Self { Self { max_frame_length } }
 }

--- a/src/codec/examples.rs
+++ b/src/codec/examples.rs
@@ -11,22 +11,28 @@ use tokio_util::codec::{Decoder, Encoder};
 
 use super::FrameCodec;
 
+/// A Hotline frame with a 20-byte big-endian header and transaction identifier.
 #[derive(Clone, Debug)]
 pub struct HotlineFrame {
+    /// Transaction identifier from the Hotline frame header.
     pub transaction_id: u32,
+    /// Frame payload following the Hotline header.
     pub payload: Bytes,
 }
 
+/// Codec for Hotline frames with 20-byte big-endian headers.
 #[derive(Clone, Debug)]
 pub struct HotlineFrameCodec {
     max_frame_length: usize,
 }
 
 impl HotlineFrameCodec {
+    /// Construct a Hotline codec with a maximum frame length.
     #[must_use]
     pub fn new(max_frame_length: usize) -> Self { Self { max_frame_length } }
 }
 
+/// Adapter that encodes and decodes Hotline frames.
 #[derive(Clone, Debug)]
 #[doc(hidden)]
 pub struct HotlineAdapter {
@@ -130,22 +136,28 @@ impl FrameCodec for HotlineFrameCodec {
     fn max_frame_length(&self) -> usize { self.max_frame_length }
 }
 
+/// A `MySQL` frame with a 3-byte little-endian length and sequence number.
 #[derive(Clone, Debug)]
 pub struct MysqlFrame {
+    /// Sequence number from the `MySQL` frame header.
     pub sequence_id: u8,
+    /// Frame payload following the `MySQL` header.
     pub payload: Bytes,
 }
 
+/// Codec for `MySQL` frames with 3-byte little-endian length headers.
 #[derive(Clone, Debug)]
 pub struct MysqlFrameCodec {
     max_frame_length: usize,
 }
 
 impl MysqlFrameCodec {
+    /// Construct a `MySQL` codec with a maximum frame length.
     #[must_use]
     pub fn new(max_frame_length: usize) -> Self { Self { max_frame_length } }
 }
 
+/// Adapter that encodes and decodes `MySQL` frames.
 #[derive(Clone, Debug)]
 #[doc(hidden)]
 pub struct MysqlAdapter {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -119,6 +119,8 @@ impl Direction {
 pub fn inc_connections() { gauge!(CONNECTIONS_ACTIVE).increment(1.0); }
 
 /// Increment the active connections gauge.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_connections() {}
 
@@ -127,6 +129,8 @@ pub fn inc_connections() {}
 pub fn dec_connections() { gauge!(CONNECTIONS_ACTIVE).decrement(1.0); }
 
 /// Decrement the active connections gauge.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn dec_connections() {}
 
@@ -137,6 +141,8 @@ pub fn inc_frames(direction: Direction) {
 }
 
 /// Record a processed frame for the given direction.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_frames(_direction: Direction) {}
 
@@ -145,6 +151,8 @@ pub fn inc_frames(_direction: Direction) {}
 pub fn inc_deser_errors() { counter!(ERRORS_TOTAL, "kind" => "deserialization").increment(1); }
 
 /// Record a deserialization error.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_deser_errors() {}
 
@@ -153,6 +161,8 @@ pub fn inc_deser_errors() {}
 pub fn inc_handler_errors() { counter!(ERRORS_TOTAL, "kind" => "handler").increment(1); }
 
 /// Record a handler error.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_handler_errors() {}
 
@@ -176,6 +186,8 @@ pub fn inc_handler_errors() {}
 pub fn inc_connection_panics() { counter!(CONNECTION_PANICS).increment(1); }
 
 /// Record a panicking connection task.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_connection_panics() {}
 
@@ -185,6 +197,9 @@ pub fn inc_pool_bookkeeping_poison_recoveries() {
     counter!(POOL_BOOKKEEPING_POISON_RECOVERIES).increment(1);
 }
 
+/// Record a recovered client pool bookkeeping lock poison event.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_pool_bookkeeping_poison_recoveries() {}
 
@@ -217,6 +232,8 @@ pub fn inc_codec_error(error_type: &'static str, recovery_policy: &'static str) 
 }
 
 /// Record a codec error with its type and recovery policy.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_codec_error(_error_type: &'static str, _recovery_policy: &'static str) {}
 
@@ -227,6 +244,8 @@ pub(crate) fn inc_server_supervisor_cancellation(reason: ServerCancellationReaso
 }
 
 /// Record a server-supervisor cancellation request with a bounded reason.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub(crate) fn inc_server_supervisor_cancellation(_reason: ServerCancellationReason) {}
 
@@ -237,5 +256,7 @@ pub(crate) fn inc_server_accept_loop_exit(reason: ServerCancellationReason) {
 }
 
 /// Record an accept loop that exited after supervisor cancellation.
+///
+/// This function is a no-op when the `metrics` feature is disabled.
 #[cfg(not(feature = "metrics"))]
 pub(crate) fn inc_server_accept_loop_exit(_reason: ServerCancellationReason) {}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -80,7 +80,9 @@ pub const SERVER_ACCEPT_LOOPS_EXITED: &str = "wireframe_server_accept_loops_exit
 /// Bounded reasons for server-supervisor cancellation metrics.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum ServerCancellationReason {
+    /// Cancellation followed completion of the graceful-shutdown future.
     Graceful,
+    /// Cancellation followed the server-supervisor future being dropped.
     Dropped,
 }
 
@@ -224,6 +226,7 @@ pub(crate) fn inc_server_supervisor_cancellation(reason: ServerCancellationReaso
     counter!(SERVER_SUPERVISOR_CANCELLATIONS, "reason" => reason.as_str()).increment(1);
 }
 
+/// Record a server-supervisor cancellation request with a bounded reason.
 #[cfg(not(feature = "metrics"))]
 pub(crate) fn inc_server_supervisor_cancellation(_reason: ServerCancellationReason) {}
 
@@ -233,5 +236,6 @@ pub(crate) fn inc_server_accept_loop_exit(reason: ServerCancellationReason) {
     counter!(SERVER_ACCEPT_LOOPS_EXITED, "reason" => reason.as_str()).increment(1);
 }
 
+/// Record an accept loop that exited after supervisor cancellation.
 #[cfg(not(feature = "metrics"))]
 pub(crate) fn inc_server_accept_loop_exit(_reason: ServerCancellationReason) {}

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -116,6 +116,7 @@ impl Direction {
 #[cfg(feature = "metrics")]
 pub fn inc_connections() { gauge!(CONNECTIONS_ACTIVE).increment(1.0); }
 
+/// Increment the active connections gauge.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_connections() {}
 
@@ -123,6 +124,7 @@ pub fn inc_connections() {}
 #[cfg(feature = "metrics")]
 pub fn dec_connections() { gauge!(CONNECTIONS_ACTIVE).decrement(1.0); }
 
+/// Decrement the active connections gauge.
 #[cfg(not(feature = "metrics"))]
 pub fn dec_connections() {}
 
@@ -132,6 +134,7 @@ pub fn inc_frames(direction: Direction) {
     counter!(FRAMES_PROCESSED, "direction" => direction.as_str()).increment(1);
 }
 
+/// Record a processed frame for the given direction.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_frames(_direction: Direction) {}
 
@@ -139,6 +142,7 @@ pub fn inc_frames(_direction: Direction) {}
 #[cfg(feature = "metrics")]
 pub fn inc_deser_errors() { counter!(ERRORS_TOTAL, "kind" => "deserialization").increment(1); }
 
+/// Record a deserialization error.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_deser_errors() {}
 
@@ -146,6 +150,7 @@ pub fn inc_deser_errors() {}
 #[cfg(feature = "metrics")]
 pub fn inc_handler_errors() { counter!(ERRORS_TOTAL, "kind" => "handler").increment(1); }
 
+/// Record a handler error.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_handler_errors() {}
 
@@ -168,6 +173,7 @@ pub fn inc_handler_errors() {}
 #[cfg(feature = "metrics")]
 pub fn inc_connection_panics() { counter!(CONNECTION_PANICS).increment(1); }
 
+/// Record a panicking connection task.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_connection_panics() {}
 
@@ -208,6 +214,7 @@ pub fn inc_codec_error(error_type: &'static str, recovery_policy: &'static str) 
     .increment(1);
 }
 
+/// Record a codec error with its type and recovery policy.
 #[cfg(not(feature = "metrics"))]
 pub fn inc_codec_error(_error_type: &'static str, _recovery_policy: &'static str) {}
 

--- a/src/server/test_util.rs
+++ b/src/server/test_util.rs
@@ -10,12 +10,16 @@ use rstest::fixture;
 use super::{Bound, ServerError, WireframeServer};
 use crate::app::WireframeApp;
 
+/// Test-only preamble payload.
 #[derive(Debug, Clone, PartialEq, Encode, Decode)]
 pub struct TestPreamble {
+    /// Preamble identifier used by tests.
     pub id: u32,
+    /// Preamble message used by tests.
     pub message: String,
 }
 
+/// Produce a default [`WireframeApp`] factory closure for tests.
 #[fixture]
 pub fn factory() -> impl Fn() -> WireframeApp + Send + Sync + Clone + 'static {
     || WireframeApp::default()
@@ -68,6 +72,7 @@ pub fn free_addr() -> io::Result<SocketAddr> {
 #[cfg(test)]
 pub fn listener_addr(listener: &StdTcpListener) -> io::Result<SocketAddr> { listener.local_addr() }
 
+/// Bind a [`WireframeServer`] to an existing listener for tests.
 pub fn bind_server<F>(
     factory: F,
     listener: StdTcpListener,
@@ -78,6 +83,7 @@ where
     WireframeServer::new(factory).bind_existing_listener(listener)
 }
 
+/// Build a [`WireframeServer`] configured with [`TestPreamble`].
 #[cfg(test)]
 pub fn server_with_preamble<F>(factory: F) -> WireframeServer<F, TestPreamble>
 where


### PR DESCRIPTION
## Summary

This branch documents the previously uncovered public and `pub(crate)` Rust
items identified in #531, so generated API documentation describes the codec,
metrics and test-support surfaces consistently.

Closes #531.

The requested `missing_docs_in_private_items` manifest setting was deliberately
not retained: Rust 1.96 reports it as unknown lint `E0602`, which blocks every
compiled target. The established `missing_docs = "deny"` policy remains in
place, and the affected `pub(crate)` helpers now carry explicit documentation.

## Summary by Sourcery

Enhancements:
- Document previously uncovered codec, metrics, and test-support public and crate-visible APIs, including feature-disabled metrics shims, to improve generated API documentation coverage.

Enhancements:

- Document previously uncovered public and crate-visible codec, metrics and
  test-support APIs to improve generated Rust API documentation coverage.
- Document both enabled and disabled metrics APIs to keep feature configurations
  consistent under the existing missing-docs policy.

## Review walkthrough

- Start with [src/codec/examples.rs](https://github.com/leynos/wireframe/blob/issue-531-docstring-coverage-below-80-threshold-document-undocumented-public-items/src/codec/examples.rs#L14)
  for the Hotline and `MySQL` frame, codec and adapter documentation.
- Then review [src/codec.rs](https://github.com/leynos/wireframe/blob/issue-531-docstring-coverage-below-80-threshold-document-undocumented-public-items/src/codec.rs#L52)
  for the length-delimited codec halves and frame-length helper.
- Review [src/metrics.rs](https://github.com/leynos/wireframe/blob/issue-531-docstring-coverage-below-80-threshold-document-undocumented-public-items/src/metrics.rs#L77)
  for feature-disabled metrics API parity.
- Finish with [src/server/test_util.rs](https://github.com/leynos/wireframe/blob/issue-531-docstring-coverage-below-80-threshold-document-undocumented-public-items/src/server/test_util.rs#L13)
  for the documented test preamble and server helpers.

## Validation

- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed.
- `coderabbit review --agent --uncommitted`: completed with zero findings.

## Coverage verification

The local repository and PR #528 metadata do not identify the external
docstring-coverage command that reported 76.19%. Before merge, please run:

```text
Run the docstring-coverage tool that produced the 76.19% figure during review of
PR #528. Confirm the reported coverage for src/ now sits at or above 80% after
the added doc comments. Report the exact tool, command, and resulting percentage.
```

## References

- Issue [#531](https://github.com/leynos/wireframe/issues/531)
- Prior review [#528](https://github.com/leynos/wireframe/pull/528)
- [Lody session](https://lody.ai/leynos/sessions/27506865-558b-4f71-867b-d589928e92b2)
