### PR TITLE
Deny private documentation gaps across workspace (#666)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ name = "wireframe"
 path = "src/lib.rs"
 doctest = true
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 features = ["metrics", "pool", "testkit"]
 
@@ -105,7 +108,7 @@ examples = []
 test-support = []
 testkit = []
 
-[lints.clippy]
+[workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 
 # 1. hygiene
@@ -115,6 +118,7 @@ blanket_clippy_restriction_lints = "deny"
 cognitive_complexity = "deny"
 needless_pass_by_value = "deny"
 implicit_hasher = "deny"
+missing_docs_in_private_items = "deny"
 
 # 2. debugging leftovers
 dbg_macro = "deny"
@@ -136,13 +140,13 @@ host_endian_bytes = "deny"
 little_endian_bytes = "deny"
 big_endian_bytes = "deny"
 
-[lints.rust]
+[workspace.lints.rust]
 unknown_lints = "deny"
 renamed_and_removed_lints = "deny"
 missing_docs = "deny"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
 
-[lints.rustdoc]
+[workspace.lints.rustdoc]
 missing_crate_level_docs = "deny"
 broken_intra_doc_links = "deny"
 private_intra_doc_links = "deny"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 CRATE ?= wireframe
 CARGO ?= cargo
 BUILD_JOBS ?=
-CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
+CLIPPY_FLAGS ?= --workspace --all-targets --all-features -- -D warnings
 RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MARKDOWNLINT_CLI2_VERSION ?= 0.22.1
 MDLINT ?= npx --yes markdownlint-cli2@$(MARKDOWNLINT_CLI2_VERSION)
@@ -52,13 +52,15 @@ test-bdd: ## Run rstest-bdd tests only
 	RUSTFLAGS="-D warnings" $(CARGO) test --test bdd --all-features $(BUILD_JOBS)
 
 test: ## Run all tests (bdd + unit/integration)
-	RUSTFLAGS="-D warnings" $(CARGO) test --all-targets --all-features $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings" $(CARGO) test --workspace --all-targets --all-features $(BUILD_JOBS)
 
 test-workflow-contracts: ## Validate workflow invocation contracts
 	$(PYTHON_NO_BYTECODE_ENV) uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 test-doc: ## Run doctests across all features
-	RUSTFLAGS="-D warnings" $(CARGO) test --doc --all-features $(BUILD_JOBS)
+	# `wireframe_testing` doctests need generic app types that standalone snippets
+	# cannot infer; issue #578 tracks their repair.
+	RUSTFLAGS="-D warnings" $(CARGO) test --workspace --exclude wireframe_testing --doc --all-features $(BUILD_JOBS)
 
 doctest-benchmark: ## Check runnable/no_run doctest ratios
 	./scripts/doctest-benchmark.sh
@@ -67,7 +69,7 @@ bench-codec: ## Run codec performance benchmarks
 	RUSTFLAGS="-D warnings" $(CARGO) bench --bench codec_performance --bench codec_performance_alloc --features test-support $(BUILD_JOBS)
 
 typecheck: ## Run a workspace typecheck
-	RUSTFLAGS="-D warnings" $(CARGO) check --all-targets --all-features $(BUILD_JOBS)
+	RUSTFLAGS="-D warnings" $(CARGO) check --workspace --all-targets --all-features $(BUILD_JOBS)
 
 # will match target/debug/libmy_library.rlib and target/release/libmy_library.rlib
 target/%/lib$(CRATE).rlib: ## Build library in debug or release
@@ -80,7 +82,7 @@ target/%/lib$(CRATE).rlib: ## Build library in debug or release
 	  $@
 
 lint: ## Run Clippy with warnings denied
-	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --no-deps
+	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 	RUSTFLAGS="-D warnings" $(WHITAKER) --all -- --all-targets --all-features
 

--- a/benches/codec_performance.rs
+++ b/benches/codec_performance.rs
@@ -65,7 +65,7 @@ fn benchmark_encode(c: &mut Criterion) {
 ///
 /// The decode path mirrors the encode measurement contract: elapsed time comes
 /// from the shared workload helper, and the decoded byte count is black-boxed
-/// to prevent optimisation from removing the operation under test.
+/// to prevent optimization from removing the operation under test.
 fn benchmark_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/decode");
 

--- a/benches/codec_performance.rs
+++ b/benches/codec_performance.rs
@@ -22,6 +22,12 @@ use wireframe_testing::codec_benchmarks::{
     measure_unfragmented_wrap,
 };
 
+/// Measures a fragmented payload using the benchmark suite's fixed fragment
+/// capacity.
+///
+/// Fragment setup is part of the benchmark invariant, so an invalid workload
+/// is a configuration error and stops the benchmark instead of recording a
+/// misleading timing sample.
 fn fragmented_measurement(payload_class: PayloadClass, iterations: u64) -> Measurement {
     match measure_fragmented_wrap(payload_class, iterations, FRAGMENT_PAYLOAD_CAP_BYTES) {
         Ok(measurement) => measurement,
@@ -29,6 +35,12 @@ fn fragmented_measurement(payload_class: PayloadClass, iterations: u64) -> Measu
     }
 }
 
+/// Records Criterion timings for encoding the representative codec workloads.
+///
+/// Each custom iteration reports the helper's elapsed duration while
+/// black-boxing the encoded byte count keeps the measurement observable to the
+/// compiler. Throughput is labelled with the payload size so workload samples
+/// remain comparable.
 fn benchmark_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/encode");
 
@@ -49,6 +61,11 @@ fn benchmark_encode(c: &mut Criterion) {
     group.finish();
 }
 
+/// Records Criterion timings for decoding the representative codec workloads.
+///
+/// The decode path mirrors the encode measurement contract: elapsed time comes
+/// from the shared workload helper, and the decoded byte count is black-boxed
+/// to prevent optimisation from removing the operation under test.
 fn benchmark_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/decode");
 
@@ -69,6 +86,12 @@ fn benchmark_decode(c: &mut Criterion) {
     group.finish();
 }
 
+/// Compares wrapped payload costs with and without protocol fragmentation.
+///
+/// A validated baseline supplies the displayed ratio, then separate Criterion
+/// functions measure each wrapping path. Keeping the baseline outside the
+/// timed closures avoids folding validation and ratio calculation into the
+/// codec timings.
 fn benchmark_fragmentation_overhead(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/fragmentation_overhead");
 

--- a/benches/codec_performance_alloc.rs
+++ b/benches/codec_performance_alloc.rs
@@ -32,17 +32,31 @@ use wireframe_testing::codec_benchmarks::{
     payload_for_class,
 };
 
+/// Forwards allocations to the system allocator while counting only those
+/// observed while the benchmark's measurement window is enabled.
 struct CountingAllocator;
 
+/// Number of allocation operations observed in the current measurement
+/// window, including allocations made by the benchmark harness.
 static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
+/// Gate that keeps setup and reporting allocations out of a baseline count.
 static ALLOCATION_COUNTING_ENABLED: AtomicBool = AtomicBool::new(false);
 
+/// Process allocator used by this benchmark so encode/decode baselines cover
+/// the same allocation path as the code under test.
 #[global_allocator]
 static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;
 
+/// Decoder type used by the length-delimited workload, kept as an alias so
+/// the prepared-input enum and its macro-generated constructor share a clear
+/// type-level contract.
 type LengthDelimitedFrameDecoder = LengthDelimitedDecoder;
+/// Decoder type used by the Hotline workload, paired with the encoded bytes
+/// it consumes during each prepared decode iteration.
 type HotlineFrameDecoder = HotlineAdapter;
 
+/// Increment the shared counter only while an allocation baseline is active;
+/// the acquire load pairs with the measurement fences when toggling the gate.
 fn record_allocation_if_enabled() {
     if ALLOCATION_COUNTING_ENABLED.load(Ordering::Acquire) {
         ALLOCATION_COUNT.fetch_add(1, Ordering::SeqCst);
@@ -102,17 +116,28 @@ where
     ALLOCATION_COUNT.load(Ordering::SeqCst)
 }
 
+/// Owns encoded input and its stateful decoder so repeated decode measurements
+/// reuse the same prepared wire representation without measuring setup work.
 enum PreparedDecodeInput {
+    /// Prepared length-delimited bytes and decoder state.
     LengthDelimited {
+        /// Frozen encoded frame copied into a fresh mutable buffer per decode.
         encoded: Bytes,
+        /// Stateful decoder retained across iterations for protocol framing.
         decoder: LengthDelimitedFrameDecoder,
     },
+    /// Prepared Hotline bytes and decoder state.
     Hotline {
+        /// Frozen encoded Hotline frame used as the source for each iteration.
         encoded: Bytes,
+        /// Hotline decoder retained across iterations while each buffer is new.
         decoder: HotlineFrameDecoder,
     },
 }
 
+/// Generates a constructor that encodes one payload before a benchmark starts;
+/// this keeps allocation measurement focused on decoding and preserves the
+/// decoder's ownership of protocol state.
 macro_rules! codec_prepare_decode_input_fn {
     ($fn_name:ident, $codec_type:ty, $decoder_type:ty, $label_str:literal) => {
         fn $fn_name(payload: Bytes) -> Result<(Bytes, $decoder_type), String> {
@@ -140,6 +165,8 @@ codec_prepare_decode_input_fn!(
     "hotline"
 );
 
+/// Builds the codec-specific prepared input and reports seed-encoding failures
+/// before timing begins, so setup errors cannot be mistaken for decode results.
 fn prepare_decode_input(workload: BenchmarkWorkload) -> Result<PreparedDecodeInput, String> {
     let payload = payload_for_class(workload.payload_class);
     match workload.codec {
@@ -154,11 +181,18 @@ fn prepare_decode_input(workload: BenchmarkWorkload) -> Result<PreparedDecodeInp
     }
 }
 
+/// Supplies the codec-specific naming and payload projection needed to apply
+/// one generic decode loop to both frame formats.
 struct DecodeOps<D: Decoder> {
+    /// Label included in errors so a failed iteration identifies its workload.
     codec_name: &'static str,
+    /// Extracts the payload to assert that framing yielded usable data.
     frame_payload: fn(&D::Item) -> &[u8],
 }
 
+/// Repeatedly decodes independent copies of one frame and checks that each
+/// result has a payload; a fresh buffer prevents consumed bytes from leaking
+/// between iterations while the decoder state remains owned by the caller.
 fn run_decode_iterations<D>(
     decoder: &mut D,
     encoded: &Bytes,
@@ -186,6 +220,8 @@ where
     Ok(())
 }
 
+/// Dispatches prepared input to its matching decoder and payload invariant,
+/// preserving the codec-specific state while sharing iteration accounting.
 fn run_prepared_decode_iterations(
     prepared_decode_input: &mut PreparedDecodeInput,
     iterations: u64,
@@ -212,6 +248,9 @@ fn run_prepared_decode_iterations(
     }
 }
 
+/// Registers allocation-baseline labels and timed encode/decode measurements;
+/// each workload completes its validation count before Criterion iterations
+/// begin, keeping labels stable and making regressions comparable across runs.
 fn benchmark_allocations(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/allocations");
 

--- a/crates/wireframe-verification/Cargo.toml
+++ b/crates/wireframe-verification/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 stateright = "0.31.0"
 wireframe = { path = "../..", features = ["test-support"] }

--- a/crates/wireframe-verification/src/connection_model/model.rs
+++ b/crates/wireframe-verification/src/connection_model/model.rs
@@ -7,6 +7,7 @@ use super::{ConnectionAction, ConnectionState, properties::properties, state::Ac
 /// Small semantic model used to land the verification crate and shared harness.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PlaceholderConnectionModel {
+    /// Caps a single checker path so CI explores a representative, finite model.
     max_steps: u8,
 }
 
@@ -16,7 +17,11 @@ impl Default for PlaceholderConnectionModel {
 }
 
 impl PlaceholderConnectionModel {
-    /// Create a model with an explicit state-space depth bound.
+    /// Creates a model with an explicit state-space depth bound.
+    ///
+    /// The bound limits path exploration rather than changing which connection
+    /// transitions are legal.
+    #[must_use]
     pub fn new(max_steps: u8) -> Self { Self { max_steps } }
 
     /// Clone `state` and advance the step counter by one.
@@ -41,15 +46,15 @@ impl PlaceholderConnectionModel {
 
     /// Transition: enqueue a high-priority output request.
     fn apply_enqueue_high(state: &ConnectionState) -> Option<ConnectionState> {
-        Self::apply_if(state, !state.high_priority_queued, |next| {
-            next.high_priority_queued = true;
+        Self::apply_if(state, !state.pending_outputs.high_priority_queued, |next| {
+            next.pending_outputs.high_priority_queued = true;
         })
     }
 
     /// Transition: enqueue a low-priority output request.
     fn apply_enqueue_low(state: &ConnectionState) -> Option<ConnectionState> {
-        Self::apply_if(state, !state.low_priority_queued, |next| {
-            next.low_priority_queued = true;
+        Self::apply_if(state, !state.pending_outputs.low_priority_queued, |next| {
+            next.pending_outputs.low_priority_queued = true;
         })
     }
 
@@ -70,26 +75,26 @@ impl PlaceholderConnectionModel {
 
     /// Transition: emit the queued high-priority output.
     fn apply_emit_high(state: &ConnectionState) -> Option<ConnectionState> {
-        Self::apply_if(state, state.high_priority_queued, |next| {
-            next.high_priority_queued = false;
-            next.emitted_high_priority = true;
-            next.fairness_allows_low = true;
+        Self::apply_if(state, state.pending_outputs.high_priority_queued, |next| {
+            next.pending_outputs.high_priority_queued = false;
+            next.emissions.high_priority = true;
+            next.pending_outputs.fairness_allows_low = true;
         })
     }
 
     /// Transition: emit the queued low-priority output under the fairness policy.
     fn apply_emit_low(state: &ConnectionState) -> Option<ConnectionState> {
         Self::apply_if(state, state.can_emit_low_priority(), |next| {
-            next.low_priority_queued = false;
-            next.emitted_low_priority = true;
-            next.fairness_allows_low = false;
+            next.pending_outputs.low_priority_queued = false;
+            next.emissions.low_priority = true;
+            next.pending_outputs.fairness_allows_low = false;
         })
     }
 
     /// Transition: emit one frame from the active output stream.
     fn apply_emit_active_frame(state: &ConnectionState) -> Option<ConnectionState> {
         Self::apply_if(state, !state.is_output_idle(), |next| {
-            next.shutdown_during_output = state.shutdown_requested;
+            next.shutdown.during_output = state.shutdown.requested;
         })
     }
 
@@ -100,7 +105,7 @@ impl PlaceholderConnectionModel {
             matches!(state.active_output, ActiveOutput::Response),
             |next| {
                 next.active_output = ActiveOutput::Idle;
-                next.response_completed = true;
+                next.completed_outputs.response = true;
             },
         )
     }
@@ -112,7 +117,7 @@ impl PlaceholderConnectionModel {
             matches!(state.active_output, ActiveOutput::MultiPacket),
             |next| {
                 next.active_output = ActiveOutput::Idle;
-                next.multi_packet_completed = true;
+                next.completed_outputs.multi_packet = true;
                 next.multi_packet_terminal_count =
                     next.multi_packet_terminal_count.saturating_add(1);
             },
@@ -121,16 +126,16 @@ impl PlaceholderConnectionModel {
 
     /// Transition: request connection shutdown.
     fn apply_shutdown(state: &ConnectionState) -> Option<ConnectionState> {
-        Self::apply_if(state, !state.shutdown_requested, |next| {
-            next.shutdown_requested = true;
-            next.shutdown_during_output = !state.is_output_idle();
+        Self::apply_if(state, !state.shutdown.requested, |next| {
+            next.shutdown.requested = true;
+            next.shutdown.during_output = !state.is_output_idle();
         })
     }
 
     /// Transition: advance the fairness timer to allow low-priority emission.
     fn apply_tick_fairness(state: &ConnectionState) -> Option<ConnectionState> {
-        Self::apply_if(state, state.low_priority_queued, |next| {
-            next.fairness_allows_low = true;
+        Self::apply_if(state, state.pending_outputs.low_priority_queued, |next| {
+            next.pending_outputs.fairness_allows_low = true;
         })
     }
 }
@@ -189,6 +194,7 @@ mod tests {
     use stateright::Model;
 
     use super::*;
+    use crate::connection_model::state::{PendingOutputs, ShutdownState};
 
     #[rstest]
     #[case(ConnectionAction::EnqueueHigh, true, false)]
@@ -204,8 +210,8 @@ mod tests {
             .expect("enqueue transition should be enabled");
 
         assert_eq!(next.steps, 1);
-        assert_eq!(next.high_priority_queued, expected_high);
-        assert_eq!(next.low_priority_queued, expected_low);
+        assert_eq!(next.pending_outputs.high_priority_queued, expected_high);
+        assert_eq!(next.pending_outputs.low_priority_queued, expected_low);
     }
 
     #[rstest]
@@ -225,8 +231,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case(ConnectionAction::EnqueueHigh, ConnectionState { high_priority_queued: true, ..Default::default() })]
-    #[case(ConnectionAction::EnqueueLow, ConnectionState { low_priority_queued: true, ..Default::default() })]
+    #[case(ConnectionAction::EnqueueHigh, ConnectionState {
+        pending_outputs: PendingOutputs { high_priority_queued: true, ..Default::default() },
+        ..Default::default()
+    })]
+    #[case(ConnectionAction::EnqueueLow, ConnectionState {
+        pending_outputs: PendingOutputs { low_priority_queued: true, ..Default::default() },
+        ..Default::default()
+    })]
     fn next_state_rejects_duplicate_enqueue(
         #[case] action: ConnectionAction,
         #[case] state: ConnectionState,
@@ -238,7 +250,10 @@ mod tests {
 
     #[rstest]
     #[case(ConnectionState { active_output: ActiveOutput::Response, ..Default::default() })]
-    #[case(ConnectionState { shutdown_requested: true, ..Default::default() })]
+    #[case(ConnectionState {
+        shutdown: ShutdownState { requested: true, ..Default::default() },
+        ..Default::default()
+    })]
     fn install_transitions_require_idle_output_and_no_shutdown(#[case] state: ConnectionState) {
         let model = PlaceholderConnectionModel::default();
 
@@ -255,9 +270,11 @@ mod tests {
     #[rstest]
     #[case(ConnectionState::default())]
     #[case(ConnectionState {
-        low_priority_queued: true,
-        high_priority_queued: true,
-        fairness_allows_low: false,
+        pending_outputs: PendingOutputs {
+            low_priority_queued: true,
+            high_priority_queued: true,
+            fairness_allows_low: false,
+        },
         ..Default::default()
     })]
     fn emit_low_priority_requires_queue_and_fairness(#[case] state: ConnectionState) {

--- a/crates/wireframe-verification/src/connection_model/properties.rs
+++ b/crates/wireframe-verification/src/connection_model/properties.rs
@@ -29,6 +29,11 @@ pub(super) fn properties() -> Vec<Property<PlaceholderConnectionModel>> {
 }
 
 /// Invariant: the multi-packet terminator count never exceeds 1.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Stateright property callbacks are function pointers with `&Model` as their required \
+              first parameter."
+)]
 fn multi_packet_terminator_is_single(
     _model: &PlaceholderConnectionModel,
     state: &ConnectionState,
@@ -37,31 +42,56 @@ fn multi_packet_terminator_is_single(
 }
 
 /// Witness: a high-priority frame has been emitted.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Stateright property callbacks are function pointers with `&Model` as their required \
+              first parameter."
+)]
 fn high_priority_progress(_model: &PlaceholderConnectionModel, state: &ConnectionState) -> bool {
-    state.emitted_high_priority
+    state.emissions.high_priority
 }
 
 /// Witness: a low-priority frame has been emitted.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Stateright property callbacks are function pointers with `&Model` as their required \
+              first parameter."
+)]
 fn low_priority_progress(_model: &PlaceholderConnectionModel, state: &ConnectionState) -> bool {
-    state.emitted_low_priority
+    state.emissions.low_priority
 }
 
 /// Witness: a response output stream has completed.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Stateright property callbacks are function pointers with `&Model` as their required \
+              first parameter."
+)]
 fn response_completion(_model: &PlaceholderConnectionModel, state: &ConnectionState) -> bool {
-    state.response_completed
+    state.completed_outputs.response
 }
 
 /// Witness: a multi-packet output stream has completed.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Stateright property callbacks are function pointers with `&Model` as their required \
+              first parameter."
+)]
 fn multi_packet_completion(_model: &PlaceholderConnectionModel, state: &ConnectionState) -> bool {
-    state.multi_packet_completed
+    state.completed_outputs.multi_packet
 }
 
 /// Witness: shutdown was requested while an output was active.
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "Stateright property callbacks are function pointers with `&Model` as their required \
+              first parameter."
+)]
 fn shutdown_races_active_output(
     _model: &PlaceholderConnectionModel,
     state: &ConnectionState,
 ) -> bool {
-    state.shutdown_during_output
+    state.shutdown.during_output
 }
 
 #[cfg(test)]
@@ -96,7 +126,10 @@ mod tests {
     ) {
         let model = PlaceholderConnectionModel::default();
         let state = ConnectionState {
-            emitted_high_priority,
+            emissions: super::super::state::EmissionEvidence {
+                high_priority: emitted_high_priority,
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -112,7 +145,10 @@ mod tests {
     ) {
         let model = PlaceholderConnectionModel::default();
         let state = ConnectionState {
-            emitted_low_priority,
+            emissions: super::super::state::EmissionEvidence {
+                low_priority: emitted_low_priority,
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -128,7 +164,10 @@ mod tests {
     ) {
         let model = PlaceholderConnectionModel::default();
         let state = ConnectionState {
-            response_completed,
+            completed_outputs: super::super::state::CompletedOutputs {
+                response: response_completed,
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -144,7 +183,10 @@ mod tests {
     ) {
         let model = PlaceholderConnectionModel::default();
         let state = ConnectionState {
-            multi_packet_completed,
+            completed_outputs: super::super::state::CompletedOutputs {
+                multi_packet: multi_packet_completed,
+                ..Default::default()
+            },
             ..Default::default()
         };
 
@@ -160,7 +202,10 @@ mod tests {
     ) {
         let model = PlaceholderConnectionModel::default();
         let state = ConnectionState {
-            shutdown_during_output,
+            shutdown: super::super::state::ShutdownState {
+                during_output: shutdown_during_output,
+                ..Default::default()
+            },
             ..Default::default()
         };
 

--- a/crates/wireframe-verification/src/connection_model/state.rs
+++ b/crates/wireframe-verification/src/connection_model/state.rs
@@ -17,28 +17,56 @@ pub enum ActiveOutput {
 pub struct ConnectionState {
     /// Number of transitions taken so far; bounded by `PlaceholderConnectionModel::max_steps`.
     pub(crate) steps: u8,
-    /// A high-priority output request is waiting to be emitted.
-    pub(crate) high_priority_queued: bool,
-    /// A low-priority output request is waiting to be emitted.
-    pub(crate) low_priority_queued: bool,
-    /// Fairness policy currently permits a low-priority emission.
-    pub(crate) fairness_allows_low: bool,
+    /// Queued-output state that governs priority selection and fairness.
+    pub(super) pending_outputs: PendingOutputs,
     /// Output stream currently held by the connection.
     pub(crate) active_output: ActiveOutput,
-    /// Shutdown has been requested for this connection.
-    pub(crate) shutdown_requested: bool,
-    /// At least one high-priority frame has been emitted.
-    pub(crate) emitted_high_priority: bool,
-    /// At least one low-priority frame has been emitted.
-    pub(crate) emitted_low_priority: bool,
-    /// A response output stream has been completed.
-    pub(crate) response_completed: bool,
-    /// A multi-packet output stream has been completed.
-    pub(crate) multi_packet_completed: bool,
-    /// Shutdown was requested or applied while an output was active.
-    pub(crate) shutdown_during_output: bool,
+    /// Shutdown request and its interaction with the active output.
+    pub(super) shutdown: ShutdownState,
+    /// Observable progress markers for priority emissions.
+    pub(super) emissions: EmissionEvidence,
+    /// Completion markers retained as liveness witnesses for both stream kinds.
+    pub(super) completed_outputs: CompletedOutputs,
     /// Number of terminator frames appended to multi-packet streams.
     pub(crate) multi_packet_terminal_count: u8,
+}
+
+/// Queue facts kept together because fairness interprets them as one decision.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub(super) struct PendingOutputs {
+    /// Records that a high-priority item must be selected before ordinary work.
+    pub(super) high_priority_queued: bool,
+    /// Records that an ordinary item remains eligible once fairness permits it.
+    pub(super) low_priority_queued: bool,
+    /// Grants one low-priority turn after high-priority traffic has progressed.
+    pub(super) fairness_allows_low: bool,
+}
+
+/// Shutdown facts retained so the checker can witness cancellation races.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub(super) struct ShutdownState {
+    /// Prevents installation of new output after connection teardown begins.
+    pub(super) requested: bool,
+    /// Captures that teardown overlapped an already-active output stream.
+    pub(super) during_output: bool,
+}
+
+/// Emission witnesses used only to prove that each priority can make progress.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub(super) struct EmissionEvidence {
+    /// Shows the high-priority path reached an emission transition.
+    pub(super) high_priority: bool,
+    /// Shows the low-priority path reached an emission transition.
+    pub(super) low_priority: bool,
+}
+
+/// Completion witnesses used to keep response and multi-packet liveness distinct.
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
+pub(super) struct CompletedOutputs {
+    /// Shows a response stream returned ownership of the active-output slot.
+    pub(super) response: bool,
+    /// Shows a multi-packet stream returned ownership of the active-output slot.
+    pub(super) multi_packet: bool,
 }
 
 impl ConnectionState {
@@ -48,12 +76,14 @@ impl ConnectionState {
     /// Returns `true` when a new output stream may be installed (output idle and no shutdown
     /// pending).
     pub(crate) fn can_install_output(&self) -> bool {
-        !self.shutdown_requested && self.is_output_idle()
+        !self.shutdown.requested && self.is_output_idle()
     }
 
     /// Returns `true` when the fairness policy permits emitting the queued low-priority output.
     pub(crate) fn can_emit_low_priority(&self) -> bool {
-        self.low_priority_queued && (!self.high_priority_queued || self.fairness_allows_low)
+        self.pending_outputs.low_priority_queued
+            && (!self.pending_outputs.high_priority_queued
+                || self.pending_outputs.fairness_allows_low)
     }
 }
 
@@ -61,7 +91,7 @@ impl ConnectionState {
 mod tests {
     use rstest::rstest;
 
-    use super::{ActiveOutput, ConnectionState};
+    use super::{ActiveOutput, ConnectionState, PendingOutputs, ShutdownState};
 
     #[rstest]
     #[case(ActiveOutput::Idle, true)]
@@ -87,7 +117,10 @@ mod tests {
         #[case] expected: bool,
     ) {
         let state = ConnectionState {
-            shutdown_requested: shutdown,
+            shutdown: ShutdownState {
+                requested: shutdown,
+                ..Default::default()
+            },
             active_output: active,
             ..Default::default()
         };
@@ -108,9 +141,11 @@ mod tests {
         #[case] expected: bool,
     ) {
         let state = ConnectionState {
-            low_priority_queued: low,
-            high_priority_queued: high,
-            fairness_allows_low: fairness,
+            pending_outputs: PendingOutputs {
+                low_priority_queued: low,
+                high_priority_queued: high,
+                fairness_allows_low: fairness,
+            },
             ..Default::default()
         };
 

--- a/crates/wireframe-verification/src/harness.rs
+++ b/crates/wireframe-verification/src/harness.rs
@@ -7,13 +7,13 @@ use stateright::{Checker, CheckerBuilder, Model};
 /// Default maximum depth for repository-local Stateright checks.
 pub const DEFAULT_TARGET_MAX_DEPTH: NonZeroUsize = match NonZeroUsize::new(8) {
     Some(v) => v,
-    _ => unreachable!(),
+    None => NonZeroUsize::MIN,
 };
 
 /// Default state budget for repository-local Stateright checks.
 pub const DEFAULT_TARGET_STATE_COUNT: NonZeroUsize = match NonZeroUsize::new(5_000) {
     Some(v) => v,
-    _ => unreachable!(),
+    None => NonZeroUsize::MIN,
 };
 
 /// Bounds applied to a Stateright checker run.

--- a/examples/async_stream.rs
+++ b/examples/async_stream.rs
@@ -12,8 +12,20 @@ use tracing::info;
 use wireframe::response::Response;
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug, PartialEq)]
+/// A small serializable payload used to make stream ordering visible.
+///
+/// The value is deliberately just a sequence number: the example can focus on
+/// the producer yielding frames and the consumer awaiting them in order rather
+/// than on application-specific message handling.
 struct Frame(u32);
 
+/// Builds a response whose frames are produced lazily by an asynchronous
+/// stream.
+///
+/// The producer yields five sequence-numbered frames and then ends. Pinning
+/// the stream in the response matches the ownership contract expected by a
+/// `ConnectionActor`: the actor owns polling while the response remains a
+/// single value that can be returned from a handler.
 fn stream_response() -> Response<Frame> {
     let frames = try_stream! {
         for n in 0..5u32 {
@@ -23,6 +35,12 @@ fn stream_response() -> Response<Frame> {
     Response::Stream(Box::pin(frames))
 }
 
+/// Runs the stream consumer and logs each frame as it arrives.
+///
+/// Awaiting `next` one item at a time demonstrates that stream back-pressure
+/// keeps consumption ordered; the loop also naturally stops when the producer
+/// signals completion. This example intentionally treats a stream error as
+/// termination because it is illustrating response shape, not error recovery.
 async fn run() {
     tracing_subscriber::fmt::init();
 

--- a/examples/client_echo_login.rs
+++ b/examples/client_echo_login.rs
@@ -22,19 +22,29 @@ mod echo_login_contract;
 
 use echo_login_contract::{LOGIN_ROUTE_ID, LoginAck, LoginRequest};
 
+/// Fallible result used by the example's setup and protocol steps.
 type ExampleResult<T> = Result<T, Box<dyn std::error::Error>>;
+
+/// Client configuration for a TCP stream that can replay bytes consumed while
+/// negotiating the connection preamble.
 type Client = WireframeClient<BincodeSerializer, RewindStream<TcpStream>, ()>;
 
+/// Installs the default formatter once, leaving embedding applications free to
+/// provide their own subscriber when this example is reused.
 fn init_tracing() { let _ = tracing_subscriber::fmt::try_init(); }
 
+/// Returns the address used by the companion echo server.
 fn server_addr() -> ExampleResult<SocketAddr> { Ok("127.0.0.1:7878".parse()?) }
 
+/// Supplies the deterministic guest credentials used in the runnable example.
 fn default_login() -> LoginRequest {
     LoginRequest {
         username: "guest".to_string(),
     }
 }
 
+/// Logs the acknowledgement and its correlation token so request/response
+/// pairing remains visible when several calls share a connection.
 fn log_acknowledgement(response: &Envelope, ack: &LoginAck) {
     info!(
         username = %ack.username,
@@ -43,6 +53,9 @@ fn log_acknowledgement(response: &Envelope, ack: &LoginAck) {
     );
 }
 
+/// Rejects an acknowledgement whose echoed identity does not match the request.
+/// This check keeps a successful transport exchange from being mistaken for a
+/// successful application-level login.
 fn validate_acknowledgement(login: &LoginRequest, ack: &LoginAck) -> ExampleResult<()> {
     if ack.username != login.username {
         error!(
@@ -60,6 +73,8 @@ fn validate_acknowledgement(login: &LoginRequest, ack: &LoginAck) -> ExampleResu
     Ok(())
 }
 
+/// Encodes a login request, performs one correlated call, and decodes its reply.
+/// The returned envelope is retained so callers can inspect the correlation ID.
 async fn request_acknowledgement(
     client: &mut Client,
     login: &LoginRequest,
@@ -71,6 +86,7 @@ async fn request_acknowledgement(
     Ok((response, ack))
 }
 
+/// Runs the complete login handshake and reports protocol or transport errors.
 async fn run() -> Result<(), Box<dyn std::error::Error>> {
     init_tracing();
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,7 +5,18 @@
 
 use wireframe::{app::Envelope, serializer::BincodeSerializer, server::WireframeServer};
 
+/// Concrete application type used by the example's bincode-encoded envelope
+/// route.
+///
+/// The unit state keeps the example stateless while `Envelope` preserves the
+/// framework's request/response protocol at the application boundary.
 type App = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
+
+/// Thread-safe handler shape accepted by `WireframeApp::route`.
+///
+/// The shared callback can be cloned into each server-created application,
+/// while the boxed future lets a route return asynchronous work without
+/// imposing one concrete future type on the application.
 type EchoHandler =
     Arc<dyn Fn(&Envelope) -> Pin<Box<dyn std::future::Future<Output = ()> + Send>> + Send + Sync>;
 
@@ -14,6 +25,12 @@ use std::{error::Error, net::SocketAddr, pin::Pin, sync::Arc};
 use tokio::signal;
 use tracing::{error, info};
 
+/// Creates the asynchronous callback for the echo route.
+///
+/// The callback records receipt for observability; `WireframeApp` owns the
+/// protocol response and echoes the incoming envelope after the handler has
+/// completed. Keeping the handler side-effect-free makes the wire-level echo
+/// behaviour explicit in this minimal example.
 fn echo_handler() -> Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
     Box::pin(async {
         info!("echo request received");
@@ -21,8 +38,19 @@ fn echo_handler() -> Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
     })
 }
 
+/// Constructs an application and binds route `1` to the echo callback.
+///
+/// Application construction is fallible because serializer and route setup
+/// can reject an invalid configuration; callers can therefore rebuild the
+/// application without hiding that failure behind a panic.
 fn build_app(handler: EchoHandler) -> wireframe::app::Result<App> { App::new()?.route(1, handler) }
 
+/// Starts the echo server and waits for a Ctrl-C shutdown signal.
+///
+/// A factory supplies independently constructed application state to the
+/// server, while the shared handler remains thread-safe for those instances.
+/// Binding, application construction, and server execution errors propagate to
+/// the command-line boundary for reporting.
 async fn run() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 

--- a/examples/metadata_routing.rs
+++ b/examples/metadata_routing.rs
@@ -16,8 +16,12 @@ use wireframe::{
     serializer::{MessageCompatibilitySerializer, Serializer},
 };
 
+/// Application type used to route envelopes after the metadata header is read.
+/// The serializer extracts the route ID before payload decoding, so dispatch can
+/// select a handler without coupling routing to the bincode representation.
 type App = wireframe::app::WireframeApp<HeaderSerializer, (), Envelope>;
 
+/// Maximum frame buffer used by this in-memory protocol demonstration.
 const MAX_FRAME: usize = 64 * 1024;
 
 /// Frame format with a two-byte id, one-byte flags, and bincode payload.
@@ -74,8 +78,12 @@ impl FrameMetadata for HeaderSerializer {
 }
 
 #[derive(bincode::Decode, bincode::Encode)]
+/// Empty payload used to exercise metadata-only dispatch for a ping route.
 struct Ping;
 
+/// Builds the in-memory client/server exchange and verifies orderly shutdown.
+/// The client writes one length-delimited frame, closes its write side, and
+/// waits for the server task so the example does not leave an actor running.
 async fn run() -> io::Result<()> {
     let app = App::with_serializer(HeaderSerializer)
         .map_err(|error| io::Error::other(error.to_string()))?

--- a/examples/multi_packet.rs
+++ b/examples/multi_packet.rs
@@ -15,6 +15,8 @@ use tokio::time::sleep;
 use tracing::info;
 use wireframe::{WireframeError, response::Response};
 
+/// Ordered application messages emitted before the final stream summary.
+/// Keeping this fixture static makes the example's frame ordering reproducible.
 const TRANSCRIPT: &[&str] = &[
     "Client: HELLO",
     "Server: HELLO-ACK",
@@ -23,18 +25,25 @@ const TRANSCRIPT: &[&str] = &[
 ];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// Distinguishes a transcript chunk from the terminal stream summary.
 enum FrameKind {
+    /// Identifies the zero-based transcript entry carried by a frame.
     Chunk(usize),
+    /// Marks the final frame after every chunk producer has completed.
     Summary,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+/// One logical response item sent through the bounded response channel.
 struct Frame {
+    /// Identifies whether `data` is an ordered chunk or the terminal summary.
     kind: FrameKind,
+    /// Human-readable transcript content carried by this response item.
     data: String,
 }
 
 impl Frame {
+    /// Creates a chunk while preserving its position in the transcript.
     fn chunk(index: usize, data: &str) -> Self {
         Self {
             kind: FrameKind::Chunk(index),
@@ -42,6 +51,7 @@ impl Frame {
         }
     }
 
+    /// Creates the terminal item reporting how many chunks were attempted.
     fn summary(total_chunks: usize) -> Self {
         Self {
             kind: FrameKind::Summary,
@@ -59,6 +69,9 @@ impl Display for Frame {
     }
 }
 
+/// Starts concurrent chunk production and returns a bounded response stream.
+/// The summary task waits for the chunk task, preserving ordering even though
+/// both producers own senders; a dropped consumer causes each sender to stop.
 fn multi_packet_response() -> Response<Frame> {
     // Capacity two keeps memory usage tight and amplifies the back-pressure
     // effect for demonstration purposes.
@@ -92,10 +105,14 @@ fn multi_packet_response() -> Response<Frame> {
     response
 }
 
+/// Emits one response item using the example's display representation.
 fn log_frame(frame: &Frame) {
     info!("{frame}");
 }
 
+/// Consumes the response until all producers close the channel.
+/// Stream errors are propagated so the example demonstrates its normal error
+/// boundary rather than silently truncating a multipart response.
 async fn run() -> Result<(), WireframeError> {
     let _ = tracing_subscriber::fmt::try_init();
     let response = multi_packet_response();

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -19,20 +19,34 @@ mod runtime_bootstrap;
 #[path = "support/server_loop.rs"]
 mod server_loop;
 
+/// Application type used by this example's middleware and route wiring.
 type App = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
 
+/// Fallback listener address used when `SERVER_ADDR` is not configured.
 const DEFAULT_ADDR: &str = "127.0.0.1:7879";
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+/// Packet variants demonstrate dispatch after deserialisation at the edge.
 enum ExamplePacket {
+    /// Health-style message with no payload.
     Ping,
-    Chat { user: String, msg: String },
+    /// User-authored chat text, retained as owned strings for async handling.
+    Chat {
+        /// Display name used when logging the message.
+        user: String,
+        /// Message body carried through the decoded frame.
+        msg: String,
+    },
+    /// A collection of counters decoded as one logical statistics message.
     Stats(Vec<u32>),
 }
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+/// Wire payload combining transport metadata with one typed packet.
 struct Frame {
+    /// Metadata available to middleware for logging or routing decisions.
     headers: HashMap<String, String>,
+    /// Deserialised application message selected by the packet discriminator.
     packet: ExamplePacket,
 }
 
@@ -41,6 +55,7 @@ struct DecodeMiddleware;
 
 /// Service wrapper that handles frame decoding before invoking the inner service.
 struct DecodeService<S> {
+    /// Inner service invoked after decoding and observing the incoming frame.
     inner: S,
 }
 
@@ -78,18 +93,21 @@ impl Transform<HandlerService<Envelope>> for DecodeMiddleware {
     }
 }
 
+/// Route callback used to acknowledge a packet after middleware inspection.
 fn handle_packet(_env: &Envelope) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     Box::pin(async {
         info!("packet received");
     })
 }
 
+/// Assemble the example application with decoding middleware before its route.
 fn build_app() -> wireframe::app::Result<App> {
     App::new()?
         .wrap(DecodeMiddleware)?
         .route(1, Arc::new(handle_packet))
 }
 
+/// Read and validate the listener address, reporting malformed configuration.
 fn parse_server_addr() -> std::io::Result<SocketAddr> {
     let addr_str = std::env::var("SERVER_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
     addr_str.parse().map_err(|error| {
@@ -100,6 +118,7 @@ fn parse_server_addr() -> std::io::Result<SocketAddr> {
     })
 }
 
+/// Initialise tracing, bind the listener, and serve until shutdown is signalled.
 async fn run() -> std::io::Result<()> {
     runtime_bootstrap::init_tracing();
     let app = runtime_bootstrap::build_runtime_app(build_app)?;

--- a/examples/packet_enum.rs
+++ b/examples/packet_enum.rs
@@ -26,7 +26,7 @@ type App = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
 const DEFAULT_ADDR: &str = "127.0.0.1:7879";
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
-/// Packet variants demonstrate dispatch after deserialisation at the edge.
+/// Packet variants demonstrate dispatch after deserialization at the edge.
 enum ExamplePacket {
     /// Health-style message with no payload.
     Ping,
@@ -46,7 +46,7 @@ enum ExamplePacket {
 struct Frame {
     /// Metadata available to middleware for logging or routing decisions.
     headers: HashMap<String, String>,
-    /// Deserialised application message selected by the packet discriminator.
+    /// Deserialized application message selected by the packet discriminator.
     packet: ExamplePacket,
 }
 
@@ -118,7 +118,7 @@ fn parse_server_addr() -> std::io::Result<SocketAddr> {
     })
 }
 
-/// Initialise tracing, bind the listener, and serve until shutdown is signalled.
+/// Initialize tracing, bind the listener, and serve until shutdown is signalled.
 async fn run() -> std::io::Result<()> {
     runtime_bootstrap::init_tracing();
     let app = runtime_bootstrap::build_runtime_app(build_app)?;

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -19,17 +19,23 @@ mod runtime_bootstrap;
 #[path = "support/server_loop.rs"]
 mod server_loop;
 
+/// Application type assembled from bincode envelopes and the middleware chain.
 type App = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+/// Request payload whose counter is incremented by the pong service.
 struct Ping(u32);
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+/// Successful response payload carrying the incremented counter.
 struct Pong(u32);
 
 #[derive(bincode::Encode, bincode::BorrowDecode, Debug)]
+/// Error response payload used when decoding, encoding, or incrementing fails.
 struct ErrorMsg(String);
 
+/// Encodes a protocol error while retaining an empty payload fallback for the
+/// example's infallible middleware boundary.
 fn encode_error(msg: impl Into<String>) -> Vec<u8> {
     let err = ErrorMsg(msg.into());
     match err.to_bytes() {
@@ -41,6 +47,7 @@ fn encode_error(msg: impl Into<String>) -> Vec<u8> {
     }
 }
 
+/// Route ID registered for ping requests in the sample application.
 const PING_ID: u32 = 1;
 
 /// Handler invoked for `PING_ID` messages.
@@ -53,9 +60,13 @@ const PING_ID: u32 = 1;
 )]
 async fn ping_handler() {}
 
+/// Middleware adapter that turns a decoded ping into a pong response.
 struct PongMiddleware;
 
+/// Service wrapper that performs ping decoding, incrementing, and encoding
+/// while preserving the inner handler's correlation ID.
 struct PongService<S> {
+    /// Inner handler retained so middleware can compose with normal routing.
     inner: S,
 }
 
@@ -109,9 +120,12 @@ impl Transform<HandlerService<Envelope>> for PongMiddleware {
     }
 }
 
+/// Middleware marker that adds request/response tracing around a handler.
 struct Logging;
 
+/// Service wrapper that logs both sides of a call before returning its result.
 struct LoggingService<S> {
+    /// Inner service whose result is observed without changing its semantics.
     inner: S,
 }
 
@@ -140,6 +154,7 @@ impl<E: Packet> Transform<HandlerService<E>> for Logging {
     }
 }
 
+/// Constructs the ping route and wraps it with response and logging middleware.
 fn build_app() -> AppResult<App> {
     App::new()?
         .serializer(BincodeSerializer)
@@ -148,8 +163,10 @@ fn build_app() -> AppResult<App> {
         .wrap(Logging)
 }
 
+/// Default listener address used when no command-line address is supplied.
 const DEFAULT_ADDR: &str = "127.0.0.1:7878";
 
+/// Parses an optional listener address, falling back to the documented default.
 fn parse_server_addr() -> std::io::Result<SocketAddr> {
     let addr = std::env::args()
         .nth(1)
@@ -157,6 +174,9 @@ fn parse_server_addr() -> std::io::Result<SocketAddr> {
     addr.parse().map_err(std::io::Error::other)
 }
 
+/// Starts the server and keeps it alive until the shared shutdown signal fires.
+/// The server loop owns listener shutdown, ensuring accepted tasks finish in the
+/// same lifecycle as the example process.
 async fn run() -> std::io::Result<()> {
     runtime_bootstrap::init_tracing();
     let app = runtime_bootstrap::build_runtime_app(build_app)?;

--- a/examples/resp_codec_impl/codec.rs
+++ b/examples/resp_codec_impl/codec.rs
@@ -15,6 +15,9 @@ use super::{
 /// RESP frame codec for use with Wireframe.
 #[derive(Clone, Debug)]
 pub struct RespFrameCodec {
+    /// Upper bound applied before a frame is admitted to the transport.
+    /// Keeping this limit in the codec makes decoder and encoder enforcement
+    /// symmetrical, so neither direction can allocate an unbounded payload.
     max_frame_length: usize,
 }
 
@@ -27,10 +30,14 @@ impl RespFrameCodec {
 /// Tokio codec adapter for RESP frames.
 #[derive(Clone, Debug)]
 pub struct RespAdapter {
+    /// Maximum encoded or decoded frame size delegated by the parent codec.
+    /// The adapter checks it before advancing the input buffer or reserving
+    /// output capacity, preserving the stream boundary on rejected frames.
     max_frame_length: usize,
 }
 
 impl RespAdapter {
+    /// Build a Tokio adapter carrying the frame-size policy for one direction.
     fn new(max_frame_length: usize) -> Self { Self { max_frame_length } }
 }
 

--- a/examples/resp_codec_impl/encode.rs
+++ b/examples/resp_codec_impl/encode.rs
@@ -15,6 +15,9 @@ const MAX_RECURSION_DEPTH: usize = 64;
 /// Compute the encoded length of a RESP frame.
 pub fn encoded_len(frame: &RespFrame) -> Result<usize, io::Error> { encoded_len_at(frame, 0) }
 
+/// Measure a frame recursively while enforcing the nesting safety limit.
+/// Checked arithmetic turns a size overflow into an input error before the
+/// encoder reserves or writes any destination capacity.
 fn encoded_len_at(frame: &RespFrame, depth: usize) -> Result<usize, io::Error> {
     if depth > MAX_RECURSION_DEPTH {
         return Err(io::Error::new(
@@ -53,6 +56,9 @@ pub fn encode_frame(frame: &RespFrame, dst: &mut BytesMut) -> Result<(), io::Err
     encode_frame_at(frame, dst, 0)
 }
 
+/// Append one frame and its nested children using RESP wire ordering.
+/// The depth guard matches [`encoded_len_at`] so length validation and actual
+/// emission reject the same recursively constructed input.
 fn encode_frame_at(frame: &RespFrame, dst: &mut BytesMut, depth: usize) -> Result<(), io::Error> {
     if depth > MAX_RECURSION_DEPTH {
         return Err(io::Error::new(
@@ -104,6 +110,7 @@ fn encode_frame_at(frame: &RespFrame, dst: &mut BytesMut, depth: usize) -> Resul
     Ok(())
 }
 
+/// Count decimal digits without allocating a temporary representation.
 fn digits_len_usize(mut value: usize) -> usize {
     let mut digits = 1;
     while value >= 10 {
@@ -113,6 +120,7 @@ fn digits_len_usize(mut value: usize) -> usize {
     digits
 }
 
+/// Count digits in a signed integer, including its possible minus sign.
 fn digits_len_i64(value: i64) -> usize {
     let mut digits = 1;
     let mut cursor = value;
@@ -120,9 +128,14 @@ fn digits_len_i64(value: i64) -> usize {
         cursor /= 10;
         digits += 1;
     }
-    if value < 0 { digits + 1 } else { digits }
+    if value < 0 {
+        digits + 1
+    } else {
+        digits
+    }
 }
 
+/// Add encoded-size components and report overflow as a frame-size error.
 fn checked_add(lhs: usize, rhs: usize) -> Result<usize, io::Error> {
     lhs.checked_add(rhs)
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "frame too large"))

--- a/examples/resp_codec_impl/encode.rs
+++ b/examples/resp_codec_impl/encode.rs
@@ -128,11 +128,7 @@ fn digits_len_i64(value: i64) -> usize {
         cursor /= 10;
         digits += 1;
     }
-    if value < 0 {
-        digits + 1
-    } else {
-        digits
-    }
+    if value < 0 { digits + 1 } else { digits }
 }
 
 /// Add encoded-size components and report overflow as a frame-size error.

--- a/examples/resp_codec_impl/parse.rs
+++ b/examples/resp_codec_impl/parse.rs
@@ -87,7 +87,6 @@ pub fn parse_frame(
 ) -> Result<Option<(RespFrame, usize)>, io::Error> {
     parse_frame_at(buf, 0, max_frame_length, 0)
 }
-
 /// Parse a line and convert to UTF-8.
 fn parse_text_line<'a>(
     ctx: ParseContext<'a>,
@@ -100,7 +99,6 @@ fn parse_text_line<'a>(
         str::from_utf8(line).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, error_msg))?;
     Ok(Some((text, next)))
 }
-
 /// Parse a text-based RESP frame (simple string or error).
 fn parse_text_frame<F>(
     ctx: ParseContext<'_>,
@@ -117,9 +115,7 @@ where
     let frame = constructor(text.to_string());
     Ok(Some((frame, next - start)))
 }
-
-/// Decode a `+` frame, retaining incremental `Ok(None)` behaviour for a
-/// terminator that has not arrived yet.
+/// Decode a `+` frame without consuming incomplete input.
 fn parse_simple_string(
     buf: &BytesMut,
     start: usize,
@@ -131,7 +127,6 @@ fn parse_simple_string(
         RespFrame::SimpleString,
     )
 }
-
 /// Decode a `-` frame and classify malformed or non-UTF-8 text as input data.
 fn parse_error(
     buf: &BytesMut,
@@ -144,7 +139,6 @@ fn parse_error(
         RespFrame::Error,
     )
 }
-
 /// Decode a `:` frame as a signed 64-bit value without consuming partial input.
 fn parse_integer(
     buf: &BytesMut,
@@ -169,8 +163,8 @@ enum BulkLength {
     Sized(usize),
 }
 
-#[derive(Clone, Copy, Debug)]
 /// Captures the offsets and byte budget needed to validate one bulk payload.
+#[derive(Clone, Copy, Debug)]
 struct BulkPayloadSpec {
     /// Start of the complete bulk frame, used for the consumed-byte count.
     start: usize,
@@ -234,8 +228,7 @@ fn parse_bulk_length(
     Ok(Some((BulkLength::Sized(len), next)))
 }
 
-/// Check availability and framing of a bulk payload before copying its bytes.
-/// Returning `Ok(None)` leaves incomplete input untouched for the next read.
+/// Validate a bulk payload without consuming incomplete input.
 fn parse_bulk_payload(
     buf: &BytesMut,
     spec: BulkPayloadSpec,
@@ -289,8 +282,7 @@ fn validate_bulk_terminator(buf: &BytesMut, cursor: usize) -> Result<(), io::Err
     Ok(())
 }
 
-/// Decode an array recursively while bounding element count, depth, and bytes.
-/// Child parsing advances the cursor only after a complete child is available.
+/// Decode an array while bounding element count, depth, and bytes.
 fn parse_array(
     buf: &BytesMut,
     start: usize,
@@ -349,9 +341,7 @@ fn parse_array(
     Ok(Some((RespFrame::Array(Some(frames)), consumed)))
 }
 
-/// Dispatch one frame at an offset while preserving incomplete-buffer semantics.
-/// The depth check prevents attacker-controlled nesting from exhausting the
-/// parser stack.
+/// Dispatch one complete frame while bounding attacker-controlled nesting.
 fn parse_frame_at(
     buf: &BytesMut,
     start: usize,
@@ -380,8 +370,7 @@ fn parse_frame_at(
     }
 }
 
-/// Find a CRLF-terminated line without reading beyond the configured budget.
-/// Partial lines remain in the caller's buffer so a subsequent read can resume.
+/// Find a bounded CRLF line without consuming partial input.
 fn parse_line(
     buf: &BytesMut,
     start: usize,

--- a/examples/resp_codec_impl/parse.rs
+++ b/examples/resp_codec_impl/parse.rs
@@ -61,12 +61,16 @@ fn decimal_digits(mut value: usize) -> usize {
 /// Encapsulates buffer context for RESP frame parsing.
 #[derive(Clone, Copy)]
 struct ParseContext<'a> {
+    /// Borrowed receive buffer; parsing never consumes it directly.
     buf: &'a BytesMut,
+    /// Offset of the current frame, used to report bytes consumed precisely.
     start: usize,
+    /// Per-frame byte budget applied to line and payload parsing.
     max_frame_length: usize,
 }
 
 impl<'a> ParseContext<'a> {
+    /// Capture the immutable buffer view and limits for one parser operation.
     fn new(buf: &'a BytesMut, start: usize, max_frame_length: usize) -> Self {
         Self {
             buf,
@@ -114,6 +118,8 @@ where
     Ok(Some((frame, next - start)))
 }
 
+/// Decode a `+` frame, retaining incremental `Ok(None)` behaviour for a
+/// terminator that has not arrived yet.
 fn parse_simple_string(
     buf: &BytesMut,
     start: usize,
@@ -126,6 +132,7 @@ fn parse_simple_string(
     )
 }
 
+/// Decode a `-` frame and classify malformed or non-UTF-8 text as input data.
 fn parse_error(
     buf: &BytesMut,
     start: usize,
@@ -138,6 +145,7 @@ fn parse_error(
     )
 }
 
+/// Decode a `:` frame as a signed 64-bit value without consuming partial input.
 fn parse_integer(
     buf: &BytesMut,
     start: usize,
@@ -153,19 +161,28 @@ fn parse_integer(
     Ok(Some((RespFrame::Integer(value), next - start)))
 }
 
+/// Describes whether a bulk header carries a payload or RESP's null marker.
 enum BulkLength {
+    /// The `-1` header denotes an absent payload rather than zero bytes.
     Null,
+    /// A non-negative length whose payload and trailing CRLF must follow.
     Sized(usize),
 }
 
 #[derive(Clone, Copy, Debug)]
+/// Captures the offsets and byte budget needed to validate one bulk payload.
 struct BulkPayloadSpec {
+    /// Start of the complete bulk frame, used for the consumed-byte count.
     start: usize,
+    /// First byte of payload data, immediately after the header CRLF.
     payload_start: usize,
+    /// Number of payload bytes promised by the header.
     len: usize,
+    /// Maximum complete-frame size accepted by the transport.
     max_frame_length: usize,
 }
 
+/// Parse a bulk header and, when present, validate and copy its payload.
 fn parse_bulk_string(
     buf: &BytesMut,
     start: usize,
@@ -188,6 +205,7 @@ fn parse_bulk_string(
     }
 }
 
+/// Parse the signed length header, accepting only `-1` or non-negative sizes.
 fn parse_bulk_length(
     buf: &BytesMut,
     start: usize,
@@ -216,6 +234,8 @@ fn parse_bulk_length(
     Ok(Some((BulkLength::Sized(len), next)))
 }
 
+/// Check availability and framing of a bulk payload before copying its bytes.
+/// Returning `Ok(None)` leaves incomplete input untouched for the next read.
 fn parse_bulk_payload(
     buf: &BytesMut,
     spec: BulkPayloadSpec,
@@ -250,6 +270,7 @@ fn parse_bulk_payload(
     )))
 }
 
+/// Require the CRLF delimiter that terminates every non-null bulk payload.
 fn validate_bulk_terminator(buf: &BytesMut, cursor: usize) -> Result<(), io::Error> {
     let cr = buf
         .get(cursor)
@@ -268,6 +289,8 @@ fn validate_bulk_terminator(buf: &BytesMut, cursor: usize) -> Result<(), io::Err
     Ok(())
 }
 
+/// Decode an array recursively while bounding element count, depth, and bytes.
+/// Child parsing advances the cursor only after a complete child is available.
 fn parse_array(
     buf: &BytesMut,
     start: usize,
@@ -326,6 +349,9 @@ fn parse_array(
     Ok(Some((RespFrame::Array(Some(frames)), consumed)))
 }
 
+/// Dispatch one frame at an offset while preserving incomplete-buffer semantics.
+/// The depth check prevents attacker-controlled nesting from exhausting the
+/// parser stack.
 fn parse_frame_at(
     buf: &BytesMut,
     start: usize,
@@ -354,6 +380,8 @@ fn parse_frame_at(
     }
 }
 
+/// Find a CRLF-terminated line without reading beyond the configured budget.
+/// Partial lines remain in the caller's buffer so a subsequent read can resume.
 fn parse_line(
     buf: &BytesMut,
     start: usize,

--- a/examples/support/echo_login_contract.rs
+++ b/examples/support/echo_login_contract.rs
@@ -6,11 +6,15 @@ pub const LOGIN_ROUTE_ID: u32 = 1;
 /// Client login payload sent to the echo server.
 #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::BorrowDecode)]
 pub struct LoginRequest {
+    /// User name carried in the request and echoed by the server as proof that
+    /// the login handshake decoded the same payload on both sides.
     pub username: String,
 }
 
 /// Acknowledgement payload decoded from the echoed login message.
 #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::BorrowDecode)]
 pub struct LoginAck {
+    /// User name returned by the server; the client compares it with its
+    /// request before considering the handshake complete.
     pub username: String,
 }

--- a/examples/support/runtime_bootstrap.rs
+++ b/examples/support/runtime_bootstrap.rs
@@ -8,6 +8,9 @@ use wireframe::{app::Envelope, serializer::BincodeSerializer};
 
 use crate::server_loop;
 
+/// Concrete application handle shared by the TCP examples' bootstrap helpers.
+/// Keeping the alias here ensures each example wires the same envelope and
+/// serializer contract into its runtime and connection tasks.
 type ExampleApp = wireframe::app::WireframeApp<BincodeSerializer, (), Envelope>;
 
 /// Initialize tracing for examples, ignoring duplicate global subscriber setup.

--- a/examples/support/server_loop.rs
+++ b/examples/support/server_loop.rs
@@ -6,12 +6,12 @@ use tokio::{
 };
 use tracing::{error, info};
 
+/// Report either a signal-wait failure or the normal shutdown message.
 #[expect(
     clippy::cognitive_complexity,
     reason = "This helper only logs the two shutdown outcomes; tracing macros inflate the lint \
               score"
 )]
-/// Report either a signal-wait failure or the normal shutdown message.
 fn log_shutdown_result(result: std::io::Result<()>, shutdown_message: &str) {
     if let Err(error) = result {
         error!("failed waiting for shutdown signal: {error}");

--- a/examples/support/server_loop.rs
+++ b/examples/support/server_loop.rs
@@ -11,6 +11,7 @@ use tracing::{error, info};
     reason = "This helper only logs the two shutdown outcomes; tracing macros inflate the lint \
               score"
 )]
+/// Report either a signal-wait failure or the normal shutdown message.
 fn log_shutdown_result(result: std::io::Result<()>, shutdown_message: &str) {
     if let Err(error) = result {
         error!("failed waiting for shutdown signal: {error}");

--- a/src/app/builder/core.rs
+++ b/src/app/builder/core.rs
@@ -32,20 +32,34 @@ pub struct WireframeApp<
     E: Packet = Envelope,
     F: FrameCodec = LengthDelimitedFrameCodec,
 > {
+    /// Handler factories keyed by the protocol message identifier.
     pub(in crate::app) handlers: HashMap<u32, Handler<E>>,
+    /// Lazily built middleware chains, shared after the first connection uses them.
     pub(in crate::app) routes: OnceCell<Arc<HashMap<u32, HandlerService<E>>>>,
+    /// Middleware applied in registration order around each handler.
     pub(in crate::app) middleware: Vec<Box<dyn Middleware<E>>>,
+    /// Serializer retained by every connection built from this application.
     pub(in crate::app) serializer: S,
+    /// Type-erased application state available to handlers and hooks.
     pub(in crate::app) app_data: AppDataStore,
+    /// Optional asynchronous hook that creates per-connection state.
     pub(in crate::app) on_connect: Option<Arc<ConnectionSetup<C>>>,
+    /// Optional asynchronous hook that releases state after clean processing.
     pub(in crate::app) on_disconnect: Option<Arc<ConnectionTeardown<C>>>,
+    /// Optional protocol hook used to customise frame-level processing.
     pub(in crate::app) protocol:
         Option<Arc<dyn WireframeProtocol<Frame = F::Frame, ProtocolError = ()>>>,
+    /// Optional dead-letter sink for pushes that cannot be delivered.
     pub(in crate::app) push_dlq: Option<mpsc::Sender<Vec<u8>>>,
+    /// Frame codec used by all connections from this application.
     pub(in crate::app) codec: F,
+    /// Maximum interval to wait for the next inbound frame.
     pub(in crate::app) read_timeout_ms: u64,
+    /// Optional limits and timeout for transparent frame fragmentation.
     pub(in crate::app) fragmentation: Option<crate::fragment::FragmentationConfig>,
+    /// Optional assembler for protocol messages spread across several frames.
     pub(in crate::app) message_assembler: Option<Arc<dyn MessageAssembler>>,
+    /// Optional byte caps protecting message and connection memory usage.
     pub(in crate::app) memory_budgets: Option<MemoryBudgets>,
 }
 
@@ -122,11 +136,17 @@ where
 /// and memory budgets into a single value to keep the rebuild signature
 /// concise.
 pub(super) struct RebuildParams<S2, F2: FrameCodec> {
+    /// Serializer to carry into the rebuilt application type.
     pub(super) serializer: S2,
+    /// Codec to carry into the rebuilt application type.
     pub(super) codec: F2,
+    /// Protocol hook whose frame type matches the replacement codec.
     pub(super) protocol: Option<Arc<dyn WireframeProtocol<Frame = F2::Frame, ProtocolError = ()>>>,
+    /// Fragmentation settings retained across a type transition.
     pub(super) fragmentation: Option<crate::fragment::FragmentationConfig>,
+    /// Message assembler retained across a type transition.
     pub(super) message_assembler: Option<Arc<dyn MessageAssembler>>,
+    /// Memory limits retained across a type transition.
     pub(super) memory_budgets: Option<MemoryBudgets>,
 }
 

--- a/src/app/builder/core.rs
+++ b/src/app/builder/core.rs
@@ -46,7 +46,7 @@ pub struct WireframeApp<
     pub(in crate::app) on_connect: Option<Arc<ConnectionSetup<C>>>,
     /// Optional asynchronous hook that releases state after clean processing.
     pub(in crate::app) on_disconnect: Option<Arc<ConnectionTeardown<C>>>,
-    /// Optional protocol hook used to customise frame-level processing.
+    /// Optional protocol hook used to customize frame-level processing.
     pub(in crate::app) protocol:
         Option<Arc<dyn WireframeProtocol<Frame = F::Frame, ProtocolError = ()>>>,
     /// Optional dead-letter sink for pushes that cannot be delivered.

--- a/src/app/builder_defaults.rs
+++ b/src/app/builder_defaults.rs
@@ -8,16 +8,24 @@ use crate::{
     fragment::FragmentationConfig,
 };
 
+/// Smallest permitted read timeout, preventing a busy loop on zero duration.
 pub(super) const MIN_READ_TIMEOUT_MS: u64 = 1;
+/// Largest permitted read timeout, limiting how long idle connections linger.
 pub(super) const MAX_READ_TIMEOUT_MS: u64 = 86_400_000;
 /// Default preamble read timeout in milliseconds.
 pub(super) const DEFAULT_READ_TIMEOUT_MS: u64 = 100;
+/// Timeout after which incomplete fragment assemblies are evicted.
 const DEFAULT_FRAGMENT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Multiplier used to derive a logical-message cap from the frame cap.
 const DEFAULT_MESSAGE_SIZE_MULTIPLIER: usize = 16;
+/// Multiplier keeping the message-memory budget aligned with fragmentation.
 const DEFAULT_MESSAGE_BUDGET_MULTIPLIER: usize = DEFAULT_MESSAGE_SIZE_MULTIPLIER;
+/// Multiplier limiting aggregate bytes retained by one connection.
 const DEFAULT_CONNECTION_BUDGET_MULTIPLIER: usize = 64;
+/// Multiplier limiting bytes retained by concurrent in-flight assemblies.
 const DEFAULT_IN_FLIGHT_BUDGET_MULTIPLIER: usize = 64;
 
+/// Derive safe fragmentation defaults from the codec's frame budget.
 pub(super) fn default_fragmentation(frame_budget: usize) -> Option<FragmentationConfig> {
     let frame_budget = clamp_frame_length(frame_budget);
     let max_message =

--- a/src/app/codec_driver.rs
+++ b/src/app/codec_driver.rs
@@ -36,7 +36,9 @@ use crate::{
 /// Produces a buffer of processed envelopes ready for serialization and
 /// transmission.
 pub(crate) struct FramePipeline {
+    /// Optional state that turns oversized envelopes into ordered fragments.
     fragmentation: Option<FragmentationState>,
+    /// Envelopes waiting to be serialised and written to the transport.
     out: Vec<Envelope>,
 }
 
@@ -105,6 +107,7 @@ impl FramePipeline {
     #[cfg(test)]
     pub(crate) fn has_fragmentation(&self) -> bool { self.fragmentation.is_some() }
 
+    /// Append one processed envelope and account for its outbound emission.
     fn push_frame(&mut self, envelope: Envelope) {
         self.out.push(envelope);
         crate::metrics::inc_frames(crate::metrics::Direction::Outbound);

--- a/src/app/codec_driver.rs
+++ b/src/app/codec_driver.rs
@@ -38,7 +38,7 @@ use crate::{
 pub(crate) struct FramePipeline {
     /// Optional state that turns oversized envelopes into ordered fragments.
     fragmentation: Option<FragmentationState>,
-    /// Envelopes waiting to be serialised and written to the transport.
+    /// Envelopes waiting to be serialized and written to the transport.
     out: Vec<Envelope>,
 }
 

--- a/src/app/combined_codec.rs
+++ b/src/app/combined_codec.rs
@@ -5,15 +5,20 @@ use tokio_util::codec::{Decoder, Encoder};
 
 use crate::codec::FrameCodec;
 
+/// Adapter combining independent decoder and encoder halves for `Framed`.
 pub(super) struct CombinedCodec<D, E> {
+    /// Decoder that consumes bytes from the transport.
     decoder: D,
+    /// Encoder that writes protocol frames to the transport.
     encoder: E,
 }
 
 impl<D, E> CombinedCodec<D, E> {
+    /// Pair codec halves without changing either half's buffering semantics.
     pub(super) fn new(decoder: D, encoder: E) -> Self { Self { decoder, encoder } }
 }
 
+/// Codec type selected from a [`FrameCodec`] implementation.
 pub(super) type ConnectionCodec<F> =
     CombinedCodec<<F as FrameCodec>::Decoder, <F as FrameCodec>::Encoder>;
 

--- a/src/app/envelope.rs
+++ b/src/app/envelope.rs
@@ -288,8 +288,8 @@ impl PacketParts {
         self
     }
 
-    #[inline]
     /// Resolve inherited correlation metadata and flag conflicting identifiers.
+    #[inline]
     fn select_correlation(current: Option<u64>, source: Option<u64>) -> (Option<u64>, bool) {
         match (current, source) {
             (None, cid) => (cid, false),

--- a/src/app/envelope.rs
+++ b/src/app/envelope.rs
@@ -132,8 +132,11 @@ pub trait Packet: CorrelatableFrame + Send + Sync + 'static {
 /// Component values extracted from or used to build a [`Packet`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PacketParts {
+    /// Message identifier used by dispatch and response routing.
     id: u32,
+    /// Optional request/response correlation metadata.
     correlation_id: Option<u64>,
+    /// Serialized application payload, excluding routing metadata.
     payload: Vec<u8>,
 }
 
@@ -144,8 +147,11 @@ pub struct PacketParts {
 /// message identifier and raw payload bytes.
 #[derive(bincode::Decode, bincode::Encode, Debug, Clone, PartialEq, Eq)]
 pub struct Envelope {
+    /// Message identifier used to select the handler chain.
     pub(crate) id: u32,
+    /// Optional identifier copied between request and response frames.
     pub(crate) correlation_id: Option<u64>,
+    /// Wire payload handed to the serializer or fragment assembler.
     pub(crate) payload: Vec<u8>,
 }
 
@@ -283,6 +289,7 @@ impl PacketParts {
     }
 
     #[inline]
+    /// Resolve inherited correlation metadata and flag conflicting identifiers.
     fn select_correlation(current: Option<u64>, source: Option<u64>) -> (Option<u64>, bool) {
         match (current, source) {
             (None, cid) => (cid, false),

--- a/src/app/frame_handling/assembly.rs
+++ b/src/app/frame_handling/assembly.rs
@@ -26,7 +26,9 @@ const DEFAULT_MESSAGE_ASSEMBLY_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Borrowed inbound runtime state used for message assembly.
 pub(crate) struct AssemblyRuntime<'a> {
+    /// Shared assembler implementation, absent when assembly is disabled.
     pub(crate) assembler: Option<&'a Arc<dyn MessageAssembler>>,
+    /// Mutable connection-local assembly state and its memory accounting.
     pub(crate) state: &'a mut Option<MessageAssemblyState>,
 }
 
@@ -163,9 +165,13 @@ pub(crate) fn assemble_if_needed(
     }
 }
 
+/// Mutable assembly state plus the failure budget for one inbound frame.
 struct AssemblyContext<'a, 'b> {
+    /// Connection-local assembler state updated by accepted fragments.
     state: &'a mut MessageAssemblyState,
+    /// Failure tracker that closes the connection at its configured threshold.
     failures: &'a mut DeserFailureTracker<'b>,
+    /// Correlation metadata used to diagnose malformed frame errors.
     correlation_id: Option<u64>,
 }
 
@@ -181,6 +187,7 @@ impl AssemblyContext<'_, '_> {
     }
 }
 
+/// Validate and feed a first assembly frame into connection-local state.
 fn process_first_frame(
     context: &mut AssemblyContext<'_, '_>,
     header: &FirstFrameHeader,
@@ -239,6 +246,7 @@ fn process_first_frame(
     }
 }
 
+/// Validate and append a continuation frame in sequence order.
 fn process_continuation_frame(
     context: &mut AssemblyContext<'_, '_>,
     header: &ContinuationFrameHeader,

--- a/src/app/frame_handling/backpressure.rs
+++ b/src/app/frame_handling/backpressure.rs
@@ -120,6 +120,7 @@ pub(super) fn should_pause_inbound_reads(
     is_at_or_above_soft_limit(buffered_bytes, aggregate_limit)
 }
 
+/// Select the stricter connection-wide or in-flight assembly cap.
 fn active_aggregate_limit_bytes(budgets: MemoryBudgets) -> usize {
     budgets
         .bytes_per_connection()
@@ -140,6 +141,7 @@ pub(crate) fn resolve_effective_budgets(
     explicit.unwrap_or_else(|| default_memory_budgets(frame_budget))
 }
 
+/// Compare buffered bytes against the configured soft pause threshold safely.
 fn is_at_or_above_soft_limit(buffered_bytes: usize, aggregate_limit: usize) -> bool {
     let lhs = (buffered_bytes as u128).saturating_mul(SOFT_LIMIT_DENOMINATOR);
     let rhs = (aggregate_limit as u128).saturating_mul(SOFT_LIMIT_NUMERATOR);

--- a/src/app/frame_handling/core.rs
+++ b/src/app/frame_handling/core.rs
@@ -61,6 +61,6 @@ where
     pub(crate) framed: &'a mut Framed<W, ConnectionCodec<F>>,
     /// Outbound pipeline that applies fragmentation and metrics.
     pub(crate) pipeline: &'a mut FramePipeline,
-    /// Codec that wraps serialised payloads into wire frames.
+    /// Codec that wraps serialized payloads into wire frames.
     pub(crate) codec: &'a F,
 }

--- a/src/app/frame_handling/core.rs
+++ b/src/app/frame_handling/core.rs
@@ -14,13 +14,17 @@ use crate::{
 
 /// Tracks deserialization failures and enforces a maximum error threshold.
 pub(crate) struct DeserFailureTracker<'a> {
+    /// Counter shared with the connection loop so failures accumulate per peer.
     count: &'a mut u32,
+    /// Threshold at which malformed input terminates the connection.
     limit: u32,
 }
 
 impl<'a> DeserFailureTracker<'a> {
+    /// Borrow the loop counter and configure the malformed-input threshold.
     pub(crate) fn new(count: &'a mut u32, limit: u32) -> Self { Self { count, limit } }
 
+    /// Record one malformed frame and close the connection at the threshold.
     pub(super) fn record(
         &mut self,
         correlation_id: Option<u64>,
@@ -51,8 +55,12 @@ where
     W: AsyncRead + AsyncWrite + Unpin,
     F: FrameCodec,
 {
+    /// Serializer used to encode the handler response.
     pub(crate) serializer: &'a S,
+    /// Framed transport receiving encoded response frames.
     pub(crate) framed: &'a mut Framed<W, ConnectionCodec<F>>,
+    /// Outbound pipeline that applies fragmentation and metrics.
     pub(crate) pipeline: &'a mut FramePipeline,
+    /// Codec that wraps serialised payloads into wire frames.
     pub(crate) codec: &'a F,
 }

--- a/src/app/frame_handling/reassembly.rs
+++ b/src/app/frame_handling/reassembly.rs
@@ -26,6 +26,7 @@ pub(crate) fn reassemble_if_needed(
     handle_reassembly_result(state.reassemble(env), &mut failures, correlation_id)
 }
 
+/// Convert fragment-processing errors into counted connection failures.
 fn handle_reassembly_result(
     result: Result<Option<Envelope>, FragmentProcessError>,
     failures: &mut DeserFailureTracker<'_>,

--- a/src/app/inbound_handler.rs
+++ b/src/app/inbound_handler.rs
@@ -26,6 +26,7 @@ use crate::{
     serializer::Serializer,
 };
 
+/// Remove stale outbound and message-assembly state after an idle interval.
 fn purge_expired(
     pipeline: &mut FramePipeline,
     message_assembly: &mut Option<MessageAssemblyState>,
@@ -43,10 +44,15 @@ where
     W: AsyncRead + AsyncWrite + Unpin,
     F: FrameCodec,
 {
+    /// Framed transport borrowed for response writes during frame handling.
     framed: &'a mut Framed<W, ConnectionCodec<F>>,
+    /// Connection-wide malformed-frame counter shared with all stages.
     deser_failures: &'a mut u32,
+    /// Immutable middleware chains used to dispatch decoded envelopes.
     routes: &'a HashMap<u32, HandlerService<E>>,
+    /// Outbound processing state for fragmenting and counting responses.
     pipeline: &'a mut FramePipeline,
+    /// Connection-local state for assembling multi-frame messages.
     message_assembly: &'a mut Option<MessageAssemblyState>,
 }
 
@@ -55,9 +61,13 @@ struct DispatchBuildContext<'a, F>
 where
     F: FrameCodec,
 {
+    /// Raw frame borrowed while decoding its envelope metadata and payload.
     frame: &'a F::Frame,
+    /// Pipeline needed to reassemble fragmented input and emit responses.
     pipeline: &'a mut FramePipeline,
+    /// Mutable assembly state retained across inbound frames.
     message_assembly: &'a mut Option<MessageAssemblyState>,
+    /// Failure counter used to enforce the malformed-input limit.
     deser_failures: &'a mut u32,
 }
 
@@ -143,6 +153,7 @@ where
         }
     }
 
+    /// Build middleware chains once, preserving reverse wrapping order.
     async fn build_chains(&self) -> HashMap<u32, HandlerService<E>> {
         let mut routes = HashMap::new();
         for (&id, handler) in &self.handlers {
@@ -155,6 +166,7 @@ where
         routes
     }
 
+    /// Read frames until EOF, timeout, or a transport/handler error occurs.
     async fn process_stream<W>(
         &self,
         stream: W,
@@ -225,6 +237,7 @@ where
         Ok(())
     }
 
+    /// Decode one frame, apply reassembly, and dispatch its response.
     async fn handle_frame<W>(
         &self,
         frame: &F::Frame,
@@ -275,6 +288,7 @@ where
         Ok(())
     }
 
+    /// Run decode, fragment reassembly, and message assembly in order.
     fn build_dispatchable_envelope(
         &self,
         ctx: DispatchBuildContext<'_, F>,

--- a/src/app/memory_budgets.rs
+++ b/src/app/memory_budgets.rs
@@ -66,8 +66,11 @@ impl From<BudgetBytes> for usize {
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct MemoryBudgets {
+    /// Maximum bytes retained while constructing one logical message.
     message_budget: BudgetBytes,
+    /// Maximum bytes retained by all assemblies on one connection.
     connection_window: BudgetBytes,
+    /// Maximum bytes retained across concurrent in-flight assemblies.
     assembly_bytes: BudgetBytes,
 }
 

--- a/src/app/outbound_encoding.rs
+++ b/src/app/outbound_encoding.rs
@@ -16,6 +16,7 @@ use crate::{codec::FrameCodec, message::EncodeWith, serializer::Serializer};
 /// A serialized message wrapped into a transport codec frame.
 #[derive(Debug)]
 pub(crate) struct EncodedFrame<T> {
+    /// Codec-owned frame ready for asynchronous transport output.
     pub(crate) frame: T,
 }
 

--- a/src/app_data_store.rs
+++ b/src/app_data_store.rs
@@ -33,6 +33,7 @@ use dashmap::DashMap;
 /// ```
 #[derive(Clone, Default)]
 pub struct AppDataStore {
+    /// Concurrent type-erased values keyed by their concrete [`TypeId`].
     values: DashMap<TypeId, Arc<dyn Any + Send + Sync>>,
 }
 

--- a/src/client/builder/core.rs
+++ b/src/client/builder/core.rs
@@ -28,12 +28,19 @@ use crate::{
 /// let _ = builder;
 /// ```
 pub struct WireframeClientBuilder<S = BincodeSerializer, P = (), C = ()> {
+    /// Serializer retained until a physical connection is created.
     pub(crate) serializer: S,
+    /// Length-prefix and frame-size limits applied to each connection.
     pub(crate) codec_config: ClientCodecConfig,
+    /// OS-level options applied before opening the TCP stream.
     pub(crate) socket_options: SocketOptions,
+    /// Optional handshake recipe, including callbacks and timeout.
     pub(crate) preamble_config: Option<PreambleConfig<P>>,
+    /// Setup and teardown callbacks that own per-connection state.
     pub(crate) lifecycle_hooks: LifecycleHooks<C>,
+    /// Hooks invoked around request dispatch on each connection.
     pub(crate) request_hooks: RequestHooks,
+    /// Span levels and timing switches copied into each connection.
     pub(crate) tracing_config: TracingConfig,
 }
 

--- a/src/client/codec_config.rs
+++ b/src/client/codec_config.rs
@@ -4,8 +4,11 @@ use tokio_util::codec::LengthDelimitedCodec;
 
 use crate::frame::{Endianness, LengthFormat};
 
+/// Smallest frame accepted so a length prefix cannot consume the payload.
 const MIN_FRAME_LENGTH: usize = 64;
+/// Upper bound preventing a peer from forcing an unbounded read allocation.
 const MAX_FRAME_LENGTH: usize = 16 * 1024 * 1024;
+/// Conservative default that keeps ordinary request buffers small.
 const DEFAULT_MAX_FRAME_LENGTH: usize = 1024;
 
 /// Codec configuration for the wireframe client.
@@ -20,7 +23,9 @@ const DEFAULT_MAX_FRAME_LENGTH: usize = 1024;
 /// ```
 #[derive(Clone, Copy, Debug)]
 pub struct ClientCodecConfig {
+    /// Width and byte order of the wire length prefix.
     length_format: LengthFormat,
+    /// Maximum encoded frame size enforced by both decoder and encoder.
     max_frame_length: usize,
 }
 
@@ -99,6 +104,7 @@ impl ClientCodecConfig {
     #[must_use]
     pub const fn length_format_value(&self) -> LengthFormat { self.length_format }
 
+    /// Build the framed transport codec with the configured wire limits.
     pub(crate) fn build_codec(&self) -> LengthDelimitedCodec {
         let mut builder = LengthDelimitedCodec::builder();
         builder.length_field_length(self.length_format.bytes());

--- a/src/client/config.rs
+++ b/src/client/config.rs
@@ -24,10 +24,15 @@ use tokio::net::TcpSocket;
 /// ```
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SocketOptions {
+    /// Whether small writes bypass Nagle coalescing.
     nodelay: Option<bool>,
+    /// Keepalive policy; `None` means leave the platform default untouched.
     keepalive: Option<KeepAliveSetting>,
+    /// Requested kernel send-buffer capacity.
     send_buffer_size: Option<u32>,
+    /// Requested kernel receive-buffer capacity.
     recv_buffer_size: Option<u32>,
+    /// Whether the address may be rebound while it is in use.
     reuseaddr: Option<bool>,
     #[cfg(all(
         unix,
@@ -35,16 +40,21 @@ pub struct SocketOptions {
         not(target_os = "illumos"),
         not(target_os = "cygwin"),
     ))]
+    /// Whether supported platforms may share a listening port.
     reuseport: Option<bool>,
 }
 
+/// Internal representation of the optional TCP keepalive override.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum KeepAliveSetting {
+    /// Explicitly disable keepalive probes.
     Disabled,
+    /// Enable probes after the supplied idle duration.
     Duration(Duration),
 }
 
 impl KeepAliveSetting {
+    /// Convert the policy to the socket API's optional duration form.
     const fn to_option(self) -> Option<Duration> {
         match self {
             Self::Disabled => None,
@@ -167,6 +177,7 @@ impl SocketOptions {
         self
     }
 
+    /// Apply every configured option, preserving the first OS error.
     pub(crate) fn apply(&self, socket: &TcpSocket) -> io::Result<()> {
         self.apply_nodelay(socket)?;
         self.apply_keepalive(socket)?;
@@ -177,6 +188,7 @@ impl SocketOptions {
         Ok(())
     }
 
+    /// Apply `TCP_NODELAY` when the caller supplied an override.
     fn apply_nodelay(&self, socket: &TcpSocket) -> io::Result<()> {
         if let Some(enabled) = self.nodelay {
             socket.set_nodelay(enabled)?;
@@ -184,6 +196,7 @@ impl SocketOptions {
         Ok(())
     }
 
+    /// Apply keepalive enablement and its platform-specific idle interval.
     fn apply_keepalive(&self, socket: &TcpSocket) -> io::Result<()> {
         if let Some(keepalive) = self.keepalive {
             match keepalive.to_option() {
@@ -201,6 +214,7 @@ impl SocketOptions {
         Ok(())
     }
 
+    /// Apply the requested kernel send-buffer capacity.
     fn apply_send_buffer_size(&self, socket: &TcpSocket) -> io::Result<()> {
         if let Some(size) = self.send_buffer_size {
             socket.set_send_buffer_size(size)?;
@@ -208,6 +222,7 @@ impl SocketOptions {
         Ok(())
     }
 
+    /// Apply the requested kernel receive-buffer capacity.
     fn apply_recv_buffer_size(&self, socket: &TcpSocket) -> io::Result<()> {
         if let Some(size) = self.recv_buffer_size {
             socket.set_recv_buffer_size(size)?;
@@ -215,6 +230,7 @@ impl SocketOptions {
         Ok(())
     }
 
+    /// Apply address reuse before the connect attempt.
     fn apply_reuseaddr(&self, socket: &TcpSocket) -> io::Result<()> {
         if let Some(enabled) = self.reuseaddr {
             socket.set_reuseaddr(enabled)?;
@@ -228,6 +244,7 @@ impl SocketOptions {
         not(target_os = "illumos"),
         not(target_os = "cygwin"),
     ))]
+    /// Apply port sharing on platforms that expose this option.
     fn apply_reuseport(&self, socket: &TcpSocket) -> io::Result<()> {
         if let Some(enabled) = self.reuseport {
             socket.set_reuseport(enabled)?;
@@ -241,5 +258,6 @@ impl SocketOptions {
         not(target_os = "illumos"),
         not(target_os = "cygwin"),
     )))]
+    /// Keep the option pipeline portable where port sharing is unavailable.
     fn apply_reuseport(&self, _socket: &TcpSocket) -> io::Result<()> { Ok(()) }
 }

--- a/src/client/connect_parts.rs
+++ b/src/client/connect_parts.rs
@@ -20,6 +20,7 @@ use super::{
 };
 use crate::{rewind_stream::RewindStream, serializer::Serializer};
 
+/// Initial read-buffer hint bounded by the configured maximum frame length.
 // Equivalent mutant: a pre-allocation hint later min'd against the codec's
 // max_frame_length, so `*`→`+`/`/` cannot change observable behaviour.
 #[cfg_attr(test, mutants::skip)]
@@ -27,12 +28,19 @@ const INITIAL_READ_BUFFER_CAPACITY: usize = 64 * 1024;
 
 /// Cloneable connection recipe used by pooled reconnect paths.
 pub(crate) struct ClientBuildParts<S, P, C> {
+    /// Serializer cloned into each reconnect attempt.
     pub(crate) serializer: S,
+    /// Frame prefix and size limits shared by pooled and direct clients.
     pub(crate) codec_config: ClientCodecConfig,
+    /// Socket options applied before each TCP connection.
     pub(crate) socket_options: super::SocketOptions,
+    /// Optional preamble exchange performed before framing starts.
     pub(crate) preamble_config: Option<PreambleConfig<P>>,
+    /// Connection setup and teardown callbacks with their state type.
     pub(crate) lifecycle_hooks: LifecycleHooks<C>,
+    /// Request-level callbacks copied into the resulting client.
     pub(crate) request_hooks: RequestHooks,
+    /// Span and timing configuration copied into the resulting client.
     pub(crate) tracing_config: TracingConfig,
 }
 

--- a/src/client/pool/client_pool.rs
+++ b/src/client/pool/client_pool.rs
@@ -27,21 +27,29 @@ use crate::{
     serializer::Serializer,
 };
 
+/// Slot and admission token returned by a successful checkout.
 type AcquirePermit<S, P, C> = (Arc<PoolSlot<S, P, C>>, tokio::sync::OwnedSemaphorePermit);
 
+/// Erased future used to race all slots for the first available permit.
 type AcquirePermitFuture<S, P, C> =
     Pin<Box<dyn Future<Output = Result<AcquirePermit<S, P, C>, ClientError>> + Send>>;
 
+/// Shared state coordinating slots, fairness, and cancellation for a pool.
 pub(crate) struct ClientPoolInner<S, P = (), C = ()>
 where
     S: Serializer + Clone + Send + Sync + 'static,
     P: Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Physical slots participating in round-robin selection.
     pub(crate) slots: Arc<[Arc<PoolSlot<S, P, C>>]>,
+    /// Cursor used to rotate the first slot attempted by each acquisition.
     pub(crate) next_slot: AtomicUsize,
+    /// Fairness coordinator for handles waiting on slot capacity.
     pub(crate) scheduler: Arc<PoolScheduler<S, P, C>>,
+    /// Release flag observed by blocked acquisitions and close.
     shutdown: AtomicBool,
+    /// Notification used to cancel scheduler waits during shutdown.
     shutdown_notify: Notify,
 }
 
@@ -52,6 +60,7 @@ where
     P: Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Reference-counted state shared by pool handles and leases.
     inner: Arc<ClientPoolInner<S, P, C>>,
 }
 
@@ -61,6 +70,7 @@ where
     P: Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Build all configured slots and their warm physical connections.
     pub(crate) async fn connect(
         addr: SocketAddr,
         pool_config: ClientPoolConfig,
@@ -146,16 +156,20 @@ where
     P: Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Read the release-acquire shutdown flag used by all waiters.
     pub(crate) fn is_shutdown(&self) -> bool { self.shutdown.load(Ordering::Acquire) }
 
+    /// Wait until pool shutdown wakes a cancellation-sensitive operation.
     pub(crate) async fn shutdown_notified(&self) { self.shutdown_notify.notified().await; }
 
+    /// Publish shutdown and wake both direct and scheduler-managed waiters.
     pub(crate) fn shutdown(&self) {
         self.shutdown.store(true, Ordering::Release);
         self.shutdown_notify.notify_waiters();
         self.scheduler.notify_shutdown();
     }
 
+    /// Attempt a non-blocking lease while preserving slot rotation fairness.
     pub(crate) fn try_acquire_immediately(self: &Arc<Self>) -> Option<PooledClientLease<S, P, C>> {
         if self.is_shutdown() {
             return None;
@@ -166,6 +180,7 @@ where
         })
     }
 
+    /// Race slot permits and return the first available capacity or error.
     pub(crate) async fn acquire_slot_permit(&self) -> Result<AcquirePermit<S, P, C>, ClientError> {
         let waiters = self
             .ordered_slots()
@@ -181,6 +196,7 @@ where
         result
     }
 
+    /// Rotate slots from an atomic cursor to avoid favouring one socket.
     fn ordered_slots(&self) -> Vec<Arc<PoolSlot<S, P, C>>> {
         let mut ordered = self.slots.iter().cloned().collect::<Vec<_>>();
         let len = ordered.len();

--- a/src/client/pool/config.rs
+++ b/src/client/pool/config.rs
@@ -4,9 +4,13 @@ use std::time::Duration;
 
 use super::policy::PoolFairnessPolicy;
 
+/// Default number of physical sockets kept warm.
 const DEFAULT_POOL_SIZE: usize = 4;
+/// Default serial admission per physical socket.
 const DEFAULT_MAX_IN_FLIGHT_PER_SOCKET: usize = 1;
+/// Default idle lifetime before a socket is recycled.
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 600;
+/// Duration form of [`DEFAULT_IDLE_TIMEOUT_SECS`].
 const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(DEFAULT_IDLE_TIMEOUT_SECS);
 
 /// Configuration for a pooled wireframe client.
@@ -30,9 +34,13 @@ const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(DEFAULT_IDLE_TIMEOUT_
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ClientPoolConfig {
+    /// Number of physical sockets maintained by the pool.
     pool_size: usize,
+    /// Maximum concurrent leases admitted by each socket.
     max_in_flight_per_socket: usize,
+    /// Idle duration after which a returned socket is refreshed.
     idle_timeout: Duration,
+    /// Queue policy applied to blocked logical-session handles.
     fairness_policy: PoolFairnessPolicy,
 }
 

--- a/src/client/pool/handle.rs
+++ b/src/client/pool/handle.rs
@@ -38,7 +38,9 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Shared pool state whose scheduler tracks this logical session.
     inner: Arc<ClientPoolInner<S, P, C>>,
+    /// Scheduler identity removed when this handle is dropped.
     handle_id: u64,
 }
 
@@ -48,6 +50,7 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Bind a scheduler-assigned identity to the shared pool state.
     pub(crate) fn new(inner: Arc<ClientPoolInner<S, P, C>>, handle_id: u64) -> Self {
         Self { inner, handle_id }
     }

--- a/src/client/pool/lease.rs
+++ b/src/client/pool/lease.rs
@@ -23,8 +23,11 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Slot whose physical connection is checked out for each operation.
     slot: Arc<PoolSlot<S, P, C>>,
+    /// Admission token held for the lifetime of this lease.
     _permit: OwnedSemaphorePermit,
+    /// Scheduler state to notify when this lease releases capacity.
     release_inner: Option<Arc<ClientPoolInner<S, P, C>>>,
 }
 
@@ -34,6 +37,7 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Construct a lease while retaining the permit until drop.
     pub(crate) fn new(
         slot: Arc<PoolSlot<S, P, C>>,
         permit: OwnedSemaphorePermit,
@@ -46,8 +50,10 @@ where
         }
     }
 
+    /// Classify transport errors that make a pooled connection unsafe to reuse.
     fn should_recycle(err: &ClientError) -> bool { err.should_recycle_connection() }
 
+    /// Run one operation against a checked-out connection and mark bad sockets.
     async fn dispatch_on_connection<R>(
         &self,
         operation: impl AsyncFnOnce(&mut ManagedClientConnection<S, C>) -> Result<R, ClientError>,

--- a/src/client/pool/managed.rs
+++ b/src/client/pool/managed.rs
@@ -19,7 +19,9 @@ where
     S: Serializer + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Manually dropped client so teardown can run on an available runtime.
     client: ManuallyDrop<WireframeClient<S, RewindStream<TcpStream>, C>>,
+    /// Set after protocol or I/O failure to force pool replacement.
     is_broken: bool,
 }
 
@@ -28,6 +30,7 @@ where
     S: Serializer + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Wrap a connected client as a healthy pooled resource.
     pub(crate) fn new(client: WireframeClient<S, RewindStream<TcpStream>, C>) -> Self {
         Self {
             client: ManuallyDrop::new(client),
@@ -35,8 +38,10 @@ where
         }
     }
 
+    /// Mark the resource so `bb8` discards it instead of reusing it.
     pub(crate) fn mark_broken(&mut self) { self.is_broken = true; }
 
+    /// Report whether a prior operation invalidated this physical connection.
     pub(crate) const fn is_broken(&self) -> bool { self.is_broken }
 }
 

--- a/src/client/pool/manager.rs
+++ b/src/client/pool/manager.rs
@@ -14,11 +14,14 @@ use crate::{
 /// Connection manager for one pooled wireframe socket.
 #[derive(Clone)]
 pub(crate) struct WireframeConnectionManager<S, P, C> {
+    /// Remote endpoint used for each replacement connection.
     addr: SocketAddr,
+    /// Cloneable construction recipe shared by reconnect attempts.
     parts: ClientBuildParts<S, P, C>,
 }
 
 impl<S, P, C> WireframeConnectionManager<S, P, C> {
+    /// Capture the endpoint and recipe for one pool slot.
     pub(crate) fn new(addr: SocketAddr, parts: ClientBuildParts<S, P, C>) -> Self {
         Self { addr, parts }
     }

--- a/src/client/pool/scheduler.rs
+++ b/src/client/pool/scheduler.rs
@@ -19,16 +19,21 @@ use super::{
 };
 use crate::{client::ClientError, serializer::Serializer};
 
+/// One-shot completion channel for a blocked logical-session acquisition.
 type WaiterSender<S, P, C> = oneshot::Sender<Result<PooledClientLease<S, P, C>, ClientError>>;
 
+/// Policy-specific waiter queues protected by the scheduler mutex.
 struct SchedulerState<S, P, C>
 where
     S: Serializer + Clone + Send + Sync + 'static,
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Global arrival order used by FIFO admission.
     fifo_queue: VecDeque<(u64, WaiterSender<S, P, C>)>,
+    /// Rotating handle identities used to provide per-session turns.
     round_robin_order: VecDeque<u64>,
+    /// Per-handle queues preserving request order within a session.
     handle_waiters: HashMap<u64, VecDeque<WaiterSender<S, P, C>>>,
 }
 
@@ -38,6 +43,7 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Start with empty queues and no registered logical sessions.
     fn new() -> Self {
         Self {
             fifo_queue: VecDeque::new(),
@@ -46,11 +52,13 @@ where
         }
     }
 
+    /// Add a handle to both identity tracking and round-robin rotation.
     fn register_handle(&mut self, handle_id: u64) {
         self.handle_waiters.insert(handle_id, VecDeque::new());
         self.round_robin_order.push_back(handle_id);
     }
 
+    /// Remove a handle and all queued requests so dropped callers cannot win capacity.
     fn deregister_handle(&mut self, handle_id: u64) {
         self.handle_waiters.remove(&handle_id);
         self.round_robin_order
@@ -97,10 +105,12 @@ where
         }
     }
 
+    /// Report whether any policy queue still contains a request.
     fn has_waiters(&self) -> bool {
         !self.fifo_queue.is_empty() || self.handle_waiters.values().any(|queue| !queue.is_empty())
     }
 
+    /// Select one waiter according to the configured ordering policy.
     fn take_next_waiter(&mut self, policy: PoolFairnessPolicy) -> Option<WaiterSender<S, P, C>> {
         match policy {
             PoolFairnessPolicy::RoundRobin => self.take_next_round_robin_waiter(),
@@ -108,6 +118,7 @@ where
         }
     }
 
+    /// Pop FIFO arrivals, skipping requests from handles already dropped.
     fn take_next_fifo_waiter(&mut self) -> Option<WaiterSender<S, P, C>> {
         while let Some((handle_id, sender)) = self.fifo_queue.pop_front() {
             if self.handle_waiters.contains_key(&handle_id) {
@@ -117,6 +128,7 @@ where
         None
     }
 
+    /// Visit each registered handle once and pop its oldest pending request.
     fn take_next_round_robin_waiter(&mut self) -> Option<WaiterSender<S, P, C>> {
         let len = self.round_robin_order.len();
         for _ in 0..len {
@@ -139,9 +151,13 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Policy chosen for all blocked acquisitions in this pool.
     fairness_policy: PoolFairnessPolicy,
+    /// Monotonic source of logical-session identities.
     next_handle_id: AtomicU64,
+    /// Single-service guard preventing duplicate scheduler tasks.
     is_servicing: AtomicBool,
+    /// Mutex-protected queues shared by acquisition and release paths.
     state: Mutex<SchedulerState<S, P, C>>,
 }
 
@@ -151,6 +167,7 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Create a scheduler with no active handles or waiters.
     pub(crate) fn new(fairness_policy: PoolFairnessPolicy) -> Self {
         Self {
             fairness_policy,
@@ -160,16 +177,19 @@ where
         }
     }
 
+    /// Allocate and register a stable identity for one logical session.
     pub(crate) fn register_handle(&self) -> u64 {
         let handle_id = self.next_handle_id.fetch_add(1, Ordering::Relaxed);
         lock_or_recover(&self.state).register_handle(handle_id);
         handle_id
     }
 
+    /// Remove a session and cancel its queued requests by dropping senders.
     pub(crate) fn deregister_handle(&self, handle_id: u64) {
         lock_or_recover(&self.state).deregister_handle(handle_id);
     }
 
+    /// Queue an acquisition, taking an immediate lease when capacity permits.
     pub(crate) async fn acquire_for_handle(
         self: &Arc<Self>,
         inner: Arc<ClientPoolInner<S, P, C>>,
@@ -206,6 +226,7 @@ where
         receiver.await.map_err(|_| ClientError::disconnected())?
     }
 
+    /// Complete every queued waiter with a disconnected error.
     pub(crate) fn notify_shutdown(&self) {
         let mut state = lock_or_recover(&self.state);
         while let Some(waiter) = state.take_next_waiter(self.fairness_policy) {
@@ -213,6 +234,7 @@ where
         }
     }
 
+    /// Restart service when a released lease may satisfy a waiter.
     pub(crate) fn notify_capacity_available(
         self: &Arc<Self>,
         inner: Arc<ClientPoolInner<S, P, C>>,
@@ -220,6 +242,7 @@ where
         self.kick(inner);
     }
 
+    /// Spawn at most one worker to drain waiters as capacity appears.
     fn kick(self: &Arc<Self>, inner: Arc<ClientPoolInner<S, P, C>>) {
         if self
             .is_servicing
@@ -233,6 +256,7 @@ where
         }
     }
 
+    /// Re-arm the worker if a race left requests after it stopped.
     fn restart_if_waiters(&self) -> bool {
         if !lock_or_recover(&self.state).has_waiters() {
             return false;
@@ -243,6 +267,7 @@ where
             .is_ok()
     }
 
+    /// Dequeue a waiter, closing the worker only after queues are empty.
     fn take_next_waiter_or_stop(&self) -> Option<WaiterSender<S, P, C>> {
         loop {
             if let Some(sender) =
@@ -258,6 +283,7 @@ where
         }
     }
 
+    /// Serially service waiters so fairness order is deterministic.
     async fn service_waiters(self: Arc<Self>, inner: Arc<ClientPoolInner<S, P, C>>) {
         while let Some(sender) = self.take_next_waiter_or_stop() {
             self.service_one_waiter(sender, Arc::clone(&inner)).await;
@@ -268,6 +294,7 @@ where
         clippy::integer_division_remainder_used,
         reason = "tokio::select! macro internally uses % for random branch selection"
     )]
+    /// Race slot capacity against shutdown for one selected waiter.
     async fn service_one_waiter(
         &self,
         sender: WaiterSender<S, P, C>,

--- a/src/client/pool/scheduler.rs
+++ b/src/client/pool/scheduler.rs
@@ -290,11 +290,11 @@ where
         }
     }
 
+    /// Race slot capacity against shutdown for one selected waiter.
     #[expect(
         clippy::integer_division_remainder_used,
         reason = "tokio::select! macro internally uses % for random branch selection"
     )]
-    /// Race slot capacity against shutdown for one selected waiter.
     async fn service_one_waiter(
         &self,
         sender: WaiterSender<S, P, C>,

--- a/src/client/pool/slot.rs
+++ b/src/client/pool/slot.rs
@@ -22,9 +22,13 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Size-one pool containing the reusable physical client.
     pub(crate) pool: Pool<WireframeConnectionManager<S, P, C>>,
+    /// Admission semaphore limiting concurrent logical operations.
     permits: Arc<Semaphore>,
+    /// Idle age at which the physical resource must be replaced.
     idle_timeout: Duration,
+    /// Last healthy return time used for idle recycling.
     last_returned_at: Mutex<Option<Instant>>,
 }
 
@@ -34,6 +38,7 @@ where
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Construct a slot with independent admission and recycle state.
     pub(crate) fn new(
         pool: Pool<WireframeConnectionManager<S, P, C>>,
         max_in_flight_per_socket: usize,
@@ -47,10 +52,12 @@ where
         }
     }
 
+    /// Try to reserve capacity without waiting or registering a waiter.
     pub(crate) fn try_acquire_permit(self: &Arc<Self>) -> Option<OwnedSemaphorePermit> {
         self.permits.clone().try_acquire_owned().ok()
     }
 
+    /// Wait for capacity; semaphore closure is surfaced as disconnection.
     pub(crate) async fn acquire_permit(
         self: &Arc<Self>,
     ) -> Result<OwnedSemaphorePermit, ClientError> {
@@ -61,6 +68,7 @@ where
             .map_err(|_| ClientError::disconnected())
     }
 
+    /// Check out a healthy connection, refreshing an idle one before use.
     pub(crate) async fn checkout(&self) -> Result<SlotConnection<'_, S, P, C>, ClientError> {
         let mut connection = self.get_connection().await?;
 
@@ -77,6 +85,7 @@ where
         })
     }
 
+    /// Obtain the bb8 resource and translate checkout failures to client errors.
     async fn get_connection(
         &self,
     ) -> Result<PooledConnection<'_, WireframeConnectionManager<S, P, C>>, ClientError> {
@@ -89,26 +98,32 @@ where
         })
     }
 
+    /// Determine whether the last healthy return exceeded the idle lifetime.
     fn should_recycle_idle(&self) -> bool {
         self.lock_last_returned_at()
             .as_ref()
             .is_some_and(|returned_at| returned_at.elapsed() >= self.idle_timeout)
     }
 
+    /// Clear the timestamp while replacing or invalidating the physical socket.
     fn clear_last_returned_at(&self) { *self.lock_last_returned_at() = None; }
 
+    /// Recover the timestamp mutex after a poisoned test or worker thread.
     fn lock_last_returned_at(&self) -> MutexGuard<'_, Option<Instant>> {
         lock_or_recover(&self.last_returned_at)
     }
 }
 
+/// Borrowed checkout that records whether its physical resource stayed healthy.
 pub(crate) struct SlotConnection<'a, S, P, C>
 where
     S: Serializer + Clone + Send + Sync + 'static,
     P: bincode::Encode + Clone + Send + Sync + 'static,
     C: Send + 'static,
 {
+    /// Checked-out resource whose drop records healthy or broken return state.
     connection: PooledConnection<'a, WireframeConnectionManager<S, P, C>>,
+    /// Slot timestamp updated when the checkout is returned.
     last_returned_at: &'a Mutex<Option<Instant>>,
 }
 

--- a/src/client/preamble_exchange.rs
+++ b/src/client/preamble_exchange.rs
@@ -15,9 +15,13 @@ use crate::preamble::write_preamble;
 
 /// Holds optional preamble configuration for the client builder.
 pub(crate) struct PreambleConfig<P> {
+    /// Encoded handshake value sent before length-delimited frames.
     pub(crate) preamble: P,
+    /// Callback that may read handshake response bytes for the codec.
     pub(crate) on_success: Option<ClientPreambleSuccessHandler<P>>,
+    /// Best-effort callback invoked after a failed handshake.
     pub(crate) on_failure: Option<ClientPreambleFailureHandler>,
+    /// Optional bound for the complete write-and-success-callback exchange.
     pub(crate) timeout: Option<Duration>,
 }
 

--- a/src/client/response_stream.rs
+++ b/src/client/response_stream.rs
@@ -64,10 +64,15 @@ where
     S: Serializer + Send + Sync,
     T: ClientStream,
 {
+    /// Exclusive mutable client borrow used to read the next framed response.
     client: &'a mut super::WireframeClient<S, T, C>,
+    /// Correlation value every non-terminator frame must carry.
     correlation_id: u64,
+    /// Set once the terminator, EOF, decode error, or mismatch is observed.
     terminated: bool,
+    /// Number of successfully decoded data frames, excluding the terminator.
     frame_count: usize,
+    /// Keeps the packet type at the stream level without storing a value.
     _phantom: PhantomData<fn() -> P>,
 }
 

--- a/src/client/runtime.rs
+++ b/src/client/runtime.rs
@@ -60,11 +60,17 @@ pub struct WireframeClient<S = BincodeSerializer, T = TcpStream, C = ()>
 where
     T: ClientStream,
 {
+    /// Framed transport whose mutable borrow serializes client operations.
     pub(crate) framed: Framed<T, LengthDelimitedCodec>,
+    /// Serializer used for every message on this connection.
     pub(crate) serializer: S,
+    /// Configuration retained for frame construction and diagnostics.
     pub(crate) codec_config: ClientCodecConfig,
+    /// State returned by the connection setup hook, if configured.
     pub(crate) connection_state: Option<C>,
+    /// Teardown callback consuming connection state during close.
     pub(crate) on_disconnect: Option<ClientConnectionTeardownHandler<C>>,
+    /// Best-effort callback invoked before returning client errors.
     pub(crate) on_error: Option<ClientErrorHandler>,
     /// Hooks invoked on every outgoing and incoming frame.
     pub(crate) request_hooks: RequestHooks,

--- a/src/client/send_streaming.rs
+++ b/src/client/send_streaming.rs
@@ -40,7 +40,9 @@ use crate::serializer::Serializer;
 /// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct SendStreamingConfig {
+    /// Optional upper bound for body bytes placed in one frame.
     chunk_size: Option<usize>,
+    /// Optional deadline covering reads, writes, and flushes.
     timeout: Option<Duration>,
 }
 
@@ -111,6 +113,7 @@ impl SendStreamingConfig {
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SendStreamingOutcome {
+    /// Number of complete frames written before the operation returned.
     frames_sent: u64,
 }
 

--- a/src/client/streaming_helpers.rs
+++ b/src/client/streaming_helpers.rs
@@ -152,9 +152,13 @@ pub struct TypedResponseStream<S, Mapper, P, Item>
 where
     S: Stream<Item = Result<P, ClientError>>,
 {
+    /// Wrapped response stream preserving transport order and termination.
     inner: S,
+    /// Mapper that may drop control frames or terminate with an error.
     mapper: Mapper,
+    /// Prevents polling after a mapper or underlying stream terminal result.
     terminated: bool,
+    /// Retains erased protocol and item types for type checking only.
     _phantom: PhantomData<fn() -> (P, Item)>,
 }
 
@@ -162,6 +166,7 @@ impl<S, Mapper, P, Item> TypedResponseStream<S, Mapper, P, Item>
 where
     S: Stream<Item = Result<P, ClientError>>,
 {
+    /// Construct an adapter with an active stream and mapper.
     fn new(inner: S, mapper: Mapper) -> Self {
         Self {
             inner,

--- a/src/client/tracing_config.rs
+++ b/src/client/tracing_config.rs
@@ -41,17 +41,29 @@ use tracing::Level;
 )]
 #[derive(Clone, Debug)]
 pub struct TracingConfig {
+    /// Span level for connection establishment.
     pub(crate) connect_level: Level,
+    /// Span level for one-way sends.
     pub(crate) send_level: Level,
+    /// Span level for one-way receives.
     pub(crate) receive_level: Level,
+    /// Span level for request-response calls.
     pub(crate) call_level: Level,
+    /// Span level for streaming calls.
     pub(crate) streaming_level: Level,
+    /// Span level for orderly connection close.
     pub(crate) close_level: Level,
+    /// Emit elapsed microseconds for connection establishment.
     pub(crate) connect_timing: bool,
+    /// Emit elapsed microseconds for one-way sends.
     pub(crate) send_timing: bool,
+    /// Emit elapsed microseconds for one-way receives.
     pub(crate) receive_timing: bool,
+    /// Emit elapsed microseconds for request-response calls.
     pub(crate) call_timing: bool,
+    /// Emit elapsed microseconds for streaming calls.
     pub(crate) streaming_timing: bool,
+    /// Emit elapsed microseconds for orderly connection close.
     pub(crate) close_timing: bool,
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -109,6 +109,7 @@ pub trait FrameCodec: Send + Sync + Clone + 'static {
 /// 4-byte big-endian length prefix (`tokio_util` default).
 #[derive(Clone, Debug)]
 pub struct LengthDelimitedFrameCodec {
+    /// Maximum payload accepted before the encoder reports a framing error.
     max_frame_length: usize,
 }
 
@@ -125,6 +126,7 @@ impl LengthDelimitedFrameCodec {
     #[must_use]
     pub fn max_frame_length(&self) -> usize { self.max_frame_length }
 
+    /// Build a fresh tokio codec so encoder and decoder state remain isolated.
     fn new_inner_codec(&self) -> LengthDelimitedCodec {
         LengthDelimitedCodec::builder()
             .max_frame_length(self.max_frame_length)
@@ -146,6 +148,7 @@ pub const LENGTH_HEADER_SIZE: usize = 4;
 /// Decoder half of [`LengthDelimitedFrameCodec`].
 #[doc(hidden)]
 pub struct LengthDelimitedDecoder {
+    /// Stateful length-delimited decoder used for one stream.
     inner: LengthDelimitedCodec,
 }
 
@@ -188,13 +191,17 @@ impl Decoder for LengthDelimitedDecoder {
     }
 }
 
+/// Buffer measurements used to classify clean EOF versus truncation.
 #[derive(Clone, Copy, Debug)]
 struct EofContext {
+    /// Number of bytes still present when EOF was observed.
     bytes_received: usize,
+    /// Declared payload length when a complete prefix was available.
     expected: Option<usize>,
 }
 
 impl EofContext {
+    /// Inspect buffered bytes without consuming them before EOF classification.
     fn from_buffer(src: &BytesMut) -> Self {
         let bytes_received = src.len();
         let expected = src
@@ -241,7 +248,9 @@ fn build_eof_error(context: EofContext) -> io::Error {
 /// Encoder half of [`LengthDelimitedFrameCodec`].
 #[doc(hidden)]
 pub struct LengthDelimitedEncoder {
+    /// Stateful length-delimited encoder used for one stream.
     inner: LengthDelimitedCodec,
+    /// Local limit checked before delegating to the underlying encoder.
     max_frame_length: usize,
 }
 

--- a/src/connection/counter.rs
+++ b/src/connection/counter.rs
@@ -10,6 +10,7 @@ static ACTIVE_CONNECTIONS: AtomicU64 = AtomicU64::new(0);
 pub(super) struct ActiveConnection;
 
 impl ActiveConnection {
+    /// Register one live actor before it begins polling connection sources.
     pub(super) fn new() -> Self {
         ACTIVE_CONNECTIONS.fetch_add(1, Ordering::Relaxed);
         crate::metrics::inc_connections();

--- a/src/connection/drain.rs
+++ b/src/connection/drain.rs
@@ -7,15 +7,20 @@ use crate::{app::Packet, correlation::CorrelatableFrame, push::FrameLike};
 
 /// Context for drain operations containing mutable references to output and actor state.
 pub(super) struct DrainContext<'a, F> {
+    /// Destination preserving the actor's wire-order output.
     pub(super) out: &'a mut Vec<F>,
+    /// Lifecycle state updated when a queue closes or yields a frame.
     pub(super) state: &'a mut ActorState,
 }
 
 /// Queue variants processed by the connection actor.
 #[derive(Clone, Copy)]
 pub(super) enum QueueKind {
+    /// Urgent pushes that take precedence in the biased select loop.
     High,
+    /// Best-effort pushes subject to fairness yielding.
     Low,
+    /// Frames from the currently active multi-packet response.
     Multi,
 }
 
@@ -122,6 +127,7 @@ where
         state.mark_closed();
     }
 
+    /// Forward one frame, then update fairness and lifecycle bookkeeping.
     fn forward_queue_frame(&mut self, kind: QueueKind, frame: F, ctx: DrainContext<'_, F>) {
         let DrainContext { out, state } = ctx;
         if self.should_emit_multi_packet_frame(kind) {
@@ -136,6 +142,7 @@ where
         }
     }
 
+    /// Check whether multi-packet output needs correlation stamping.
     fn should_emit_multi_packet_frame(&mut self, kind: QueueKind) -> bool {
         matches!(kind, QueueKind::Multi)
             && self
@@ -144,6 +151,7 @@ where
                 .is_some_and(|ctx| ctx.is_stamping_enabled())
     }
 
+    /// Mark a source closed when polling reports no further frames.
     fn handle_empty_queue(&mut self, kind: QueueKind, state: &mut ActorState, out: &mut Vec<F>) {
         match kind {
             QueueKind::High => {
@@ -159,6 +167,7 @@ where
         }
     }
 
+    /// Perform one non-blocking low-priority drain after a fairness yield.
     fn try_opportunistic_low_drain(&mut self, state: &mut ActorState, out: &mut Vec<F>) -> bool {
         let Some(receiver) = self.low_rx.as_mut() else {
             return false;
@@ -178,6 +187,7 @@ where
         }
     }
 
+    /// Perform one non-blocking multi-packet drain after a fairness yield.
     fn try_opportunistic_multi_drain(&mut self, state: &mut ActorState, out: &mut Vec<F>) -> bool {
         let Some(ctx) = self.active_output.multi_packet_mut() else {
             return false;

--- a/src/connection/event.rs
+++ b/src/connection/event.rs
@@ -8,8 +8,11 @@ use crate::response::WireframeError;
 /// `Clone` or `PartialEq`.
 #[derive(Debug)]
 pub(super) enum Event<F, E> {
+    /// Cancellation was observed and all sources must begin shutdown.
     Shutdown,
+    /// Result from polling the urgent push queue.
     High(Option<F>),
+    /// Result from polling the best-effort push queue.
     Low(Option<F>),
     /// Frames drained from the multi-packet response channel.
     /// Frames are forwarded in channel order after low-priority queues to
@@ -17,6 +20,8 @@ pub(super) enum Event<F, E> {
     /// The actor emits the protocol terminator when the sender closes the
     /// channel so downstream observers see end-of-stream signalling.
     MultiPacket(Option<F>),
+    /// Result from polling the streaming response, including transport errors.
     Response(Option<Result<F, WireframeError<E>>>),
+    /// No source was eligible; this is a defensive select-loop fallback.
     Idle,
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -77,7 +77,9 @@ pub enum ConnectionStateError {
 /// # drop(actor);
 /// ```
 pub struct ConnectionActor<F, E = NoProtocolError> {
+    /// Receiver for urgent frames, polled before all other data sources.
     high_rx: Option<mpsc::Receiver<F>>,
+    /// Receiver for best-effort frames, serviced subject to fairness limits.
     low_rx: Option<mpsc::Receiver<F>>,
     /// Active output source: either a streaming response or a multi-packet channel.
     ///
@@ -85,13 +87,21 @@ pub struct ConnectionActor<F, E = NoProtocolError> {
     /// is drained after low-priority frames to preserve fairness with queued sources.
     /// The actor emits the protocol terminator when the sender closes the channel.
     active_output: ActiveOutput<F, E>,
+    /// Cancellation signal shared by the supervisor and this actor.
     shutdown: CancellationToken,
+    /// RAII registration keeping the global active-connection gauge accurate.
     counter: Option<ActiveConnection>,
+    /// Protocol callbacks invoked around frame and stream lifecycle events.
     hooks: ProtocolHooks<F, E>,
+    /// Per-connection context passed to protocol callbacks.
     ctx: ConnectionContext,
+    /// Scheduler state preventing high-priority traffic from starving low traffic.
     fairness: FairnessTracker,
+    /// Optional fragmenter applied immediately before outbound emission.
     fragmenter: Option<Arc<Fragmenter>>,
+    /// Identifier used to correlate actor diagnostics with connection setup.
     connection_id: Option<ConnectionId>,
+    /// Peer address retained for diagnostics when the socket exposes it.
     peer_addr: Option<SocketAddr>,
 }
 

--- a/src/connection/multi_packet.rs
+++ b/src/connection/multi_packet.rs
@@ -30,6 +30,7 @@ pub(super) enum MultiPacketTerminationReason {
 }
 
 impl MultiPacketTerminationReason {
+    /// Provide a stable low-cardinality label for logs and metrics.
     pub(super) const fn as_str(self) -> &'static str {
         match self {
             Self::Drained => "drained",
@@ -45,11 +46,14 @@ impl fmt::Display for MultiPacketTerminationReason {
 
 /// Multi-packet channel state tracking the active receiver and stamping config.
 pub(super) struct MultiPacketContext<F> {
+    /// Receiver owned by the actor until closure or shutdown.
     channel: Option<mpsc::Receiver<F>>,
+    /// Correlation metadata applied to frames emitted from the receiver.
     stamp: MultiPacketStamp,
 }
 
 impl<F> MultiPacketContext<F> {
+    /// Start with no receiver so stamping cannot occur accidentally.
     pub(super) const fn new() -> Self {
         Self {
             channel: None,
@@ -75,6 +79,7 @@ impl<F> MultiPacketContext<F> {
         self.stamp = stamp;
     }
 
+    /// Borrow the receiver without transferring actor ownership.
     pub(super) fn channel_mut(&mut self) -> Option<&mut mpsc::Receiver<F>> { self.channel.as_mut() }
 
     /// Returns `true` if correlation stamping is enabled.
@@ -82,6 +87,7 @@ impl<F> MultiPacketContext<F> {
         matches!(self.stamp, MultiPacketStamp::Enabled(_))
     }
 
+    /// Return the identifier to stamp on frames, if stamping is enabled.
     pub(super) fn correlation_id(&self) -> Option<u64> {
         match self.stamp {
             MultiPacketStamp::Enabled(value) => value,

--- a/src/connection/output.rs
+++ b/src/connection/output.rs
@@ -39,9 +39,13 @@ pub(super) struct MultiPacketCloseResult {
 )]
 #[derive(Clone, Copy)]
 pub(super) struct EventAvailability {
+    /// Whether an urgent queue can currently be polled.
     pub(super) high: bool,
+    /// Whether a best-effort queue can currently be polled.
     pub(super) low: bool,
+    /// Whether the active multi-packet source can be polled.
     pub(super) multi_packet: bool,
+    /// Whether the active streaming response can be polled.
     pub(super) response: bool,
 }
 

--- a/src/connection/shutdown.rs
+++ b/src/connection/shutdown.rs
@@ -62,6 +62,7 @@ where
         self.hooks.on_command_end(&mut self.ctx);
     }
 
+    /// Log a stream termination with severity matching its cancellation cause.
     pub(super) fn log_multi_packet_closure(
         &self,
         reason: MultiPacketTerminationReason,

--- a/src/connection/state.rs
+++ b/src/connection/state.rs
@@ -12,8 +12,11 @@ enum RunState {
 
 /// Tracks progress through the actor lifecycle.
 pub(super) struct ActorState {
+    /// Current lifecycle phase; only `Active` may accept normal frames.
     run_state: RunState,
+    /// Number of source closures observed by the actor.
     closed_sources: usize,
+    /// Number of sources that must close before the actor can finish.
     total_sources: usize,
 }
 

--- a/src/connection/test_support.rs
+++ b/src/connection/test_support.rs
@@ -62,7 +62,9 @@ pub fn create_test_actor_with_hooks(
 
 /// Convenience harness wrapping an actor, its state, and buffered output.
 pub struct ActorHarness {
+    /// Actor under test, retaining the real queue and lifecycle logic.
     actor: ConnectionActor<u8>,
+    /// Mutable lifecycle state supplied to direct drain helpers.
     state: ActorState,
     /// Frames emitted by the actor during tests, preserved for assertions.
     pub out: Vec<u8>,
@@ -198,6 +200,7 @@ pub struct ActorStateSnapshot {
 
 /// Harness around `ActorState` for integration tests.
 pub struct ActorStateHarness {
+    /// Lifecycle state exercised by verification helpers.
     state: ActorState,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,7 @@ impl<E: std::fmt::Debug> std::fmt::Display for WireframeError<E> {
     }
 }
 
+/// Return the underlying transport or codec cause, when one exists.
 fn transport_or_codec_source<E>(
     error: &WireframeError<E>,
 ) -> Option<&(dyn std::error::Error + 'static)> {
@@ -94,6 +95,7 @@ impl std::error::Error for WireframeError<NoProtocolError> {
     }
 }
 
+/// Expose a protocol error as a source without claiming setup errors have one.
 fn protocol_error_source<E>(error: &WireframeError<E>) -> Option<&(dyn std::error::Error + 'static)>
 where
     E: std::error::Error + 'static,

--- a/src/extractor/connection_info.rs
+++ b/src/extractor/connection_info.rs
@@ -7,6 +7,8 @@ use super::{FromMessageRequest, MessageRequest, Payload};
 /// Extractor providing peer connection metadata.
 #[derive(Debug, Clone, Copy)]
 pub struct ConnectionInfo {
+    /// Captures the transport peer once so extractors cannot observe a later
+    /// connection being accepted by the same listener.
     peer_addr: Option<SocketAddr>,
 }
 

--- a/src/extractor/streaming.rs
+++ b/src/extractor/streaming.rs
@@ -36,6 +36,9 @@ use super::{ExtractError, FromMessageRequest, MessageRequest, Payload};
 ///
 /// [`RequestBodyStream`]: crate::request::RequestBodyStream
 pub struct StreamingBody {
+    /// Sole receiver for incremental request bytes; ownership prevents a
+    /// buffered extractor and a streaming extractor from consuming the same
+    /// body concurrently.
     stream: crate::request::RequestBodyStream,
 }
 

--- a/src/fairness.rs
+++ b/src/fairness.rs
@@ -46,18 +46,25 @@ impl Clock for TokioClock {
 }
 
 #[derive(Debug)]
+/// Mutable scheduling state enforcing bounded high-priority bursts.
 pub(crate) struct FairnessTracker<C: Clock = TokioClock> {
+    /// Threshold and optional time slice governing yield decisions.
     config: FairnessConfig,
+    /// Injectable clock used to make time-based decisions testable.
     clock: C,
+    /// Consecutive high-priority frames since the last low-priority frame.
     high_counter: usize,
+    /// Start of the current uninterrupted high-priority burst.
     high_start: Option<Instant>,
 }
 
 impl FairnessTracker {
+    /// Create a tracker using Tokio's monotonic clock.
     pub(crate) fn new(config: FairnessConfig) -> Self { Self::with_clock(config, TokioClock) }
 }
 
 impl<C: Clock> FairnessTracker<C> {
+    /// Construct a tracker with an explicit clock for deterministic tests.
     pub(crate) fn with_clock(config: FairnessConfig, clock: C) -> Self {
         Self {
             config,
@@ -67,11 +74,13 @@ impl<C: Clock> FairnessTracker<C> {
         }
     }
 
+    /// Replace policy and clear prior burst history so old traffic cannot bias it.
     pub(crate) fn set_config(&mut self, config: FairnessConfig) {
         self.config = config;
         self.reset();
     }
 
+    /// Count one emitted high-priority frame and start its burst timer if needed.
     pub(crate) fn record_high_priority(&mut self) {
         self.high_counter += 1;
         if self.high_counter == 1 {
@@ -79,6 +88,7 @@ impl<C: Clock> FairnessTracker<C> {
         }
     }
 
+    /// Report whether fairness policy requires checking the low-priority queue.
     pub(crate) fn should_yield_to_low_priority(&self) -> bool {
         if self.config.max_high_before_low > 0
             && self.high_counter >= self.config.max_high_before_low
@@ -93,8 +103,10 @@ impl<C: Clock> FairnessTracker<C> {
         false
     }
 
+    /// End the current high-priority burst after a low-priority frame is served.
     pub(crate) fn reset(&mut self) { self.clear(); }
 
+    /// Clear counters and timer without changing configured fairness policy.
     fn clear(&mut self) {
         self.high_counter = 0;
         self.high_start = None;

--- a/src/fragment/adapter.rs
+++ b/src/fragment/adapter.rs
@@ -63,7 +63,9 @@ pub trait FragmentAdapter: Send + Sync {
 /// Default adapter backed by [`Fragmenter`] and [`Reassembler`].
 #[derive(Debug)]
 pub struct DefaultFragmentAdapter {
+    /// Outbound state that assigns message ids and emits bounded chunks.
     fragmenter: Fragmenter,
+    /// Inbound state that enforces ordering and bounds partial allocations.
     reassembler: Reassembler,
 }
 

--- a/src/fragment/fragmenter.rs
+++ b/src/fragment/fragmenter.rs
@@ -16,17 +16,26 @@ use crate::message::Message;
 /// Splits logical messages into fragment-sized frames.
 #[derive(Debug)]
 pub struct Fragmenter {
+    /// Maximum number of payload bytes carried by one transport fragment.
     max_fragment_size: NonZeroUsize,
+    /// Atomically allocated id for the next logical message.
     next_message_id: AtomicU64,
 }
 
+/// Cursor used while walking a payload into sequential fragment slices.
+///
+/// Keeping the byte offset and protocol index together prevents a fragment
+/// from being labelled with a position that does not match its payload slice.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct FragmentCursor {
+    /// Byte offset at which the next fragment starts.
     offset: usize,
+    /// Protocol index assigned to the next fragment.
     index: FragmentIndex,
 }
 
 impl FragmentCursor {
+    /// Pair a payload offset with its corresponding fragment index.
     pub(crate) const fn new(offset: usize, index: FragmentIndex) -> Self { Self { offset, index } }
 }
 
@@ -118,6 +127,7 @@ impl Fragmenter {
         Ok(FragmentBatch::new(message_id, fragments))
     }
 
+    /// Build all fragments starting at the first protocol index.
     fn build_fragments(
         &self,
         message_id: MessageId,
@@ -130,6 +140,7 @@ impl Fragmenter {
         )
     }
 
+    /// Continue fragment construction from a cursor, validating each slice.
     fn build_fragments_from(
         &self,
         message_id: MessageId,
@@ -199,7 +210,9 @@ impl Fragmenter {
 /// Metadata and payload for a single outbound fragment.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FragmentFrame {
+    /// Header carrying identity, order, and completion state on the wire.
     header: FragmentHeader,
+    /// Bytes belonging to this fragment, excluding the encoded header.
     payload: Vec<u8>,
 }
 
@@ -224,11 +237,14 @@ impl FragmentFrame {
 /// Collection of fragments produced for a single logical message.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FragmentBatch {
+    /// Identifier shared by every frame in this batch.
     message_id: MessageId,
+    /// Frames in ascending fragment-index order.
     fragments: Vec<FragmentFrame>,
 }
 
 impl FragmentBatch {
+    /// Construct a non-empty batch produced for one logical message.
     fn new(message_id: MessageId, fragments: Vec<FragmentFrame>) -> Self {
         debug_assert!(!fragments.is_empty(), "fragment batches must not be empty");
         Self {
@@ -269,4 +285,5 @@ impl IntoIterator for FragmentBatch {
     fn into_iter(self) -> Self::IntoIter { self.fragments.into_iter() }
 }
 
+/// Compute the number of fixed-width chunks needed for a payload.
 fn div_ceil(numerator: usize, denominator: usize) -> usize { numerator.div_ceil(denominator) }

--- a/src/fragment/header.rs
+++ b/src/fragment/header.rs
@@ -24,8 +24,11 @@ use super::{FragmentIndex, MessageId};
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Encode, Decode)]
 pub struct FragmentHeader {
+    /// Logical message identity used to select the reassembly buffer.
     message_id: MessageId,
+    /// Zero-based position used to reject gaps and identify duplicates.
     fragment_index: FragmentIndex,
+    /// Marks the fragment after which the reassembly buffer may be released.
     is_last_fragment: bool,
 }
 

--- a/src/fragment/packet.rs
+++ b/src/fragment/packet.rs
@@ -13,8 +13,11 @@ use super::{FragmentationError, Fragmenter, encode_fragment_payload};
 /// types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FragmentParts {
+    /// Application route or packet identifier preserved across fragmentation.
     id: u32,
+    /// Optional request correlation value preserved on each emitted frame.
     correlation_id: Option<u64>,
+    /// Payload bytes being passed between packet and transport layers.
     payload: Vec<u8>,
 }
 

--- a/src/fragment/reassembler.rs
+++ b/src/fragment/reassembler.rs
@@ -21,20 +21,29 @@ use bincode::error::DecodeError;
 use super::{FragmentHeader, FragmentSeries, FragmentStatus, MessageId, ReassemblyError};
 use crate::message::Message;
 
+/// Owned state retained while a message's remaining fragments arrive.
 #[derive(Debug)]
 struct PartialMessage {
+    /// Ordering tracker for fragments already accepted into this buffer.
     series: FragmentSeries,
+    /// Concatenated payload, retained until the final fragment arrives.
     buffer: Vec<u8>,
+    /// Clock reading used to evict abandoned assemblies.
     started_at: Instant,
 }
 
+/// Borrowed inputs used when registering the first fragment of a series.
 struct FirstFragment<'a> {
+    /// Header establishing the message identity and initial ordering state.
     header: FragmentHeader,
+    /// Payload borrowed only for the duration of insertion and validation.
     payload: &'a [u8],
+    /// Timestamp that anchors timeout-based eviction for this series.
     now: Instant,
 }
 
 impl PartialMessage {
+    /// Start a partial message with its first payload and timeout timestamp.
     fn new(series: FragmentSeries, payload: &[u8], started_at: Instant) -> Self {
         Self {
             series,
@@ -43,19 +52,25 @@ impl PartialMessage {
         }
     }
 
+    /// Append an ordered fragment payload to the owned reassembly buffer.
     fn push(&mut self, payload: &[u8]) { self.buffer.extend_from_slice(payload); }
 
+    /// Return the number of payload bytes currently buffered.
     fn len(&self) -> usize { self.buffer.len() }
 
+    /// Return the timestamp at which this partial series began.
     fn started_at(&self) -> Instant { self.started_at }
 
+    /// Release the completed payload buffer to avoid a second allocation.
     fn into_buffer(self) -> Vec<u8> { self.buffer }
 }
 
 /// Container for a fully re-assembled message payload.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReassembledMessage {
+    /// Identity of the logical message reconstructed from the fragments.
     message_id: MessageId,
+    /// Contiguous payload bytes in protocol order.
     payload: Vec<u8>,
 }
 
@@ -95,8 +110,11 @@ impl ReassembledMessage {
 /// Stateful fragment re-assembler with timeout-based eviction.
 #[derive(Debug)]
 pub struct Reassembler {
+    /// Hard cap protecting the process from unbounded peer-controlled growth.
     max_message_size: NonZeroUsize,
+    /// Age after which an incomplete series is discarded.
     timeout: Duration,
+    /// In-flight buffers keyed by logical message identity.
     buffers: HashMap<MessageId, PartialMessage>,
 }
 
@@ -192,6 +210,7 @@ impl Reassembler {
     #[must_use]
     pub fn buffered_len(&self) -> usize { self.buffers.len() }
 
+    /// Reject a buffer size that would exceed the configured message cap.
     fn assert_within_limit(
         limit: NonZeroUsize,
         message_id: MessageId,
@@ -207,6 +226,7 @@ impl Reassembler {
         Ok(())
     }
 
+    /// Append an accepted payload and remove the entry when it completes.
     fn append_and_maybe_complete(
         limit: NonZeroUsize,
         mut occupied: OccupiedEntry<'_, MessageId, PartialMessage>,
@@ -236,6 +256,7 @@ impl Reassembler {
         }
     }
 
+    /// Validate and append a fragment for an already-started series.
     fn push_existing_fragment(
         limit: NonZeroUsize,
         mut occupied: OccupiedEntry<'_, MessageId, PartialMessage>,
@@ -263,6 +284,7 @@ impl Reassembler {
         }
     }
 
+    /// Validate and register the first fragment for a previously unseen id.
     fn push_first_fragment(
         limit: NonZeroUsize,
         vacant: std::collections::hash_map::VacantEntry<'_, MessageId, PartialMessage>,

--- a/src/fragment/series.rs
+++ b/src/fragment/series.rs
@@ -12,8 +12,11 @@ use super::{FragmentError, FragmentHeader, FragmentIndex, FragmentStatus, Messag
 /// fragment adapter without additional allocations.
 #[derive(Clone, Debug)]
 pub struct FragmentSeries {
+    /// Message identity all accepted fragments must share.
     message_id: MessageId,
+    /// Next index accepted without treating the frame as a duplicate or gap.
     next_index: FragmentIndex,
+    /// Whether a final fragment has already closed the series.
     complete: bool,
 }
 

--- a/src/frame/conversion.rs
+++ b/src/frame/conversion.rs
@@ -9,10 +9,18 @@ use crate::byte_order::{
     write_network_u64,
 };
 
+/// Explains that the configured wire prefix cannot represent any supported
+/// fixed-width integer and therefore cannot be decoded safely.
 pub(crate) const ERR_UNSUPPORTED_PREFIX: &str = "unsupported length prefix size";
+/// Preserves the distinction between an invalid local frame length and an I/O
+/// failure when encoding a bounded wire prefix.
 pub(crate) const ERR_FRAME_TOO_LARGE: &str = "frame too large";
+/// Reports truncation before decoding so callers never mistake a partial
+/// length prefix for a complete zero-length frame.
 pub(crate) const ERR_INCOMPLETE_PREFIX: &str = "incomplete length prefix";
 
+/// Decodes an explicitly little-endian eight-byte prefix independently of the
+/// host architecture selected to run the codec.
 #[inline]
 fn u64_from_le_bytes(bytes: [u8; 8]) -> u64 {
     #[expect(

--- a/src/frame/format.rs
+++ b/src/frame/format.rs
@@ -17,7 +17,11 @@ pub enum Endianness {
 /// Format of the length prefix preceding each frame.
 #[derive(Clone, Copy, Debug)]
 pub struct LengthFormat {
+    /// Number of bytes reserved before each frame; construction constrains it
+    /// to a width that conversion helpers can decode without ambiguity.
     bytes: usize,
+    /// Establishes how those prefix bytes become a length, making the wire
+    /// contract independent from the host byte order.
     endianness: Endianness,
 }
 

--- a/src/message_assembler/budget.rs
+++ b/src/message_assembler/budget.rs
@@ -15,7 +15,9 @@ use super::{MessageKey, error::MessageAssemblyError};
 /// `Option<NonZeroUsize>` parameters.
 #[derive(Clone, Copy, Debug)]
 pub(super) struct AggregateBudgets {
+    /// Maximum bytes retained across all assemblies on one connection.
     pub(super) connection: Option<NonZeroUsize>,
+    /// Maximum bytes retained for frames currently awaiting completion.
     pub(super) in_flight: Option<NonZeroUsize>,
 }
 

--- a/src/message_assembler/header.rs
+++ b/src/message_assembler/header.rs
@@ -95,7 +95,9 @@ pub struct ContinuationFrameHeader {
 /// Result of parsing a frame header from payload bytes.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ParsedFrameHeader {
+    /// Parsed protocol variant used to route body bytes and ordering checks.
     header: FrameHeader,
+    /// Number of prefix bytes consumed while parsing the header.
     header_len: usize,
 }
 

--- a/src/message_assembler/series.rs
+++ b/src/message_assembler/series.rs
@@ -61,6 +61,7 @@ enum SequenceTracking {
 /// ```
 #[derive(Clone, Debug)]
 pub struct MessageSeries {
+    /// Logical message key required on every continuation frame.
     message_key: MessageKey,
     /// Next expected sequence number (None if protocol does not supply them).
     next_sequence: Option<FrameSequence>,
@@ -256,6 +257,7 @@ impl MessageSeries {
         self.advance_sequence_or_overflow(incoming, is_last)
     }
 
+    /// Validate the incoming sequence and advance the tracker atomically.
     fn validate_and_advance_sequence(
         &mut self,
         incoming: FrameSequence,

--- a/src/message_assembler/state.rs
+++ b/src/message_assembler/state.rs
@@ -22,14 +22,20 @@ use super::{
 /// Partial message assembly in progress.
 #[derive(Debug)]
 struct PartialAssembly {
+    /// Ordering state that rejects gaps, duplicates, and post-completion data.
     series: MessageSeries,
+    /// Envelope routing retained until the assembled message is emitted.
     routing: EnvelopeRouting,
+    /// First-frame metadata kept separate from the body for reconstruction.
     metadata: Vec<u8>,
+    /// Ordered body bytes accumulated from first and continuation frames.
     body_buffer: Vec<u8>,
+    /// Start time used to discard incomplete peer-controlled state.
     started_at: Instant,
 }
 
 impl PartialAssembly {
+    /// Create empty assembly storage anchored at the first frame's timestamp.
     fn new(series: MessageSeries, routing: EnvelopeRouting, started_at: Instant) -> Self {
         Self {
             series,
@@ -40,10 +46,13 @@ impl PartialAssembly {
         }
     }
 
+    /// Append body bytes after the caller has validated size and ordering.
     fn push_body(&mut self, data: &[u8]) { self.body_buffer.extend_from_slice(data); }
 
+    /// Replace the first-frame metadata retained for the completed message.
     fn set_metadata(&mut self, data: Vec<u8>) { self.metadata = data; }
 
+    /// Return body bytes accumulated so far for per-message budget checks.
     fn accumulated_len(&self) -> usize { self.body_buffer.len() }
 
     /// Total heap bytes held by this partial assembly (body + metadata).
@@ -110,9 +119,13 @@ impl PartialAssembly {
 /// ```
 #[derive(Debug)]
 pub struct MessageAssemblyState {
+    /// Maximum body size permitted for one logical message.
     max_message_size: NonZeroUsize,
+    /// Age after which incomplete assemblies are removed.
     timeout: Duration,
+    /// Active assemblies keyed by protocol message key.
     assemblies: HashMap<MessageKey, PartialAssembly>,
+    /// Aggregate limits protecting connection and in-flight memory.
     budgets: AggregateBudgets,
 }
 

--- a/src/message_assembler/state.rs
+++ b/src/message_assembler/state.rs
@@ -33,7 +33,6 @@ struct PartialAssembly {
     /// Start time used to discard incomplete peer-controlled state.
     started_at: Instant,
 }
-
 impl PartialAssembly {
     /// Create empty assembly storage anchored at the first frame's timestamp.
     fn new(series: MessageSeries, routing: EnvelopeRouting, started_at: Instant) -> Self {
@@ -45,20 +44,15 @@ impl PartialAssembly {
             started_at,
         }
     }
-
     /// Append body bytes after the caller has validated size and ordering.
     fn push_body(&mut self, data: &[u8]) { self.body_buffer.extend_from_slice(data); }
-
     /// Replace the first-frame metadata retained for the completed message.
     fn set_metadata(&mut self, data: Vec<u8>) { self.metadata = data; }
-
     /// Return body bytes accumulated so far for per-message budget checks.
     fn accumulated_len(&self) -> usize { self.body_buffer.len() }
-
     /// Total heap bytes held by this partial assembly (body + metadata).
     fn buffered_bytes(&self) -> usize { self.body_buffer.len().saturating_add(self.metadata.len()) }
 }
-
 /// Stateful manager for multiple concurrent message assemblies.
 ///
 /// Tracks in-flight assemblies keyed by [`MessageKey`], applying continuity
@@ -128,7 +122,6 @@ pub struct MessageAssemblyState {
     /// Aggregate limits protecting connection and in-flight memory.
     budgets: AggregateBudgets,
 }
-
 impl MessageAssemblyState {
     /// Create a new assembly state manager.
     ///
@@ -140,7 +133,6 @@ impl MessageAssemblyState {
     pub fn new(max_message_size: NonZeroUsize, timeout: Duration) -> Self {
         Self::with_budgets(max_message_size, timeout, None, None)
     }
-
     /// Create a new assembly state manager with optional aggregate budgets.
     ///
     /// When `connection_budget` or `in_flight_budget` is `Some`, frames that
@@ -163,7 +155,6 @@ impl MessageAssemblyState {
             },
         }
     }
-
     /// Process a first frame, starting a new assembly.
     ///
     /// Returns `Ok(Some(msg))` if the first frame is also the last (single-
@@ -182,7 +173,6 @@ impl MessageAssemblyState {
     ) -> Result<Option<AssembledMessage>, MessageAssemblyError> {
         self.accept_first_frame_at(input, Instant::now())
     }
-
     /// Process a first frame with an explicit timestamp.
     ///
     /// See [`accept_first_frame`](Self::accept_first_frame) for details.
@@ -198,7 +188,6 @@ impl MessageAssemblyState {
         now: Instant,
     ) -> Result<Option<AssembledMessage>, MessageAssemblyError> {
         self.purge_expired_at(now);
-
         let key = input.header.message_key;
 
         // Check for duplicate first frame
@@ -252,7 +241,6 @@ impl MessageAssemblyState {
 
         Ok(None)
     }
-
     /// Process a continuation frame.
     ///
     /// Returns `Ok(Some(msg))` if the message is now complete, `Ok(None)` if
@@ -269,7 +257,6 @@ impl MessageAssemblyState {
     ) -> Result<Option<AssembledMessage>, MessageAssemblyError> {
         self.accept_continuation_frame_at(header, body, Instant::now())
     }
-
     /// Whether a continuity error is unrecoverable and requires assembly removal.
     ///
     /// Unrecoverable errors (`KeyMismatch`, `SequenceOverflow`, etc.) indicate the

--- a/src/message_assembler/types.rs
+++ b/src/message_assembler/types.rs
@@ -179,9 +179,13 @@ impl<'a> FirstFrameInput<'a> {
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AssembledMessage {
+    /// Key that correlated all frames contributing to this message.
     message_key: MessageKey,
+    /// Envelope routing metadata preserved from the first frame.
     routing: EnvelopeRouting,
+    /// Metadata bytes carried by the first frame.
     metadata: Vec<u8>,
+    /// Body bytes concatenated in validated frame order.
     body: Vec<u8>,
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -106,6 +106,8 @@ pub enum Direction {
 }
 
 impl Direction {
+    /// Supplies the bounded metric label value, avoiding call-site strings
+    /// that could make inbound and outbound observations incomparable.
     fn as_str(self) -> &'static str {
         match self {
             Direction::Inbound => "inbound",

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -13,6 +13,7 @@ use crate::app::PacketParts;
 /// Generic container for request and response frame data.
 #[derive(Debug, Default)]
 pub struct FrameContainer<F> {
+    /// Frame value transformed by middleware or consumed by a handler.
     frame: F,
 }
 
@@ -37,7 +38,9 @@ impl<F> FrameContainer<F> {
 /// Incoming request wrapper passed through middleware.
 #[derive(Debug)]
 pub struct ServiceRequest {
+    /// Mutable payload presented to the middleware chain.
     inner: FrameContainer<Vec<u8>>,
+    /// Correlation metadata preserved across middleware transformations.
     correlation_id: Option<u64>,
 }
 
@@ -78,7 +81,9 @@ impl ServiceRequest {
 /// Response produced by a handler or middleware.
 #[derive(Debug, Default)]
 pub struct ServiceResponse {
+    /// Payload returned by a handler and later encoded for transport.
     inner: FrameContainer<Vec<u8>>,
+    /// Correlation metadata copied from the corresponding request.
     correlation_id: Option<u64>,
 }
 
@@ -121,6 +126,7 @@ pub struct Next<'a, S>
 where
     S: Service + ?Sized,
 {
+    /// Borrowed next service; borrowing prevents continuation after its scope.
     service: &'a S,
 }
 
@@ -194,6 +200,7 @@ where
 /// the remaining middleware chain. It must return a [`ServiceResponse`] wrapped
 /// in a [`Result`]. The error type is the same as the wrapped service.
 pub struct FromFn<F> {
+    /// User callback invoked once for each request.
     f: F,
 }
 
@@ -236,7 +243,9 @@ pub fn from_fn<F>(f: F) -> FromFn<F> { FromFn::new(f) }
 /// `Arc` to the middleware function. The function is invoked on each request
 /// with a [`ServiceRequest`] and [`Next`] continuation.
 pub struct FnService<S, F> {
+    /// Wrapped service invoked by the continuation.
     service: S,
+    /// Shared callback so cloned middleware services preserve behaviour.
     f: Arc<F>,
 }
 
@@ -276,7 +285,9 @@ use crate::app::{Handler, Packet};
 
 /// Service that invokes a stored route handler and middleware chain.
 pub struct HandlerService<E: Packet> {
+    /// Route identifier retained for diagnostics and dispatch metadata.
     id: u32,
+    /// Type-erased middleware and handler service.
     svc: Box<dyn Service<Error = Infallible> + Send + Sync>,
     /// Marker to bind the generic parameter `E` without storing a value.
     _marker: std::marker::PhantomData<E>,
@@ -312,9 +323,13 @@ impl<E: Packet> HandlerService<E> {
     pub const fn id(&self) -> u32 { self.id }
 }
 
+/// Concrete service that invokes a packet handler for one route.
 struct RouteService<E: Packet> {
+    /// Route identifier copied into generated responses.
     id: u32,
+    /// Handler invoked after middleware accepts the request.
     handler: Handler<E>,
+    /// Keeps the packet type associated with the erased service.
     _marker: std::marker::PhantomData<E>,
 }
 

--- a/src/preamble.rs
+++ b/src/preamble.rs
@@ -13,6 +13,7 @@ use bincode::{
 };
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+/// Bound preamble reads so a peer cannot grow the initial buffer indefinitely.
 const MAX_PREAMBLE_LEN: usize = 1024;
 
 /// Trait bound for types accepted as connection preambles.
@@ -23,6 +24,7 @@ const MAX_PREAMBLE_LEN: usize = 1024;
 pub trait Preamble: for<'de> BorrowDecode<'de, ()> + Send + Sync + 'static {}
 impl<T> Preamble for T where for<'de> T: BorrowDecode<'de, ()> + Send + Sync + 'static {}
 
+/// Read exactly the requested additional bytes while enforcing the preamble cap.
 async fn read_more<R>(
     reader: &mut R,
     buf: &mut Vec<u8>,

--- a/src/push/queues/builder.rs
+++ b/src/push/queues/builder.rs
@@ -64,12 +64,19 @@ use super::{
 /// # drop((_queues, _handle));
 /// ```
 #[derive(Debug)]
+/// Pending queue and dead-letter settings consumed by `build`.
 pub struct PushQueuesBuilder<F> {
+    /// Buffer size for urgent frames.
     high_capacity: usize,
+    /// Buffer size for best-effort frames.
     low_capacity: usize,
+    /// Optional global pushes-per-second limiter.
     rate: Option<usize>,
+    /// Optional sink receiving frames dropped under a full-queue policy.
     dlq: Option<mpsc::Sender<F>>,
+    /// Number of drops between count-based diagnostics.
     dlq_log_every_n: usize,
+    /// Minimum interval between drop diagnostics.
     dlq_log_interval: Duration,
 }
 

--- a/src/push/queues/handle.rs
+++ b/src/push/queues/handle.rs
@@ -43,13 +43,21 @@ use super::{FrameLike, PushError, PushPolicy, PushPriority};
 /// - `limiter` – optional rate-limiter enforcing global push throughput.
 /// - `dlq_tx` – optional dead-letter queue for discarded frames.
 pub(crate) struct PushHandleInner<F> {
+    /// Sender for urgent frames, preserving priority at the actor boundary.
     pub(crate) high_prio_tx: mpsc::Sender<F>,
+    /// Sender for best-effort frames.
     pub(crate) low_prio_tx: mpsc::Sender<F>,
+    /// Shared limiter that bounds aggregate producer throughput.
     pub(crate) limiter: Option<RateLimiter>,
+    /// Optional sink for frames discarded by non-blocking push policies.
     pub(crate) dlq_tx: Option<mpsc::Sender<F>>,
+    /// Number of drops since the last diagnostic reset.
     pub(crate) dlq_drops: AtomicUsize,
+    /// Timestamp used for interval-based drop logging.
     pub(crate) dlq_last_log: Mutex<Instant>,
+    /// Count interval used for drop diagnostics.
     pub(crate) dlq_log_every_n: usize,
+    /// Time interval used for drop diagnostics.
     pub(crate) dlq_log_interval: Duration,
 }
 
@@ -71,6 +79,7 @@ impl<F> PushHandleProbe<F> {
 }
 
 impl<F: FrameLike> PushHandle<F> {
+    /// Wrap shared queue state while retaining cloneable producer ownership.
     pub(crate) fn from_arc(arc: Arc<PushHandleInner<F>>) -> Self { Self(arc) }
 
     /// Returns a probe for inspecting internal state during loom verification.
@@ -214,6 +223,7 @@ impl<F: FrameLike> PushHandle<F> {
     /// quickly while remaining negligible relative to the 1s refill window.
     const PERMIT_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+    /// Poll permits without registering a parked waiter that could starve pushes.
     async fn wait_for_permit(&self, limiter: &RateLimiter) {
         loop {
             if limiter.try_acquire(1) {
@@ -226,6 +236,7 @@ impl<F: FrameLike> PushHandle<F> {
         }
     }
 
+    /// Emit a throttled diagnostic and reset the drop counter when due.
     fn log_dlq_drop(&self, frame: &F, dropped: usize, last_log: &mut Instant)
     where
         F: std::fmt::Debug,

--- a/src/push/queues/mod.rs
+++ b/src/push/queues/mod.rs
@@ -40,6 +40,7 @@ impl<T> FrameLike for T where T: Send + 'static {}
 
 // Default maximum pushes per second when no custom rate is specified.
 // This is an internal implementation detail and may change.
+/// Default throughput cap applied when callers do not choose a rate.
 const DEFAULT_PUSH_RATE: usize = 100;
 /// Highest supported rate for [`PushQueuesBuilder::rate`].
 pub const MAX_PUSH_RATE: usize = 10_000;
@@ -69,7 +70,9 @@ pub enum PushPolicy {
 
 /// Receiver ends of the push queues stored by the connection actor.
 pub struct PushQueues<F> {
+    /// Urgent receiver owned by the connection actor.
     pub(crate) high_priority_rx: mpsc::Receiver<F>,
+    /// Best-effort receiver owned by the connection actor.
     pub(crate) low_priority_rx: mpsc::Receiver<F>,
 }
 
@@ -79,11 +82,17 @@ pub struct PushQueues<F> {
 /// plus logging cadence for dropped frames.
 #[derive(Debug, Clone)]
 pub struct PushQueueConfig<F> {
+    /// Capacity bounding urgent queue memory.
     pub high_capacity: usize,
+    /// Capacity bounding best-effort queue memory.
     pub low_capacity: usize,
+    /// Optional aggregate producer rate limit.
     pub rate: Option<usize>,
+    /// Optional destination for frames discarded on overflow.
     pub dlq: Option<mpsc::Sender<F>>,
+    /// Number of discarded frames between diagnostics.
     pub dlq_log_every_n: usize,
+    /// Minimum elapsed time between diagnostics.
     pub dlq_log_interval: Duration,
 }
 
@@ -127,6 +136,7 @@ impl<F: FrameLike> PushQueues<F> {
         }
     }
 
+    /// Validate configuration, allocate channels, and pair them with a handle.
     pub(super) fn build_with_config(
         config: PushQueueConfig<F>,
     ) -> Result<(Self, PushHandle<F>), PushConfigError> {

--- a/src/request/mod.rs
+++ b/src/request/mod.rs
@@ -119,7 +119,6 @@ pub fn body_channel(
     let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
     (tx, Box::pin(stream))
 }
-
 /// Adapter wrapping a [`RequestBodyStream`] as [`AsyncRead`].
 ///
 /// Protocol crates can use this to feed streaming bytes into parsers
@@ -142,9 +141,9 @@ pub fn body_channel(
 /// }
 /// ```
 pub struct RequestBodyReader {
+    /// Owns ordered chunks so `AsyncRead` preserves backpressure and cancellation semantics.
     inner: StreamReader<RequestBodyStream, Bytes>,
 }
-
 impl RequestBodyReader {
     /// Create a new reader from a streaming body.
     ///
@@ -164,7 +163,6 @@ impl RequestBodyReader {
             inner: StreamReader::new(stream),
         }
     }
-
     /// Consume the reader and return the underlying stream.
     ///
     /// # Data loss warning
@@ -183,7 +181,6 @@ impl RequestBodyReader {
     #[must_use]
     pub fn into_inner(self) -> RequestBodyStream { self.inner.into_inner() }
 }
-
 impl AsyncRead for RequestBodyReader {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -193,7 +190,6 @@ impl AsyncRead for RequestBodyReader {
         Pin::new(&mut self.inner).poll_read(cx, buf)
     }
 }
-
 /// Request metadata extracted outwith the request body.
 ///
 /// `RequestParts` separates routing and protocol metadata from the request
@@ -228,7 +224,6 @@ pub struct RequestParts {
     /// interpret the body.
     metadata: Vec<u8>,
 }
-
 impl RequestParts {
     /// Construct a new set of request parts.
     ///
@@ -359,6 +354,8 @@ impl RequestParts {
     // Equivalent mutant (`found != expected` guard → `true`): when the ids are
     // equal the data path is identical to the mismatch arm bar a spurious
     // `warn!`, so the returned correlation is unchanged.
+    /// Resolves inherited identifiers deterministically, retaining the local value unless a source
+    /// must win.
     #[cfg_attr(test, mutants::skip)]
     #[inline]
     fn select_correlation(current: Option<u64>, source: Option<u64>) -> CorrelationResult {
@@ -378,7 +375,12 @@ enum CorrelationResult {
     /// The correlation ID was inherited (or remained unchanged).
     Inherited(Option<u64>),
     /// A mismatch was detected; the source value takes precedence.
-    Mismatch { found: u64, expected: u64 },
+    Mismatch {
+        /// Identifier retained for a useful warning although it cannot be propagated.
+        found: u64,
+        /// Source identifier that keeps the request within the source correlation chain.
+        expected: u64,
+    },
 }
 
 impl CorrelationResult {

--- a/src/rewind_stream.rs
+++ b/src/rewind_stream.rs
@@ -14,8 +14,11 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 /// A stream adapter that replays buffered bytes before reading
 /// from the underlying stream.
 pub struct RewindStream<S> {
+    /// Bytes already read with the preamble that must precede socket reads.
     leftover: Vec<u8>,
+    /// Cursor into `leftover`; reset when the buffered prefix is exhausted.
     pos: usize,
+    /// Underlying stream used after buffered bytes have been replayed.
     inner: S,
 }
 

--- a/src/server/config/binding.rs
+++ b/src/server/config/binding.rs
@@ -39,6 +39,7 @@ where
 trait WireframePreamble: Preamble {}
 impl<T> WireframePreamble for T where T: Preamble {}
 
+/// Bound typestate alias returned after a listener is configured.
 type BoundServer<F, T, Ser, Ctx, E, Codec> = WireframeServer<F, T, Bound, Ser, Ctx, E, Codec>;
 
 /// Blanket impl uses private trait aliases; suppress visibility lint
@@ -56,6 +57,7 @@ where
     E: Packet,
     Codec: FrameCodec,
 {
+    /// Convert a standard listener to Tokio's non-blocking listener.
     fn bind_to_listener(
         self,
         std_listener: StdTcpListener,

--- a/src/server/config/mod.rs
+++ b/src/server/config/mod.rs
@@ -16,6 +16,7 @@ use tokio::sync::oneshot;
 use super::{AppFactory, BackoffConfig, ServerState, Unbound, WireframeServer};
 use crate::{app::Packet, codec::FrameCodec, preamble::Preamble, serializer::Serializer};
 
+/// Generate a consuming setter that preserves builder typestate.
 macro_rules! builder_setter {
     ($(#[$meta:meta])* $fn:ident, $field:ident, $arg:ident: $ty:ty => $assign:expr) => {
         $(#[$meta])*
@@ -27,6 +28,7 @@ macro_rules! builder_setter {
     };
 }
 
+/// Generate a callback setter that stores handlers behind shared ownership.
 macro_rules! builder_callback {
     ($(#[$meta:meta])* $fn:ident, $field:ident, $($bound:tt)*) => {
         $(#[$meta])*
@@ -44,6 +46,7 @@ macro_rules! builder_callback {
 pub mod binding;
 pub mod preamble;
 
+/// Delegate worker-count selection to the server-wide CPU fallback policy.
 fn default_worker_count() -> usize { super::default_worker_count() }
 #[cfg(test)]
 mod tests;

--- a/src/server/connection_spawner.rs
+++ b/src/server/connection_spawner.rs
@@ -54,6 +54,7 @@ pub(super) fn spawn_connection_task<F, T, Ser, Ctx, E, Codec>(
     });
 }
 
+/// Complete the preamble handshake before handing bytes to the application.
 async fn process_stream<F, T, Ser, Ctx, E, Codec>(
     mut stream: TcpStream,
     peer_addr: Option<SocketAddr>,
@@ -88,6 +89,7 @@ async fn process_stream<F, T, Ser, Ctx, E, Codec>(
     handle_app_connection(&factory, stream).await;
 }
 
+/// Build an application and run it on the already-handshaken stream.
 async fn handle_app_connection<F, Ser, Ctx, E, Codec>(factory: &F, stream: RewindStream<TcpStream>)
 where
     F: AppFactory<Ser, Ctx, E, Codec>,
@@ -109,6 +111,7 @@ where
     }
 }
 
+/// Construct the decode error used when a preamble read exceeds its deadline.
 fn timeout_error() -> bincode::error::DecodeError {
     bincode::error::DecodeError::Io {
         inner: io::Error::new(io::ErrorKind::TimedOut, "preamble read timed out"),
@@ -116,6 +119,7 @@ fn timeout_error() -> bincode::error::DecodeError {
     }
 }
 
+/// Read a preamble, applying the configured timeout without leaking the stream.
 async fn read_preamble_with_timeout<T: Preamble>(
     stream: &mut TcpStream,
     preamble_timeout: Option<Duration>,
@@ -129,6 +133,7 @@ async fn read_preamble_with_timeout<T: Preamble>(
     }
 }
 
+/// Invoke the success callback while the stream remains exclusively borrowed.
 async fn run_preamble_success<T: Preamble>(
     handler: Option<&PreambleHandler<T>>,
     preamble: &T,
@@ -142,6 +147,7 @@ async fn run_preamble_success<T: Preamble>(
     }
 }
 
+/// Invoke the failure callback and preserve diagnostics for rejected peers.
 async fn run_preamble_failure(
     handler: Option<&PreambleFailure>,
     err: bincode::error::DecodeError,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -206,9 +206,13 @@ pub struct WireframeServer<
     E: Packet,
     Codec: FrameCodec,
 {
+    /// Factory cloned for each accepted connection.
     pub(crate) factory: F,
+    /// Number of accept-loop worker tasks to supervise.
     pub(crate) workers: usize,
+    /// Optional callback run after a valid preamble.
     pub(crate) on_preamble_success: Option<PreambleHandler<T>>,
+    /// Optional callback run when preamble validation fails.
     pub(crate) on_preamble_failure: Option<PreambleFailure>,
     /// Channel used to notify when the server is ready.
     ///
@@ -223,6 +227,7 @@ pub struct WireframeServer<
     /// Because only one notification may be sent, a new `ready_tx` must be
     /// provided each time the server is started.
     pub(crate) ready_tx: Option<oneshot::Sender<()>>,
+    /// Retry policy used when accepting a connection fails transiently.
     pub(crate) backoff_config: BackoffConfig,
     /// Maximum duration allowed for reading a preamble before timing out.
     ///
@@ -232,7 +237,9 @@ pub struct WireframeServer<
     /// Typestate tracking whether the server has been bound to a listener.
     /// [`Unbound`] servers require binding before they can run.
     pub(crate) state: S,
+    /// Typestate marker retaining application generic parameters.
     pub(crate) _app: PhantomData<(Ser, Ctx, E, Codec)>,
+    /// Typestate marker retaining the preamble type.
     pub(crate) _preamble: PhantomData<T>,
 }
 
@@ -243,6 +250,7 @@ pub struct Unbound;
 /// Marker indicating the server is bound to a TCP listener.
 #[derive(Debug, Clone)]
 pub struct Bound {
+    /// Shared non-blocking listener used by all supervised workers.
     pub(crate) listener: Arc<TcpListener>,
 }
 
@@ -252,6 +260,7 @@ pub trait ServerState: sealed::Sealed {}
 mod sealed {
     //! Prevent external implementations of [`ServerState`].
 
+    /// Private supertrait prevents external typestate implementations.
     pub trait Sealed {}
     impl Sealed for super::Unbound {}
     impl Sealed for super::Bound {}

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -34,9 +34,13 @@ use crate::{
     serializer::Serializer,
 };
 
+/// Supervisor has not yet observed completion or cancellation.
 const SUPERVISOR_RUNNING: u8 = 0;
+/// Shutdown future resolved and cancellation was requested intentionally.
 const SUPERVISOR_GRACEFUL: u8 = 1;
+/// Supervisor guard was dropped before normal shutdown.
 const SUPERVISOR_DROPPED: u8 = 2;
+/// All tracked workers completed without cancellation.
 const SUPERVISOR_FINISHED: u8 = 3;
 
 /// Shares one terminal cancellation reason with the supervisor's accept loops.
@@ -45,21 +49,25 @@ const SUPERVISOR_FINISHED: u8 = 3;
 /// record its own exit. It never owns a listener or task tracker.
 #[derive(Clone, Debug)]
 pub(in crate::server) struct SupervisorLifecycle {
+    /// Atomic state shared by accept loops without owning their resources.
     state: Arc<AtomicU8>,
 }
 
 impl SupervisorLifecycle {
+    /// Start lifecycle tracking in the running state.
     fn new() -> Self {
         Self {
             state: Arc::new(AtomicU8::new(SUPERVISOR_RUNNING)),
         }
     }
 
+    /// Publish intentional cancellation before notifying worker loops.
     fn record_graceful_cancellation(&self) {
         self.state.store(SUPERVISOR_GRACEFUL, Ordering::Release);
         record_supervisor_cancellation(ServerCancellationReason::Graceful);
     }
 
+    /// Publish cancellation caused by dropping the supervisor future once.
     fn record_dropped_cancellation(&self) {
         if self
             .state
@@ -75,10 +83,12 @@ impl SupervisorLifecycle {
         }
     }
 
+    /// Mark normal worker completion without incrementing cancellation metrics.
     fn record_completion_without_cancellation(&self) {
         self.state.store(SUPERVISOR_FINISHED, Ordering::Release);
     }
 
+    /// Translate the atomic terminal state into the metrics-facing reason.
     pub(in crate::server) fn cancellation_reason(&self) -> ServerCancellationReason {
         match self.state.load(Ordering::Acquire) {
             SUPERVISOR_GRACEFUL => ServerCancellationReason::Graceful,
@@ -90,6 +100,7 @@ impl SupervisorLifecycle {
     }
 }
 
+/// Emit one cancellation metric and its structured diagnostic event.
 fn record_supervisor_cancellation(reason: ServerCancellationReason) {
     inc_server_supervisor_cancellation(reason);
     tracing::info!(
@@ -104,11 +115,14 @@ fn record_supervisor_cancellation(reason: ServerCancellationReason) {
 /// The wrapped [`DropGuardRef`] preserves Tokio's borrowed cancellation guard;
 /// this wrapper records the terminal reason before that guard cancels workers.
 struct SupervisorCancellationDropGuard<'a> {
+    /// Tokio guard that cancels workers when the supervisor future is dropped.
     _guard: DropGuardRef<'a>,
+    /// Shared reason state updated before Tokio performs cancellation.
     lifecycle: SupervisorLifecycle,
 }
 
 impl<'a> SupervisorCancellationDropGuard<'a> {
+    /// Pair Tokio's cancellation guard with lifecycle accounting.
     fn new(guard: DropGuardRef<'a>, lifecycle: SupervisorLifecycle) -> Self {
         Self {
             _guard: guard,
@@ -125,6 +139,7 @@ impl Drop for SupervisorCancellationDropGuard<'_> {
     clippy::integer_division_remainder_used,
     reason = "tokio::select! expands to modulus internally"
 )]
+/// Wait for either intentional shutdown or completion of all worker tasks.
 async fn await_supervisor_termination<S>(
     shutdown: S,
     shutdown_token: &CancellationToken,

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -135,11 +135,11 @@ impl Drop for SupervisorCancellationDropGuard<'_> {
     fn drop(&mut self) { self.lifecycle.record_dropped_cancellation(); }
 }
 
+/// Wait for either intentional shutdown or completion of all worker tasks.
 #[expect(
     clippy::integer_division_remainder_used,
     reason = "tokio::select! expands to modulus internally"
 )]
-/// Wait for either intentional shutdown or completion of all worker tasks.
 async fn await_supervisor_termination<S>(
     shutdown: S,
     shutdown_token: &CancellationToken,

--- a/src/server/runtime/accept.rs
+++ b/src/server/runtime/accept.rs
@@ -35,7 +35,9 @@ use crate::{
 #[async_trait]
 #[cfg_attr(test, mockall::automock)]
 pub(in crate::server) trait AcceptListener: Send + Sync {
+    /// Await one incoming stream and its peer address.
     async fn accept(&self) -> io::Result<(TcpStream, SocketAddr)>;
+    /// Return the listener address for diagnostics after an accept failure.
     fn local_addr(&self) -> io::Result<SocketAddr>;
 }
 
@@ -49,25 +51,40 @@ impl AcceptListener for TcpListener {
 }
 
 #[derive(Debug)]
+/// Inputs shared by one accept-loop worker.
 pub(in crate::server) struct AcceptLoopOptions<T> {
+    /// Preamble callbacks and timeout applied to each accepted stream.
     pub preamble: PreambleHooks<T>,
+    /// Shared cancellation signal for every worker loop.
     pub shutdown: CancellationToken,
+    /// Tracker retaining spawned connection tasks for graceful shutdown.
     pub tracker: TaskTracker,
+    /// Normalised retry policy for transient accept failures.
     pub backoff: BackoffConfig,
+    /// Shared lifecycle state used to classify worker termination.
     pub lifecycle: SupervisorLifecycle,
 }
 
+/// Borrowed worker inputs used for one `select!` iteration.
 struct AcceptHandles<'a, T> {
+    /// Borrowed handshake callbacks; ownership remains with the accept loop.
     preamble: &'a PreambleHooks<T>,
+    /// Borrowed cancellation token observed by `select!`.
     shutdown: &'a CancellationToken,
+    /// Borrowed task tracker used when spawning connection work.
     tracker: &'a TaskTracker,
+    /// Borrowed immutable retry policy.
     backoff: &'a BackoffConfig,
 }
 
 #[derive(Default)]
+/// Preamble callbacks copied into each connection task.
 pub(in crate::server) struct PreambleHooks<T> {
+    /// Callback invoked after a valid preamble has been read.
     pub on_success: Option<PreambleHandler<T>>,
+    /// Callback invoked when the preamble is invalid or times out.
     pub on_failure: Option<PreambleFailure>,
+    /// Optional upper bound for the handshake read.
     pub timeout: Option<Duration>,
 }
 
@@ -183,6 +200,7 @@ pub(in crate::server) async fn accept_loop<F, T, L, Ser, Ctx, E, Codec>(
     record_accept_loop_exit(&shutdown, &lifecycle);
 }
 
+/// Normalise retry delays and assert the backoff safety invariants.
 fn normalized_backoff(backoff: BackoffConfig) -> BackoffConfig {
     let backoff = backoff.normalized();
     debug_assert!(
@@ -196,6 +214,7 @@ fn normalized_backoff(backoff: BackoffConfig) -> BackoffConfig {
     backoff
 }
 
+/// Record cancellation only when the worker actually exited because of it.
 fn record_accept_loop_exit(shutdown: &CancellationToken, lifecycle: &SupervisorLifecycle) {
     if shutdown.is_cancelled() {
         let reason = lifecycle.cancellation_reason();
@@ -212,6 +231,7 @@ fn record_accept_loop_exit(shutdown: &CancellationToken, lifecycle: &SupervisorL
     clippy::integer_division_remainder_used,
     reason = "tokio::select! expands to modulus internally"
 )]
+/// Select between shutdown and one accept attempt, returning the next delay.
 async fn accept_iteration<F, T, L, Ser, Ctx, E, Codec>(
     listener: &Arc<L>,
     factory: &F,

--- a/src/server/runtime/accept.rs
+++ b/src/server/runtime/accept.rs
@@ -59,7 +59,7 @@ pub(in crate::server) struct AcceptLoopOptions<T> {
     pub shutdown: CancellationToken,
     /// Tracker retaining spawned connection tasks for graceful shutdown.
     pub tracker: TaskTracker,
-    /// Normalised retry policy for transient accept failures.
+    /// Normalized retry policy for transient accept failures.
     pub backoff: BackoffConfig,
     /// Shared lifecycle state used to classify worker termination.
     pub lifecycle: SupervisorLifecycle,
@@ -200,7 +200,7 @@ pub(in crate::server) async fn accept_loop<F, T, L, Ser, Ctx, E, Codec>(
     record_accept_loop_exit(&shutdown, &lifecycle);
 }
 
-/// Normalise retry delays and assert the backoff safety invariants.
+/// Normalize retry delays and assert the backoff safety invariants.
 fn normalized_backoff(backoff: BackoffConfig) -> BackoffConfig {
     let backoff = backoff.normalized();
     debug_assert!(
@@ -227,11 +227,11 @@ fn record_accept_loop_exit(shutdown: &CancellationToken, lifecycle: &SupervisorL
     }
 }
 
+/// Select between shutdown and one accept attempt, returning the next delay.
 #[expect(
     clippy::integer_division_remainder_used,
     reason = "tokio::select! expands to modulus internally"
 )]
-/// Select between shutdown and one accept attempt, returning the next delay.
 async fn accept_iteration<F, T, L, Ser, Ctx, E, Codec>(
     listener: &Arc<L>,
     factory: &F,

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -44,11 +44,14 @@ impl MessageAssembler for TestAssembler {
 }
 
 #[derive(Clone, Copy, Debug)]
+/// Bit flags encoded in the test protocol's frame header.
 struct FrameFlags(u8);
 
 impl FrameFlags {
+    /// Whether this frame terminates the logical message.
     fn is_last(self) -> bool { self.0 & 0b1 == 0b1 }
 
+    /// Whether the header carries its optional length/sequence value.
     fn has_optional_field(self) -> bool { self.0 & 0b10 == 0b10 }
 }
 
@@ -75,6 +78,7 @@ pub fn parse_frame_header(payload: &[u8]) -> Result<ParsedFrameHeader, io::Error
     Ok(ParsedFrameHeader::new(header, header_len))
 }
 
+/// Parse the first-frame fields after the common header prefix.
 fn parse_first_frame_header(
     buf: &mut &[u8],
     flags: FrameFlags,
@@ -93,6 +97,7 @@ fn parse_first_frame_header(
     }))
 }
 
+/// Parse continuation-frame fields after the common header prefix.
 fn parse_continuation_frame_header(
     buf: &mut &[u8],
     flags: FrameFlags,
@@ -109,10 +114,12 @@ fn parse_continuation_frame_header(
     }))
 }
 
+/// Read a u32 length and convert it to the platform's `usize`.
 fn take_usize_u32(buf: &mut &[u8], message: &'static str) -> Result<usize, io::Error> {
     usize::try_from(take_u32(buf)?).map_err(|_| invalid_data(message))
 }
 
+/// Read an optional u32 length when the header flag advertises one.
 fn take_optional_usize_u32(
     buf: &mut &[u8],
     flags: FrameFlags,
@@ -125,6 +132,7 @@ fn take_optional_usize_u32(
     take_usize_u32(buf, message).map(Some)
 }
 
+/// Read an optional continuation sequence when its flag is present.
 fn take_optional_sequence(
     buf: &mut &[u8],
     flags: FrameFlags,
@@ -136,26 +144,31 @@ fn take_optional_sequence(
     Ok(Some(FrameSequence::from(take_u32(buf)?)))
 }
 
+/// Read one byte after checking that the header buffer is long enough.
 fn take_u8(buf: &mut &[u8]) -> Result<u8, io::Error> {
     ensure_remaining(buf, 1)?;
     Ok(buf.get_u8())
 }
 
+/// Read a big-endian u16 after checking header bounds.
 fn take_u16(buf: &mut &[u8]) -> Result<u16, io::Error> {
     ensure_remaining(buf, 2)?;
     Ok(buf.get_u16())
 }
 
+/// Read a big-endian u32 after checking header bounds.
 fn take_u32(buf: &mut &[u8]) -> Result<u32, io::Error> {
     ensure_remaining(buf, 4)?;
     Ok(buf.get_u32())
 }
 
+/// Read a big-endian u64 after checking header bounds.
 fn take_u64(buf: &mut &[u8]) -> Result<u64, io::Error> {
     ensure_remaining(buf, 8)?;
     Ok(buf.get_u64())
 }
 
+/// Reject a header read that would consume beyond the available bytes.
 fn ensure_remaining(buf: &mut &[u8], needed: usize) -> Result<(), io::Error> {
     if buf.remaining() < needed {
         return Err(invalid_data("header too short"));
@@ -163,6 +176,7 @@ fn ensure_remaining(buf: &mut &[u8], needed: usize) -> Result<(), io::Error> {
     Ok(())
 }
 
+/// Build the consistent invalid-data error returned by header parsing.
 fn invalid_data(message: &'static str) -> io::Error {
     io::Error::new(io::ErrorKind::InvalidData, message)
 }

--- a/src/test_helpers/frame_codec.rs
+++ b/src/test_helpers/frame_codec.rs
@@ -25,7 +25,9 @@ pub struct TestFrame {
 /// Codec implementation that wraps payloads with a tagged test frame.
 #[derive(Clone, Debug)]
 pub struct TestCodec {
+    /// Decoder/encoder limit used to exercise oversized-payload errors.
     max_frame_length: usize,
+    /// Shared count used by tests to observe encode activity.
     counter: Arc<AtomicUsize>,
 }
 
@@ -47,6 +49,7 @@ impl TestCodec {
 /// Adapter implementing the codec's encoder/decoder pair.
 #[derive(Clone, Debug)]
 pub struct TestAdapter {
+    /// Maximum payload accepted by the framed test transport.
     max_frame_length: usize,
 }
 

--- a/src/test_helpers/pool_client.rs
+++ b/src/test_helpers/pool_client.rs
@@ -26,7 +26,9 @@ pub struct ClientHello {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, bincode::Encode, bincode::Decode)]
+/// Internal server response used to complete the preamble handshake.
 struct ServerAck {
+    /// Whether the fixture accepts the client's preamble.
     accepted: bool,
 }
 
@@ -55,15 +57,23 @@ pub enum PoolServerBehavior {
 pub struct PoolTestServer {
     /// Socket address the test server is listening on.
     pub addr: SocketAddr,
+    /// Count of successful preamble exchanges observed by the fixture.
     preamble_count: Arc<AtomicUsize>,
+    /// Count of physical TCP connections accepted by the fixture.
     connection_count: Arc<AtomicUsize>,
+    /// Background accept loop; aborting it makes dropping the fixture bounded.
     handle: JoinHandle<()>,
 }
 
+/// Per-server state shared with each spawned connection task.
 struct PoolServerState {
+    /// Shared successful-handshake counter.
     preamble_count: Arc<AtomicUsize>,
+    /// Shared accepted-connection counter.
     connection_count: Arc<AtomicUsize>,
+    /// One-shot flag controlling malformed-response coverage.
     malformed_response_sent: Arc<AtomicBool>,
+    /// Response mode selected by the test case.
     behavior: PoolServerBehavior,
 }
 
@@ -170,6 +180,7 @@ pub async fn acquire_and_record(
     Ok(())
 }
 
+/// Accept connections until the listener is closed or its task is aborted.
 async fn run_pool_test_accept_loop(listener: TcpListener, state: PoolServerState) {
     loop {
         let accept_result = listener.accept().await;
@@ -186,6 +197,7 @@ async fn run_pool_test_accept_loop(listener: TcpListener, state: PoolServerState
     }
 }
 
+/// Perform one fixture handshake and echo length-delimited ping frames.
 async fn handle_pool_test_connection(mut stream: tokio::net::TcpStream, state: PoolServerState) {
     state.connection_count.fetch_add(1, Ordering::SeqCst);
     let preamble = read_preamble::<_, ClientHello>(&mut stream).await;
@@ -229,6 +241,7 @@ async fn handle_pool_test_connection(mut stream: tokio::net::TcpStream, state: P
     }
 }
 
+/// Decode the fixture's handshake response and return any buffered bytes.
 async fn read_server_ack(stream: &mut tokio::net::TcpStream) -> std::io::Result<Vec<u8>> {
     let (ack, leftover) = read_preamble::<_, ServerAck>(stream)
         .await

--- a/src/testkit/fragment_drive.rs
+++ b/src/testkit/fragment_drive.rs
@@ -18,6 +18,7 @@ use crate::{
     serializer::{BincodeSerializer, Serializer},
 };
 
+/// Fragment payload bytes and encode each fragment as a test envelope.
 fn fragment_and_encode(
     fragmenter: &Fragmenter,
     payload: Vec<u8>,
@@ -51,6 +52,7 @@ fn fragment_and_encode(
         .collect()
 }
 
+/// Stable route id used by fragment-driving fixtures.
 const DEFAULT_FRAGMENT_ROUTE_ID: u32 = 1;
 
 /// Fragment `payload`, encode each fragment into a codec frame, and drive

--- a/src/testkit/reassembly/assert_helpers.rs
+++ b/src/testkit/reassembly/assert_helpers.rs
@@ -2,6 +2,7 @@
 
 use super::super::TestResult;
 
+/// Compare a numeric observable and return a diagnostic test failure.
 pub(super) fn assert_usize_field(actual: usize, expected: usize, field_name: &str) -> TestResult {
     if actual == expected {
         Ok(())
@@ -10,6 +11,7 @@ pub(super) fn assert_usize_field(actual: usize, expected: usize, field_name: &st
     }
 }
 
+/// Compare payload bytes while preserving the assertion's semantic context.
 pub(super) fn assert_body_eq(actual: &[u8], expected: &[u8], context: &str) -> TestResult {
     if actual == expected {
         Ok(())

--- a/src/testkit/reassembly/fragment.rs
+++ b/src/testkit/reassembly/fragment.rs
@@ -9,9 +9,13 @@ use crate::{
 /// Snapshot of the observable state around a fragment-reassembly assertion.
 #[derive(Clone, Copy, Debug)]
 pub struct FragmentReassemblySnapshot<'a> {
+    /// Most recent complete payload, if the drive produced one.
     last_reassembled: Option<&'a ReassembledMessage>,
+    /// Most recent protocol or size failure, if one occurred.
     last_error: Option<&'a ReassemblyError>,
+    /// Message ids removed by the latest timeout purge.
     evicted_ids: &'a [MessageId],
+    /// Number of incomplete message buffers still retained.
     buffered_messages: usize,
 }
 
@@ -143,6 +147,7 @@ pub fn assert_fragment_reassembly_evicted(
     }
 }
 
+/// Match the structured reassembly error against a test expectation.
 fn matches_fragment_error(
     err: &ReassemblyError,
     expected: FragmentReassemblyErrorExpectation,

--- a/src/testkit/reassembly/message.rs
+++ b/src/testkit/reassembly/message.rs
@@ -12,10 +12,15 @@ use crate::{
 /// Snapshot of the observable state around a message-assembly assertion.
 #[derive(Clone, Copy, Debug)]
 pub struct MessageAssemblySnapshot<'a> {
+    /// Most recent assembly result, including incomplete and error states.
     last_result: Option<&'a Result<Option<AssembledMessage>, MessageAssemblyError>>,
+    /// Completed messages retained by the driving scenario.
     completed_messages: &'a [AssembledMessage],
+    /// Message keys removed by timeout eviction.
     evicted_keys: &'a [MessageKey],
+    /// Number of partial assemblies still active.
     buffered_count: usize,
+    /// Aggregate body and metadata bytes still retained.
     total_buffered_bytes: usize,
 }
 
@@ -142,6 +147,7 @@ pub fn assert_message_assembly_error(
     }
 }
 
+/// Reuse numeric snapshot assertions while naming the selected field.
 macro_rules! assert_snapshot_usize_field {
     ($snapshot:expr, $field:ident, $expected:expr) => {
         assert_usize_field($snapshot.$field, $expected, stringify!($field))
@@ -188,6 +194,7 @@ pub fn assert_message_assembly_evicted(
     }
 }
 
+/// Render an assembly result for diagnostics when an assertion fails.
 fn describe_last_result(
     last_result: Option<&Result<Option<AssembledMessage>, MessageAssemblyError>>,
 ) -> String {

--- a/src/testkit/reassembly/message_error.rs
+++ b/src/testkit/reassembly/message_error.rs
@@ -51,6 +51,7 @@ pub enum MessageAssemblyErrorExpectation {
     },
 }
 
+/// Match a structured assembly error against the expected protocol failure.
 pub(super) fn matches_message_error(
     err: &MessageAssemblyError,
     expected: MessageAssemblyErrorExpectation,
@@ -80,6 +81,7 @@ pub(super) fn matches_message_error(
     }
 }
 
+/// Match a sequence gap while retaining both expected and received indexes.
 fn matches_sequence_mismatch(
     err: &MessageAssemblyError,
     expected: FrameSequence,
@@ -94,6 +96,7 @@ fn matches_sequence_mismatch(
     )
 }
 
+/// Match a repeated continuation frame for one message key.
 fn matches_duplicate_frame(
     err: &MessageAssemblyError,
     key: MessageKey,
@@ -108,6 +111,7 @@ fn matches_duplicate_frame(
     )
 }
 
+/// Match a continuation that arrived without a registered first frame.
 fn matches_missing_first_frame(err: &MessageAssemblyError, key: MessageKey) -> bool {
     matches!(
         err,
@@ -117,6 +121,7 @@ fn matches_missing_first_frame(err: &MessageAssemblyError, key: MessageKey) -> b
     )
 }
 
+/// Match a second first frame for an already active message key.
 fn matches_duplicate_first_frame(err: &MessageAssemblyError, key: MessageKey) -> bool {
     matches!(
         err,
@@ -125,6 +130,7 @@ fn matches_duplicate_first_frame(err: &MessageAssemblyError, key: MessageKey) ->
     )
 }
 
+/// Match a per-message size-limit rejection.
 fn matches_message_too_large(err: &MessageAssemblyError, key: MessageKey) -> bool {
     matches!(
         err,
@@ -133,6 +139,7 @@ fn matches_message_too_large(err: &MessageAssemblyError, key: MessageKey) -> boo
     )
 }
 
+/// Match a connection-wide aggregate budget rejection.
 fn matches_connection_budget_exceeded(err: &MessageAssemblyError, key: MessageKey) -> bool {
     matches!(
         err,
@@ -141,6 +148,7 @@ fn matches_connection_budget_exceeded(err: &MessageAssemblyError, key: MessageKe
     )
 }
 
+/// Match an in-flight aggregate budget rejection.
 fn matches_in_flight_budget_exceeded(err: &MessageAssemblyError, key: MessageKey) -> bool {
     matches!(
         err,

--- a/src/testkit/slow_io.rs
+++ b/src/testkit/slow_io.rs
@@ -114,6 +114,7 @@ impl SlowIoConfig {
     }
 }
 
+/// Ensure pacing chunks cannot exceed the duplex buffer capacity.
 fn validate_pacing_chunk_size(
     pacing: Option<SlowIoPacing>,
     direction: &str,
@@ -134,12 +135,14 @@ fn validate_pacing_chunk_size(
     Ok(())
 }
 
+/// Delay only between chunks, never before the first transfer.
 async fn pause_between_chunks(delay: Duration, should_pause: bool) {
     if should_pause && !delay.is_zero() {
         sleep(delay).await;
     }
 }
 
+/// Write all bytes either at once or in paced chunks.
 async fn write_with_optional_pacing<W>(
     writer: &mut W,
     bytes: &[u8],
@@ -168,6 +171,7 @@ where
     }
 }
 
+/// Read until EOF either at once or with deterministic pacing delays.
 async fn read_with_optional_pacing<R>(
     reader: &mut R,
     pacing: Option<SlowIoPacing>,
@@ -233,6 +237,7 @@ where
     .await
 }
 
+/// Encode payloads into contiguous length-delimited wire bytes for tests.
 fn encode_length_delimited_payloads(payloads: Vec<Vec<u8>>) -> io::Result<Vec<u8>> {
     let codec = LengthDelimitedFrameCodec::new(DEFAULT_CAPACITY);
     let frames = encode_payloads_with_codec(&codec, payloads)?;

--- a/src/testkit/support.rs
+++ b/src/testkit/support.rs
@@ -23,6 +23,7 @@ use crate::{
     serializer::{MessageCompatibilitySerializer, Serializer},
 };
 
+/// Default in-memory duplex capacity used by test drivers.
 pub(crate) const DEFAULT_CAPACITY: usize = 4096;
 
 /// Serializer bounds expected by the in-memory test harness.
@@ -158,6 +159,7 @@ pub(crate) async fn read_all(mut reader: impl AsyncRead + Unpin) -> io::Result<V
 // High-level internal drivers (convenience wrappers)
 // ---------------------------------------------------------------------------
 
+/// Adapt the frame writer to the strategy callback expected by the driver.
 async fn write_frames_strategy(
     mut writer: WriteHalf<DuplexStream>,
     frames: Vec<Vec<u8>>,
@@ -166,6 +168,7 @@ async fn write_frames_strategy(
     Ok(writer)
 }
 
+/// Adapt the chunked writer to the strategy callback expected by the driver.
 async fn write_chunked_strategy(
     mut writer: WriteHalf<DuplexStream>,
     bytes: Vec<u8>,
@@ -175,6 +178,7 @@ async fn write_chunked_strategy(
     Ok(writer)
 }
 
+/// Drive a list of already encoded frames through the shared harness.
 pub(crate) async fn drive_internal<F, Fut>(
     server_fn: F,
     frames: Vec<Vec<u8>>,
@@ -193,6 +197,7 @@ where
     .await
 }
 
+/// Drive contiguous bytes through the harness using fixed-size writes.
 pub(crate) async fn drive_chunked_internal<F, Fut>(
     server_fn: F,
     wire_bytes: Vec<u8>,
@@ -216,6 +221,7 @@ where
 // Codec encode / decode
 // ---------------------------------------------------------------------------
 
+/// Encode each logical payload independently before flattening onto the wire.
 pub(crate) fn encode_payloads_with_codec<F: FrameCodec>(
     codec: &F,
     payloads: Vec<Vec<u8>>,
@@ -237,6 +243,7 @@ pub(crate) fn encode_payloads_with_codec<F: FrameCodec>(
         .collect()
 }
 
+/// Decode all frames and reject trailing bytes that form an incomplete frame.
 pub(crate) fn decode_frames_with_codec<F: FrameCodec>(
     codec: &F,
     bytes: &[u8],
@@ -284,6 +291,7 @@ where
     decode_frames_with_codec(codec, &raw)
 }
 
+/// Copy payloads out of decoded frames for concise test assertions.
 pub(crate) fn extract_payloads<F: FrameCodec>(frames: &[F::Frame]) -> Vec<Vec<u8>> {
     frames
         .iter()
@@ -291,6 +299,7 @@ pub(crate) fn extract_payloads<F: FrameCodec>(frames: &[F::Frame]) -> Vec<Vec<u8
         .collect()
 }
 
+/// Run an app on the server half, preserving ownership for task orchestration.
 pub(crate) async fn run_owned_app<S, C, E, F>(app: WireframeApp<S, C, E, F>, server: DuplexStream)
 where
     S: TestSerializer,

--- a/wireframe_testing/Cargo.toml
+++ b/wireframe_testing/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["async", "networking", "binary-protocol", "protocol", "tokio"]
 categories = ["network-programming", "asynchronous"]
 documentation = "https://docs.rs/wireframe_testing"
 
+[lints]
+workspace = true
+
 [dependencies]
 tokio = { version = "1", features = ["macros", "rt", "io-util", "net", "sync", "time"] }
 wireframe = { version = "0.3.0", path = "..", features = ["testkit"] }

--- a/wireframe_testing/src/client_pair.rs
+++ b/wireframe_testing/src/client_pair.rs
@@ -55,8 +55,11 @@ use crate::{TestError, TestResult, integration_helpers::unused_listener};
 /// Fields are `Option` so they can be individually extracted during shutdown
 /// while keeping the `Running` struct in place until all awaits complete.
 struct Running {
+    /// Connected client retained until graceful teardown closes its hooks.
     client: Option<WireframeClient<BincodeSerializer, RewindStream<tokio::net::TcpStream>, ()>>,
+    /// One-shot signal consumed when graceful server shutdown begins.
     shutdown_tx: Option<oneshot::Sender<()>>,
+    /// Server task joined before the harness releases its listener resources.
     handle: Option<JoinHandle<Result<(), wireframe::server::ServerError>>>,
 }
 
@@ -74,7 +77,9 @@ struct Running {
 /// [`WireframeServer`]: wireframe::server::WireframeServer
 /// [`WireframeClient`]: wireframe::client::WireframeClient
 pub struct WireframePair {
+    /// Loopback endpoint reserved for the paired client and server.
     addr: SocketAddr,
+    /// Live resources, removed only after shutdown completes or drop takes ownership.
     running: Option<Running>,
 }
 
@@ -180,6 +185,10 @@ impl Drop for WireframePair {
 /// This gives the server task a chance to run `tracker.close()` and
 /// `tracker.wait().await` for spawned connection tasks before being
 /// force-aborted.
+#[expect(
+    clippy::integer_division_remainder_used,
+    reason = "Tokio's select macro expands to scheduler arithmetic outside this harness"
+)]
 fn spawn_bounded_shutdown(
     mut handle: JoinHandle<Result<(), wireframe::server::ServerError>>,
     timeout: std::time::Duration,
@@ -190,7 +199,7 @@ fn spawn_bounded_shutdown(
                 _ = &mut handle => {
                     // Task completed within timeout.
                 }
-                _ = tokio::time::sleep(timeout) => {
+                () = tokio::time::sleep(timeout) => {
                     // Timeout expired, abort the task.
                     handle.abort();
                 }
@@ -212,6 +221,7 @@ type ServerShutdownHandle = (
     JoinHandle<Result<(), wireframe::server::ServerError>>,
 );
 
+/// Owns a not-yet-published server task so failed setup cannot leak it.
 struct PendingServer(Option<ServerShutdownHandle>);
 
 impl PendingServer {

--- a/wireframe_testing/src/codec_benchmarks/codec_benchmark_support.rs
+++ b/wireframe_testing/src/codec_benchmarks/codec_benchmark_support.rs
@@ -135,6 +135,10 @@ pub struct Measurement {
 }
 
 /// Measure encode performance for one workload.
+///
+/// # Errors
+///
+/// Returns a description when the selected codec rejects a generated frame.
 pub fn measure_encode(workload: BenchmarkWorkload, iterations: u64) -> Result<Measurement, String> {
     let payload = payload_for_class(workload.payload_class);
     let payload_len = payload.len() as u64;
@@ -156,6 +160,10 @@ pub fn measure_encode(workload: BenchmarkWorkload, iterations: u64) -> Result<Me
 }
 
 /// Measure decode performance for one workload.
+///
+/// # Errors
+///
+/// Returns a description when seeding or decoding the selected codec fails.
 pub fn measure_decode(workload: BenchmarkWorkload, iterations: u64) -> Result<Measurement, String> {
     if iterations == 0 {
         return Ok(Measurement {
@@ -176,6 +184,7 @@ pub fn measure_decode(workload: BenchmarkWorkload, iterations: u64) -> Result<Me
     }
 }
 
+/// Defines a codec-specific encode probe while retaining one shared timing contract.
 macro_rules! codec_measure_encode_fn {
     ($fn_name:ident, $codec_type:ty, $label_str:literal) => {
         fn $fn_name(
@@ -209,6 +218,7 @@ codec_measure_encode_fn!(
 );
 codec_measure_encode_fn!(measure_encode_hotline, HotlineFrameCodec, "hotline");
 
+/// Defines a codec-specific decode probe with a common malformed-result check.
 macro_rules! codec_measure_decode_fn {
     ($fn_name:ident, $codec_type:ty, $label_str:literal, $frame_payload_path:path) => {
         fn $fn_name(

--- a/wireframe_testing/src/codec_benchmarks/codec_fragmentation_benchmark_support.rs
+++ b/wireframe_testing/src/codec_benchmarks/codec_fragmentation_benchmark_support.rs
@@ -82,6 +82,7 @@ impl FragmentationOverhead {
 }
 
 /// Measure unfragmented payload wrapping performance for the default codec.
+#[must_use]
 pub fn measure_unfragmented_wrap(payload_class: PayloadClass, iterations: u64) -> Measurement {
     let payload = payload_for_class(payload_class);
     let codec = LengthDelimitedFrameCodec::new(LARGE_PAYLOAD_BYTES + 4096);
@@ -101,6 +102,10 @@ pub fn measure_unfragmented_wrap(payload_class: PayloadClass, iterations: u64) -
 }
 
 /// Measure fragmented payload wrapping performance for the default codec.
+///
+/// # Errors
+///
+/// Returns a description when the requested cap cannot produce valid fragments.
 pub fn measure_fragmented_wrap(
     payload_class: PayloadClass,
     iterations: u64,
@@ -134,6 +139,10 @@ pub fn measure_fragmented_wrap(
 }
 
 /// Measure fragmentation overhead for one payload class.
+///
+/// # Errors
+///
+/// Propagates the fragmented measurement failure for an invalid fragmentation cap.
 pub fn measure_fragmentation_overhead(
     payload_class: PayloadClass,
     iterations: u64,

--- a/wireframe_testing/src/helpers.rs
+++ b/wireframe_testing/src/helpers.rs
@@ -41,8 +41,11 @@ impl<T> TestSerializer for T where
 {
 }
 
+/// Default duplex capacity that permits ordinary frame-exchange fixtures.
 pub(crate) const DEFAULT_CAPACITY: usize = 4096;
+/// Largest capacity accepted by slow-I/O fixtures before they lose their purpose.
 pub(crate) const MAX_CAPACITY: usize = wireframe::testkit::MAX_SLOW_IO_CAPACITY;
+/// Tiny duplex capacity used to exercise a server with no buffered response room.
 pub(crate) const EMPTY_SERVER_CAPACITY: usize = 64;
 /// Shared frame cap used by helpers and tests to avoid drift.
 pub const TEST_MAX_FRAME: usize = DEFAULT_CAPACITY;

--- a/wireframe_testing/src/helpers/codec.rs
+++ b/wireframe_testing/src/helpers/codec.rs
@@ -14,6 +14,7 @@ use super::TEST_MAX_FRAME;
 /// The codec uses the default [`LengthFormat`] framing and enforces
 /// `max_len` during decode.
 #[inline]
+#[must_use]
 pub fn new_test_codec(max_len: usize) -> LengthDelimitedCodec {
     let mut builder = LengthDelimitedCodec::builder();
     builder.max_frame_length(max_len);
@@ -32,6 +33,10 @@ pub fn new_test_codec(max_len: usize) -> LengthDelimitedCodec {
 /// assert_eq!(frames, vec![vec![42]]);
 /// # Ok::<(), std::io::Error>(())
 /// ```
+///
+/// # Errors
+///
+/// Returns invalid-data errors for malformed frames or a trailing partial frame.
 pub fn decode_frames(bytes: Vec<u8>) -> io::Result<Vec<Vec<u8>>> {
     decode_frames_with_max(bytes, TEST_MAX_FRAME)
 }
@@ -40,6 +45,14 @@ pub fn decode_frames(bytes: Vec<u8>) -> io::Result<Vec<Vec<u8>>> {
 ///
 /// Returns an error if decode fails or trailing bytes remain after frame
 /// extraction.
+///
+/// # Errors
+///
+/// Returns invalid-data errors for malformed frames or trailing partial bytes.
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "The public fixture helper accepts ownership consistently with decode_frames"
+)]
 pub fn decode_frames_with_max(bytes: Vec<u8>, max_len: usize) -> io::Result<Vec<Vec<u8>>> {
     let mut codec = new_test_codec(max_len);
     let mut buf = BytesMut::from(&bytes[..]);
@@ -64,6 +77,10 @@ pub fn decode_frames_with_max(bytes: Vec<u8>, max_len: usize) -> io::Result<Vec<
 /// Encode bytes with a length-delimited `codec`, preallocating the prefix.
 ///
 /// Returns an error if framing fails.
+///
+/// # Errors
+///
+/// Returns an invalid-data error if the codec rejects the payload.
 pub fn encode_frame(codec: &mut LengthDelimitedCodec, bytes: Vec<u8>) -> io::Result<Vec<u8>> {
     let header_len = LengthFormat::default().bytes();
     let mut buf = BytesMut::with_capacity(bytes.len() + header_len);

--- a/wireframe_testing/src/helpers/codec_ext.rs
+++ b/wireframe_testing/src/helpers/codec_ext.rs
@@ -78,6 +78,10 @@ pub fn encode_payloads_with_codec<F: FrameCodec>(
 ///     .expect("decoding should succeed for well-formed wire bytes");
 /// assert_eq!(frames.len(), 1);
 /// ```
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "The public fixture helper owns wire bytes just like the concrete codec helpers"
+)]
 pub fn decode_frames_with_codec<F: FrameCodec>(
     codec: &F,
     bytes: Vec<u8>,

--- a/wireframe_testing/src/helpers/codec_fixtures.rs
+++ b/wireframe_testing/src/helpers/codec_fixtures.rs
@@ -202,11 +202,9 @@ pub fn truncated_hotline_payload(payload_len: impl Into<PayloadLength>) -> Vec<u
     let data_size = u32_from_usize(payload_len);
     let total_size = u32_from_usize(payload_len.saturating_add(HEADER_LEN));
 
-    let half_payload = payload_len / 2;
+    let half_payload = payload_len >> 1;
     let mut buf = Vec::with_capacity(HEADER_LEN + half_payload);
-    buf.extend_from_slice(&data_size.to_be_bytes());
-    buf.extend_from_slice(&total_size.to_be_bytes());
-    buf.extend_from_slice(&0u32.to_be_bytes()); // transaction_id
+    append_hotline_header(&mut buf, data_size, total_size, 0); // transaction_id
     buf.extend_from_slice(&[0u8; 8]); // reserved
     buf.extend_from_slice(&vec![0xcc; half_payload]);
     buf
@@ -301,10 +299,7 @@ fn build_hotline_wire(
     };
 
     let mut buf = Vec::with_capacity(HEADER_LEN + payload.len());
-    buf.extend_from_slice(&data_size_u32.to_be_bytes());
-    buf.extend_from_slice(&total_size.to_be_bytes());
-    buf.extend_from_slice(&transaction_id.to_be_bytes());
-    buf.extend_from_slice(&[0u8; 8]); // reserved
+    append_hotline_header(&mut buf, data_size_u32, total_size, transaction_id);
     buf.extend_from_slice(payload);
     buf
 }
@@ -314,3 +309,15 @@ fn build_hotline_wire(
 /// Fixture payloads are always small enough to fit in `u32`, but we avoid a
 /// truncating cast to satisfy Clippy.
 fn u32_from_usize(value: usize) -> u32 { u32::try_from(value).unwrap_or(u32::MAX) }
+
+/// Append the fixed-width Hotline header fields in the protocol's network byte order.
+#[expect(
+    clippy::big_endian_bytes,
+    reason = "Hotline fixtures must construct the protocol's big-endian wire header"
+)]
+fn append_hotline_header(buf: &mut Vec<u8>, data_size: u32, total_size: u32, transaction_id: u32) {
+    buf.extend_from_slice(&data_size.to_be_bytes());
+    buf.extend_from_slice(&total_size.to_be_bytes());
+    buf.extend_from_slice(&transaction_id.to_be_bytes());
+    buf.extend_from_slice(&[0_u8; 8]);
+}

--- a/wireframe_testing/src/helpers/drive.rs
+++ b/wireframe_testing/src/helpers/drive.rs
@@ -45,7 +45,7 @@ where
             .catch_unwind()
             .await;
         match result {
-            Ok(_) => Ok(()),
+            Ok(()) => Ok(()),
             Err(panic) => {
                 let panic_msg = wireframe::panic::format_panic(&panic);
                 Err(io::Error::other(format!("server task failed: {panic_msg}")))
@@ -68,6 +68,7 @@ where
     Ok(buf)
 }
 
+/// Defines a default-capacity façade that preserves the supplied helper docs.
 macro_rules! forward_default {
     (
         $(#[$docs:meta])* $vis:vis fn $name:ident(
@@ -77,6 +78,10 @@ macro_rules! forward_default {
         => $inner:ident($app_expr:ident, $arg_expr:expr)
     ) => {
         $(#[$docs])*
+        ///
+        /// # Errors
+        ///
+        /// Returns I/O errors from the duplex transport or the driven application.
         $vis async fn $name<S, C, E>(
             $app: $app_ty,
             $arg: $arg_ty,
@@ -91,6 +96,7 @@ macro_rules! forward_default {
     };
 }
 
+/// Defines a capacity-selectable façade that preserves the supplied helper docs.
 macro_rules! forward_with_capacity {
     (
         $(#[$docs:meta])* $vis:vis fn $name:ident(
@@ -101,6 +107,10 @@ macro_rules! forward_with_capacity {
         => $inner:ident($app_expr:ident, $arg_expr:expr, capacity)
     ) => {
         $(#[$docs])*
+        ///
+        /// # Errors
+        ///
+        /// Returns I/O errors from the duplex transport or the driven application.
         $vis async fn $name<S, C, E>(
             $app: $app_ty,
             $arg: $arg_ty,
@@ -188,6 +198,10 @@ forward_default! {
 ///
 /// This variant exposes the buffer size for fine-grained control in tests.
 ///
+/// # Errors
+///
+/// Returns I/O errors from the duplex transport or the driven application.
+///
 /// ```rust
 /// # use wireframe_testing::drive_with_frames_with_capacity;
 /// # use wireframe::app::WireframeApp;
@@ -265,6 +279,10 @@ forward_default! {
 }
 
 /// Feed multiple frames into `app` with a duplex buffer of `capacity` bytes.
+///
+/// # Errors
+///
+/// Returns I/O errors from the duplex transport or the driven application.
 ///
 /// ```rust
 /// # use wireframe_testing::drive_with_frames_with_capacity_mut;

--- a/wireframe_testing/src/helpers/payloads.rs
+++ b/wireframe_testing/src/helpers/payloads.rs
@@ -17,6 +17,10 @@ use super::{DEFAULT_CAPACITY, TestSerializer, drive, new_test_codec};
 /// This helper wraps each payload using the default length-delimited framing
 /// format before sending it to the application.
 ///
+/// # Errors
+///
+/// Returns I/O errors while framing payloads or driving the application.
+///
 /// ```rust
 /// # use wireframe_testing::drive_with_payloads;
 /// # use wireframe::app::WireframeApp;
@@ -41,6 +45,10 @@ where
 
 /// Encode payloads as length-delimited frames and drive a mutable `app`.
 ///
+/// # Errors
+///
+/// Returns I/O errors while framing payloads or driving the application.
+///
 /// ```rust
 /// # use wireframe_testing::drive_with_payloads_mut;
 /// # use wireframe::app::WireframeApp;
@@ -63,6 +71,7 @@ where
     drive_with_payloads_with_capacity_mut(app, payloads, DEFAULT_CAPACITY).await
 }
 
+/// Converts each payload into an owned frame so the writer can preserve input order.
 fn encode_payloads(
     payloads: Vec<Vec<u8>>,
     mut codec: LengthDelimitedCodec,
@@ -83,6 +92,7 @@ fn encode_payloads(
         .collect()
 }
 
+/// Drives an owned application with payload fixtures using the caller's back-pressure cap.
 async fn drive_with_payloads_with_capacity<S, C, E>(
     app: WireframeApp<S, C, E>,
     payloads: Vec<Vec<u8>>,
@@ -98,6 +108,7 @@ where
     drive::drive_with_frames_with_capacity(app, frames, capacity).await
 }
 
+/// Drives a reusable application while preserving its state between fixture exchanges.
 async fn drive_with_payloads_with_capacity_mut<S, C, E>(
     app: &mut WireframeApp<S, C, E>,
     payloads: Vec<Vec<u8>>,
@@ -114,6 +125,10 @@ where
 }
 
 /// Encode `msg` using bincode, frame it and drive `app`.
+///
+/// # Errors
+///
+/// Returns invalid-data errors for bincode failures and I/O errors from framing or driving.
 ///
 /// ```rust
 /// # use wireframe_testing::drive_with_bincode;

--- a/wireframe_testing/src/helpers/tests/helper_tests.rs
+++ b/wireframe_testing/src/helpers/tests/helper_tests.rs
@@ -82,10 +82,11 @@ async fn drive_with_payloads_wraps_frames() -> io::Result<()> {
             format!("failed to deserialise envelope: {error}"),
         )
     })?;
-    assert_eq!(
-        decoded.payload_bytes(),
-        payload.as_slice(),
-        "payload mismatch"
-    );
+    if decoded.payload_bytes() != payload.as_slice() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "response payload did not preserve the request payload",
+        ));
+    }
     Ok(())
 }

--- a/wireframe_testing/src/integration_helpers.rs
+++ b/wireframe_testing/src/integration_helpers.rs
@@ -371,10 +371,9 @@ mod tests {
     }
 
     #[test]
-    fn factory_builds_default_app() -> super::TestResult {
+    fn factory_builds_default_app() {
         let build = factory();
         let app = build();
         let _codec = app.length_codec();
-        Ok(())
     }
 }

--- a/wireframe_testing/src/lib.rs
+++ b/wireframe_testing/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! These helpers spawn the application on a `tokio::io::duplex` stream and
 //! return all bytes written by the app for easy assertions. They work with any
-//! message implementing [`serde::Serialize`]. The payload is encoded with
+//! message implementing `serde::Serialize`. The payload is encoded with
 //! [`bincode::encode_to_vec`] using [`bincode::config::standard()`], which means
 //! little-endian byte order, variable-length integer encoding and no byte limit
 //! are applied. The example uses a simple `u8` value so no generics are

--- a/wireframe_testing/src/logging.rs
+++ b/wireframe_testing/src/logging.rs
@@ -35,6 +35,7 @@ use rstest::fixture;
 /// assert!(log.pop().is_none());
 /// ```
 pub struct LoggerHandle {
+    /// Exclusive guard that keeps another test from draining this test's logs.
     guard: MutexGuard<'static, Logger>,
 }
 
@@ -64,6 +65,7 @@ impl LoggerHandle {
     /// assert!(log.pop().is_some());
     /// assert!(log.pop().is_none());
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         // Preserve the shared logger even if a prior test panicked while
         // holding the mutex, but clear any buffered state so the next test
@@ -126,7 +128,7 @@ mod tests {
         let join_result = std::thread::spawn(|| {
             let _guard = shared_logger()
                 .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             log::info!("stale");
             panic!("poison logger mutex");
         })

--- a/wireframe_testing/src/observability/mod.rs
+++ b/wireframe_testing/src/observability/mod.rs
@@ -86,9 +86,13 @@ pub(crate) type SnapshotEntry = (CompositeKey, Option<Unit>, Option<SharedString
 /// log::info!("captured");
 /// ```
 pub struct ObservabilityHandle {
+    /// Log-capture guard held for the whole metrics observation transaction.
     pub(crate) logger: LoggerHandle,
+    /// Thread-local recorder receiving metrics emitted inside the fixture scope.
     recorder: DebuggingRecorder,
+    /// Draining view used to transfer the recorder's current values into assertions.
     snapshotter: Snapshotter,
+    /// Most recent drained metric values queried by the assertion helpers.
     pub(crate) captured: Vec<SnapshotEntry>,
 }
 
@@ -106,6 +110,7 @@ pub struct ObservabilityHandle {
 /// ```
 impl ObservabilityHandle {
     /// Create a new observability handle.
+    #[must_use]
     pub fn new() -> Self {
         let logger = LoggerHandle::new();
         let recorder = DebuggingRecorder::new();
@@ -144,6 +149,7 @@ impl ObservabilityHandle {
     ///     // Metrics emitted here are captured by the recorder.
     /// });
     /// ```
+    #[must_use]
     pub fn recorder(&self) -> &DebuggingRecorder { &self.recorder }
 
     /// Take a snapshot of the current metrics state.


### PR DESCRIPTION
## Summary

This branch makes internal implementation documentation a workspace-wide
deny-level Clippy requirement, so protocol, lifecycle, ownership and
verification contracts are reviewed alongside the public API.

Closes #666.

## Review walkthrough

- Start with [Cargo.toml](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/Cargo.toml#L108) to review the shared lint policy and every package inheriting it.
- Then review [Makefile](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/Makefile#L54) for canonical workspace lint, test and documentation coverage.
- Review [client pool scheduling](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/src/client/pool/scheduler.rs#L47), [message assembly](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/src/message_assembler/state.rs#L22), and [verification state](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/crates/wireframe-verification/src/connection_model/state.rs#L1) for the ownership, framing and model-checking contracts added by the gate.
- Finish with [testing helpers](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/wireframe_testing/src/lib.rs#L1) and [allocation benchmark support](https://github.com/leynos/wireframe/blob/issue-666-deny-missing-documentation-on-private-items-across-the-workspace/benches/codec_performance_alloc.rs#L1) for secondary-crate and target coverage.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `make check-fmt`
- `make lint`
- `make test`
- `make test-doc`
- `make typecheck`
- `make markdownlint`
- `make nixie`
- `make test-workflow-contracts`
- `cargo test --test workspace_manifest --all-features`
- `coderabbit review --agent`

## Notes

The binary private-item gate complements, rather than replaces, the public
documentation-coverage work in #531. The known standalone `wireframe_testing`
doctest inference limitation remains explicitly scoped to #578.

## References

- [Issue #666](https://github.com/leynos/wireframe/issues/666)
- [Public documentation coverage #531](https://github.com/leynos/wireframe/issues/531)
- [Lody session](https://lody.ai/leynos/sessions/358a77b7-eb0b-41b0-86f4-c9d51113a0e3)
