### PR TITLE
Refactor shared-action invocation scanning

### DIFF
--- a/tests/workflow_contracts/shared_actions_test.py
+++ b/tests/workflow_contracts/shared_actions_test.py
@@ -19,6 +19,29 @@ SHARED_ACTION_USES_RE = re.compile(
 )
 
 
+def _workflow_paths() -> Iterator[Path]:
+    """Yield supported workflow paths in deterministic order.
+
+    For example, ``.yaml`` and ``.yml`` files are yielded, while other
+    directory entries are skipped.
+    """
+    for workflow_path in sorted(WORKFLOWS_DIR.iterdir()):
+        if workflow_path.suffix in WORKFLOW_SUFFIXES:
+            yield workflow_path
+
+
+def _shared_action_use(mapping: dict[str, object]) -> str | None:
+    """Return a shared-actions invocation from a workflow mapping.
+
+    For example, ``leynos/shared-actions/...`` is returned, whereas an
+    unrelated or non-string ``uses`` value produces ``None``.
+    """
+    uses = mapping.get("uses")
+    if isinstance(uses, str) and uses.startswith("leynos/shared-actions/"):
+        return uses
+    return None
+
+
 def _workflow_mappings(value: object) -> Iterator[dict[str, object]]:
     """Yield every mapping nested beneath a parsed workflow document."""
     if isinstance(value, dict):
@@ -42,22 +65,14 @@ def _mappings_in_values(values: Iterable[object]) -> Iterator[dict[str, object]]
 def _shared_action_invocations() -> list[tuple[Path, str]]:
     """Return each shared-action invocation and its containing workflow."""
     invocations = []
-    for workflow_path in sorted(WORKFLOWS_DIR.iterdir()):
-        if workflow_path.suffix not in WORKFLOW_SUFFIXES:
-            continue
+    for workflow_path in _workflow_paths():
         workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
-        assert isinstance(workflow, dict), (
-            f"{workflow_path.name} must be a mapping"
-        )
+        assert isinstance(workflow, dict), f"{workflow_path.name} must be a mapping"
         for mapping in _workflow_mappings(workflow):
-            uses = mapping.get("uses")
-            if isinstance(uses, str) and uses.startswith(
-                "leynos/shared-actions/"
-            ):
+            uses = _shared_action_use(mapping)
+            if uses is not None:
                 invocations.append((workflow_path, uses))
-    assert invocations, (
-        "at least one workflow must invoke leynos/shared-actions"
-    )
+    assert invocations, "at least one workflow must invoke leynos/shared-actions"
     return invocations
 
 

--- a/tests/workflow_contracts/shared_actions_test.py
+++ b/tests/workflow_contracts/shared_actions_test.py
@@ -9,6 +9,7 @@ import re
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 
+import pytest
 import yaml
 
 WORKFLOWS_DIR = Path(__file__).resolve().parents[2] / ".github" / "workflows"
@@ -20,22 +21,14 @@ SHARED_ACTION_USES_RE = re.compile(
 
 
 def _workflow_paths() -> Iterator[Path]:
-    """Yield supported workflow paths in deterministic order.
-
-    For example, ``.yaml`` and ``.yml`` files are yielded, while other
-    directory entries are skipped.
-    """
+    """Yield supported workflow paths in deterministic order."""
     for workflow_path in sorted(WORKFLOWS_DIR.iterdir()):
         if workflow_path.suffix in WORKFLOW_SUFFIXES:
             yield workflow_path
 
 
 def _shared_action_use(mapping: dict[str, object]) -> str | None:
-    """Return a shared-actions invocation from a workflow mapping.
-
-    For example, ``leynos/shared-actions/...`` is returned, whereas an
-    unrelated or non-string ``uses`` value produces ``None``.
-    """
+    """Return a shared-actions invocation from a workflow mapping."""
     uses = mapping.get("uses")
     if isinstance(uses, str) and uses.startswith("leynos/shared-actions/"):
         return uses
@@ -88,6 +81,36 @@ def _shared_action_versions() -> list[tuple[Path, str]]:
         )
         versions.append((workflow_path, match["version"]))
     return versions
+
+
+def test_workflow_paths_filter_supported_suffixes_in_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Workflow path discovery keeps supported files in lexical order."""
+    for filename in ("zebra.yml", "notes.txt", "alpha.yaml"):
+        (tmp_path / filename).touch()
+    monkeypatch.setitem(_workflow_paths.__globals__, "WORKFLOWS_DIR", tmp_path)
+
+    assert [path.name for path in _workflow_paths()] == ["alpha.yaml", "zebra.yml"]
+
+
+@pytest.mark.parametrize(
+    ("mapping", "expected"),
+    [
+        (
+            {"uses": "leynos/shared-actions/.github/actions/check"},
+            "leynos/shared-actions/.github/actions/check",
+        ),
+        ({"uses": "actions/checkout@v4"}, None),
+        ({}, None),
+        ({"uses": 42}, None),
+    ],
+)
+def test_shared_action_use_filters_workflow_mappings(
+    mapping: dict[str, object], expected: str | None
+) -> None:
+    """Shared-action filtering accepts only the expected string prefix."""
+    assert _shared_action_use(mapping) == expected
 
 
 def test_shared_action_invocations_have_expected_shape() -> None:


### PR DESCRIPTION
## Summary

This branch refactors shared-action invocation scanning so its workflow-path
and action-use filtering responsibilities are cohesive helpers, preserving
the existing workflow-contract behaviour while removing nested conditionals.
It now also directly proves the new helper contracts and keeps their private
documentation concise.

## Review walkthrough

- Start with [shared_actions_test.py](https://github.com/leynos/wireframe/blob/refactor-shared-action-invocations/tests/workflow_contracts/shared_actions_test.py#L23) to review deterministic workflow-path selection and shared-action filtering.
- Then review [_shared_action_invocations](https://github.com/leynos/wireframe/blob/refactor-shared-action-invocations/tests/workflow_contracts/shared_actions_test.py#L58) to confirm YAML loading, recursive mapping traversal, result ordering, and assertions remain unchanged.
- Finish with the [focused helper tests](https://github.com/leynos/wireframe/blob/refactor-shared-action-invocations/tests/workflow_contracts/shared_actions_test.py#L86) for suffix ordering and `uses` predicate cases.

## Validation

- `make test-workflow-contracts`: passed (18 tests)
- `ruff format --isolated --target-version py313 --check tests/workflow_contracts/shared_actions_test.py`: passed
- `ruff check --isolated --target-version py313 tests/workflow_contracts/shared_actions_test.py`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make test`: passed
- `git diff --check origin/main...HEAD`: passed

## Summary by Sourcery

Enhancements:

- Refactor shared-action invocation scanning into cohesive helpers for
  deterministic workflow selection and shared-action filtering while
  preserving existing contract behaviour.

## References

- [Lody session](https://lody.ai/leynos/sessions/6c74781c-0810-4259-9465-af8a3adbc65d)
